### PR TITLE
🧹 [bibtex] Replace console.error with Error throw in get command

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -113,8 +113,7 @@ program
 
             const result = await fetchBibtex(lookup);
             if (!result) {
-                console.error("BibTeX を取得できませんでした");
-                process.exit(1);
+                throw new Error("BibTeX を取得できませんでした");
             }
 
             const customKey = deriveCustomKey(result.bibtex, keyFormat);


### PR DESCRIPTION
🎯 **What:** 
Replaced `console.error("BibTeX を取得できませんでした"); process.exit(1);` with `throw new Error("BibTeX を取得できませんでした");` in the `get` command handler of the bibtex CLI (`packages/bibtex/src/index.ts:116`).

💡 **Why:** 
This improves maintainability by promoting proper error propagation instead of a direct exit. Using `throw new Error` allows the surrounding `try-catch` block (which already exists, starting at line 107) to handle the error properly and log it centrally with the error stack/message if needed.

✅ **Verification:** 
Verified by searching for `console.error` usages in `packages/bibtex/src/index.ts` and confirming that the related `throw` statement fits the logic inside the try-catch loop. I then ran the test suite using `pnpm --filter @paper-tools/bibtex test`, which executed vitest correctly ensuring no regressions. Tests run globally via `pnpm test` also pass. Pre-commit validations (formatting and linting via build step `pnpm build`) passed successfully.

✨ **Result:** 
More robust and structured error handling for the BibTeX `get` CLI command when fetch fails, preventing abrupt silent app exits and conforming to node best practices.

---
*PR created automatically by Jules for task [16445114635215629162](https://jules.google.com/task/16445114635215629162) started by @is0692vs*