### PR TITLE
🧪 [core] Add missing error test for getPaper in semantic-scholar-client

### DIFF
--- a/packages/core/tests/semantic-scholar-client.test.ts
+++ b/packages/core/tests/semantic-scholar-client.test.ts
@@ -71,6 +71,16 @@ describe("Semantic Scholar Client", () => {
         expect(paper.externalIds?.DOI).toBe("10.1000/abc");
     });
 
+    it("getPaper should throw formatted error on API failure", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+        });
+
+        await expect(getPaper("bad-id")).rejects.toThrow("HTTP 404: Not Found for");
+    });
+
     it("should attach x-api-key header when S2_API_KEY is set", async () => {
         const previous = process.env["S2_API_KEY"];
         process.env["S2_API_KEY"] = "dummy-key";


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a missing error test for the `getPaper` function in the Semantic Scholar client, verifying that errors from the API (such as HTTP 404) are properly parsed and handled.

📊 **Coverage:** What scenarios are now tested
- The test mocks an unsuccessful API response (`ok: false`, status `404`) and asserts that `getPaper` correctly rejects and throws an expected formatted error string (`HTTP 404: Not Found for ...`).

✨ **Result:** The improvement in test coverage
Increased robustness of `semantic-scholar-client` tests by explicitly covering the failure path for individual paper fetching.

---
*PR created automatically by Jules for task [8138701396342725362](https://jules.google.com/task/8138701396342725362) started by @is0692vs*