### PR TITLE
🧪 [test] add coverage for semantic-scholar-client parseResponse error handling

### DIFF
--- a/packages/core/tests/semantic-scholar-client.test.ts
+++ b/packages/core/tests/semantic-scholar-client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as rateLimiter from "../src/rate-limiter.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -91,5 +92,17 @@ describe("Semantic Scholar Client", () => {
         } else {
             process.env["S2_API_KEY"] = previous;
         }
+    });
+
+    it("parseResponse should throw formatted error on failed response", async () => {
+        const spy = vi.spyOn(rateLimiter, "fetchWithRetry").mockResolvedValueOnce({
+            ok: false,
+            status: 400,
+            statusText: "Bad Request",
+            text: async () => "Invalid ID",
+        } as unknown as Response);
+
+        await expect(getPaper("bad-id")).rejects.toThrow("Semantic Scholar API error: 400 Bad Request - Invalid ID");
+        spy.mockRestore();
     });
 });

--- a/packages/core/tests/semantic-scholar-client.test.ts.patch
+++ b/packages/core/tests/semantic-scholar-client.test.ts.patch
@@ -1,0 +1,10 @@
+--- packages/core/tests/semantic-scholar-client.test.ts
++++ packages/core/tests/semantic-scholar-client.test.ts
+@@ -1,6 +1,7 @@
+ import { beforeEach, describe, expect, it, vi } from "vitest";
++import * as rateLimiter from "../src/rate-limiter.js";
+
+ const mockFetch = vi.fn();
+ vi.stubGlobal("fetch", mockFetch);
+
+ const {

--- a/patch2.diff
+++ b/patch2.diff
@@ -1,0 +1,18 @@
+--- packages/core/tests/semantic-scholar-client.test.ts
++++ packages/core/tests/semantic-scholar-client.test.ts
+@@ -82,3 +82,14 @@
+         }
+     });
++
++    it("parseResponse should throw formatted error on failed response", async () => {
++        const spy = vi.spyOn(rateLimiter, "fetchWithRetry").mockResolvedValueOnce({
++            ok: false,
++            status: 400,
++            statusText: "Bad Request",
++            text: async () => "Invalid ID",
++        } as unknown as Response);
++
++        await expect(getPaper("bad-id")).rejects.toThrow("Semantic Scholar API error: 400 Bad Request - Invalid ID");
++        spy.mockRestore();
++    });
+ });


### PR DESCRIPTION
🎯 **What:** The untested `parseResponse` error handling in `semantic-scholar-client.ts` was not covered by tests.
📊 **Coverage:** A test case has been added to mock a failed error response from `fetchWithRetry` simulating a Semantic Scholar API error.
✨ **Result:** Improved test coverage by verifying the formatting of error exceptions thrown from the Semantic Scholar client on non-OK responses.

---
*PR created automatically by Jules for task [9267164348579957571](https://jules.google.com/task/9267164348579957571) started by @is0692vs*