### PR TITLE
🧪 [test] `searchCrossref`のテスト追加

### DIFF
--- a/packages/drilldown/tests/search.test.ts
+++ b/packages/drilldown/tests/search.test.ts
@@ -5,7 +5,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // Import after mocking
-const { searchByKeyword, searchByVenue, enrichWithCrossref, enrichAllWithCrossref } = await import("../src/search.js");
+const { searchByKeyword, searchByVenue, enrichWithCrossref, enrichAllWithCrossref, searchCrossref } = await import("../src/search.js");
 
 describe("search", () => {
     beforeEach(() => {
@@ -92,5 +92,34 @@ describe("search", () => {
         const result = await enrichWithCrossref(paper);
         expect(result).toEqual(paper);
         expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("searchCrossref should call Crossref API and return papers", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                message: {
+                    items: [
+                        {
+                            title: ["Machine Learning Basics"],
+                            author: [{ given: "John", family: "Doe" }],
+                            DOI: "10.5678/ml",
+                            "container-title": ["Journal of ML"],
+                        },
+                    ],
+                },
+            }),
+        });
+
+        const papers = await searchCrossref("machine learning", 15);
+        expect(papers).toHaveLength(1);
+        expect(papers[0].title).toBe("Machine Learning Basics");
+        expect(papers[0].doi).toBe("10.5678/ml");
+        expect(papers[0].venue).toBe("Journal of ML");
+
+        const calledUrl = mockFetch.mock.calls[0][0] as string;
+        expect(calledUrl).toContain("query=machine+learning");
+        expect(calledUrl).toContain("rows=15");
     });
 });


### PR DESCRIPTION
🧪 `searchCrossref` 関数のテスト追加

🎯 **What:** `packages/drilldown/src/search.ts` 内の `searchCrossref` 関数に対するテストカバレッジが不足していたため、新たに追加しました。この関数は `@paper-tools/core` の `searchWorks` のラッパーとして機能するため、パラメーターが正しく渡されているかを確認するテストが必要です。
📊 **Coverage:** `searchCrossref` の呼び出し時に正しいクエリ (`query`) と最大取得数 (`maxResults`) がAPIリクエストに含まれること、および、期待されるレスポンス（タイトル、DOI、カンファレンス名など）が正しくパースされて返されることを検証するテストケースを追加しました。
✨ **Result:** テストが追加されたことで `search.ts` のカバレッジが向上し、Crossrefの検索機能に対するリファクタリングがより安全に行えるようになりました。

---
*PR created automatically by Jules for task [5455707966422406430](https://jules.google.com/task/5455707966422406430) started by @is0692vs*