### PR TITLE
🧹 [Code Health] Avoid using 'any' type in paper test context setup

### DIFF
--- a/packages/web/src/app/api/paper/[paperId]/route.test.ts
+++ b/packages/web/src/app/api/paper/[paperId]/route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import type { PaperDetail } from "@/types/paper";
 
 vi.mock("@paper-tools/core", () => ({
     RateLimiter: class {
@@ -39,7 +40,7 @@ describe("/api/paper/[paperId] GET", () => {
             fieldsOfStudy: [{ category: "Computer Science", source: "s2" }],
             publicationDate: "2024-01-01",
             journal: { name: "J", volume: "1", pages: "1-10" },
-        } as any);
+        } as unknown as Partial<PaperDetail>);
 
         const res = await GET(new NextRequest("http://localhost/api/paper/abc"), ctx("abc"));
         const data = await res.json();


### PR DESCRIPTION
🎯 **What:** The `any` type assertion was replaced with `unknown as Partial<PaperDetail>` in the mock paper object within `route.test.ts`.

💡 **Why:** By avoiding `any`, we restore type safety and readability for the mocked paper structure. Since the test mock simulates a Semantic Scholar response which includes fields from `PaperDetail` that are not natively part of `S2Paper` (like `tldr`, `publicationDate`, `journal`), casting it to `unknown as Partial<PaperDetail>` correctly expresses our intent without bypassing the type checker completely.

✅ **Verification:** Verified that the vitest suite for `@paper-tools/web` continues to pass, and type checks succeed successfully.

✨ **Result:** Improved type checking guarantees and overall code health within the paper API test suite.

---
*PR created automatically by Jules for task [2377317925632478594](https://jules.google.com/task/2377317925632478594) started by @is0692vs*