### PR TITLE
🧹 [Code Health] Remove deprecated console.warn for background fetch errors

### DIFF
--- a/packages/web/src/app/graph/page.tsx
+++ b/packages/web/src/app/graph/page.tsx
@@ -64,7 +64,9 @@ function GraphPageClient() {
             next.add(`title:${String(record.title).trim().toLowerCase()}`);
         }
         setSavedKeys(next);
-      } catch (err) { console.warn("Failed to fetch archive:", err); }
+      } catch (err) {
+        // Silently ignore background failures
+      }
     };
     void fetchArchive();
     return () => {

--- a/packages/web/src/app/recommend/page.tsx
+++ b/packages/web/src/app/recommend/page.tsx
@@ -110,7 +110,7 @@ function RecommendPageClient() {
         }
         setSavedKeys(next);
       } catch (err) {
-        console.warn("Failed to fetch archive:", err);
+        // Silently ignore background failures
       }
     };
     void fetchArchive();

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -68,7 +68,7 @@ export default function SearchPage() {
         }
         setSavedKeys(next);
       } catch (err) {
-        console.warn("Failed to fetch archive:", err);
+        // Silently ignore background failures
       }
     };
     void fetchArchive();


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the use of deprecated `console.warn` when silently catching errors during background archive fetches.

💡 **Why:** How this improves maintainability
The codebase guidelines treat `console.warn` as deprecated for production code, especially for non-critical background failures. By replacing it with an explanatory comment (`// Silently ignore background failures`), we reduce console noise in production and make the intention of the empty catch block explicitly clear to future developers.

✅ **Verification:** How you confirmed the change is safe
- Located all instances of the identical pattern (`packages/web/src/app/search/page.tsx`, `packages/web/src/app/graph/page.tsx`, and `packages/web/src/app/recommend/page.tsx`).
- Substituted the `console.warn` statements with comments explaining the silent ignore.
- Ran formatting checks, linting, and the entire `pnpm test` suite across all workspaces successfully. 
- Passed code review which verified that the solution addresses the problem correctly with zero regressions.

✨ **Result:** The improvement achieved
A cleaner production console and consistent error-handling documentation across multiple similar Next.js page components.

---
*PR created automatically by Jules for task [9900689550431400166](https://jules.google.com/task/9900689550431400166) started by @is0692vs*