### PR TITLE
docs: READMEの日本語部分を英語に翻訳し言語を統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ node packages/bibtex/dist/index.js validate papers.bib
 cat papers.bib | node packages/bibtex/dist/index.js validate -
 ```
 
-- `get` は取得優先順位として Crossref (DOI) → DBLP (title) → Semantic Scholar (title→DOI→Crossref) を使用します。
-- `export` は `NOTION_DATABASE_ID` で指定した Notion DB を読み取り、DOI 優先で BibTeX を生成します。
-- `validate` は必須フィールド不足、重複キー、重複 DOI を検出します。
+- `get` uses the priority order: Crossref (DOI) → DBLP (title) → Semantic Scholar (title→DOI→Crossref).
+- `export` reads the Notion DB specified by `NOTION_DATABASE_ID` and generates BibTeX entries, prioritizing DOIs.
+- `validate` detects missing required fields, duplicate keys, and duplicate DOIs.
 
 ### Author Profiler CLI
 
@@ -162,8 +162,8 @@ node packages/author-profiler/dist/cli.js coauthors "Yann LeCun" --depth 1
 node packages/author-profiler/dist/cli.js save "Geoffrey Hinton" --dry-run
 ```
 
-- `save` は `NOTION_API_KEY` と `NOTION_AUTHOR_DATABASE_ID` を利用します。
-- Notion 著者 DB 推奨プロパティ:
+- `save` utilizes `NOTION_API_KEY` and `NOTION_AUTHOR_DATABASE_ID`.
+- Recommended properties for the Notion Author DB:
   - `Name` (title)
   - `Semantic Scholar ID` (text)
   - `H-Index` (number)
@@ -210,12 +210,12 @@ node packages/visualizer/dist/cli.js multi \
 
 **Optional Properties:**
 
-- `著者` / `Authors` (Rich text)
-- `年` / `Year` (Number)
-- `会議/ジャーナル` / `Venue` (Rich text)
-- `被引用数` / `Citation Count` (Number)
-- `分野` / `Fields` (Multi-select)
-- `ソース` / `Source` (Select)
+- `Authors` (Rich text)
+- `Year` (Number)
+- `Venue` (Rich text)
+- `Citation Count` (Number)
+- `Fields` (Multi-select)
+- `Source` (Select)
 - `Open Access PDF` (URL)
 - `Semantic Scholar ID` (Rich text)
-- `要約` / `Summary` (Rich text)
+- `Summary` (Rich text)


### PR DESCRIPTION
### **User description**
## 概要

`README.md` 内に一部残存していた日本語の記述をすべて英語に翻訳し、ドキュメント全体で言語を統一しました。

## 変更内容

- BibTeX CLI コマンド (`get`, `export`, `validate`) の説明を英語に翻訳
- Author Profiler CLI コマンド (`save`) の説明および推奨プロパティの説明を英語に翻訳
- Notion Database Schema Requirements セクション内の `Optional Properties` リストにおいて、日本語のプロパティ名（例: `著者 / `）を削除し、英語名のみの記載に修正

## 影響範囲

ドキュメントの更新のみであり、コードの実行や機能に影響はありません。
テスト・ビルドも正常にパスすることを確認済みです。

---
*PR created automatically by Jules for task [17835087026004979139](https://jules.google.com/task/17835087026004979139) started by @is0692vs*


___

### **PR Type**
Documentation


___

### **Description**
- Translate remaining Japanese text in README to English

- Unify documentation language throughout the file

- Remove Japanese property names from Notion schema section

- Maintain consistency with existing English documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md<br/>with Japanese text"] -- "Translate CLI<br/>command descriptions" --> B["English CLI<br/>descriptions"]
  A -- "Translate Author<br/>Profiler section" --> C["English Author<br/>Profiler docs"]
  A -- "Remove Japanese<br/>property names" --> D["English-only<br/>Notion schema"]
  B --> E["Unified English<br/>README.md"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Translate Japanese documentation to English</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Translated BibTeX CLI command descriptions (<code>get</code>, <code>export</code>, <code>validate</code>) <br>from Japanese to English<br> <li> Translated Author Profiler CLI section and Notion Author DB <br>recommended properties to English<br> <li> Removed Japanese property names from Notion Database Schema Optional <br>Properties list, keeping only English names<br> <li> Ensured consistent English language throughout the documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/paper-tools/pull/30/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+12/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

