### PR TITLE
🧪 deriveBibtexKey関数のテストカバレッジを向上

### DIFF
--- a/packages/bibtex/tests/bibtex-formatter.test.ts
+++ b/packages/bibtex/tests/bibtex-formatter.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { formatBibtex, parseBibtexEntry, splitBibtexEntries } from "../src/bibtex-formatter.js";
+import { deriveBibtexKey, formatBibtex, parseBibtexEntry, splitBibtexEntries } from "../src/bibtex-formatter.js";
 
 describe("bibtex-formatter", () => {
+    describe("deriveBibtexKey", () => {
+        it("returns undefined if keyFormat is 'default'", () => {
+            const result = deriveBibtexKey(`@article{tmp, title={Paper}, author={Alice Smith}, year={2024}, journal={J}}`, "default");
+            expect(result).toBeUndefined();
+        });
+
+        it("returns a generated key for valid bibtex entry with valid format", () => {
+            const result = deriveBibtexKey(`@article{tmp, title={Sample Paper}, author={Alice Smith and Bob Jones}, year={2024}, journal={Journal of Testing}}`, "short");
+            expect(result).toBeDefined();
+            expect(typeof result).toBe("string");
+            expect(result).not.toBe("tmp");
+        });
+
+        it("returns undefined for invalid bibtex entry", () => {
+            const result = deriveBibtexKey(`invalid bibtex string`, "short");
+            expect(result).toBeUndefined();
+        });
+    });
+
     it("parses a single bibtex entry", () => {
         const parsed = parseBibtexEntry(`@article{tmp, title={Paper}, author={Alice Smith}, year={2024}, journal={J}}`);
         expect(parsed.entryType).toBe("article");


### PR DESCRIPTION
🎯 **What:** `bibtex-formatter.ts` の `deriveBibtexKey` 関数に対するテストギャップを解消しました。不正な生の BibTeX 文字列に対する try/catch ブロックがテストされるようになりました。

📊 **Coverage:** 以下のシナリオがユニットテストでカバーされるようになりました：
- `keyFormat` が `'default'` の場合に `undefined` を返す
- 有効な形式の有効な BibTeX エントリに対して生成されたキーを返す
- 不正な BibTeX エントリに対して `undefined` を返す（`catch` ブロックをトリガーする）

✨ **Result:** `bibtex-formatter.ts` のテストカバレッジが向上し、`deriveBibtexKey` のエラーハンドリングと正常系の信頼性が確保されました。

---
*PR created automatically by Jules for task [223215762841303599](https://jules.google.com/task/223215762841303599) started by @is0692vs*