### PR TITLE
🧪 [testing improvement description]

### DIFF
--- a/packages/web/src/app/api/databases/select/route.test.ts
+++ b/packages/web/src/app/api/databases/select/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+vi.mock("@/lib/auth", () => ({
+    getAccessToken: vi.fn(),
+    getNotionClient: vi.fn(),
+    setDatabaseCookie: vi.fn(),
+}));
+
+import * as auth from "@/lib/auth";
+
+describe("/api/databases/select POST", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns 400 when databaseId is missing from body", async () => {
+        vi.mocked(auth.getAccessToken).mockReturnValue("fake-token");
+
+        const req = new NextRequest("http://localhost/api/databases/select", {
+            method: "POST",
+            body: JSON.stringify({}),
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+
+        const data = await res.json();
+        expect(data.error).toBe("databaseId is required");
+    });
+});


### PR DESCRIPTION
🎯 **What:** The missing databaseId test gap in `packages/web/src/app/api/databases/select/route.ts` has been resolved. The handler now has a test to cover returning a 400 error status when the `databaseId` is absent from the body.

📊 **Coverage:** The test ensures that an empty JSON body correctly causes the endpoint to respond with a `400 Bad Request` and `{"error": "databaseId is required"}`.

✨ **Result:** Test coverage improved by verifying the input payload format requirement.

I've also run the test suite and confirmed that all 27 tests in `@paper-tools/web` pass successfully, ensuring no regressions.

---
*PR created automatically by Jules for task [4772230858520664026](https://jules.google.com/task/4772230858520664026) started by @is0692vs*