### PR TITLE
🧪 [test] add error handling tests for authors search API route

### DIFF
--- a/packages/web/src/app/api/authors/search/route.test.ts
+++ b/packages/web/src/app/api/authors/search/route.test.ts
@@ -42,4 +42,26 @@ describe("/api/authors/search GET", () => {
         const res = await GET(req);
         expect(res.status).toBe(400);
     });
+
+    it("returns 502 when searchAuthors throws an Error", async () => {
+        vi.mocked(core.searchAuthors).mockRejectedValueOnce(new Error("External API Error"));
+
+        const req = new NextRequest("http://localhost/api/authors/search?q=alice");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(502);
+        expect(data.error).toBe("External API Error");
+    });
+
+    it("returns 502 with 'Unknown error' when searchAuthors throws a non-Error", async () => {
+        vi.mocked(core.searchAuthors).mockRejectedValueOnce("String error");
+
+        const req = new NextRequest("http://localhost/api/authors/search?q=alice");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(502);
+        expect(data.error).toBe("Unknown error");
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test coverage for the error handling logic in the Authors Search API route (`packages/web/src/app/api/authors/search/route.ts`).

📊 **Coverage:** What scenarios are now tested:
- When `searchAuthors` throws a standard `Error` object, verifying a 502 status code and the `Error.message` is returned in the JSON response.
- When `searchAuthors` throws a non-Error string, verifying a 502 status code and the "Unknown error" fallback message is returned in the JSON response.

✨ **Result:** The improvement in test coverage: The catch block logic in the `/api/authors/search` route is now fully covered by unit tests, increasing the reliability of the web package and giving more confidence in refactoring.

---
*PR created automatically by Jules for task [8425029613113563249](https://jules.google.com/task/8425029613113563249) started by @is0692vs*