### PR TITLE
🧹 Remove 'any' type in mock setup for author search test

### DIFF
--- a/packages/web/src/app/api/authors/search/route.test.ts
+++ b/packages/web/src/app/api/authors/search/route.test.ts
@@ -27,7 +27,7 @@ describe("/api/authors/search GET", () => {
                     hIndex: 8,
                 },
             ],
-        } as any);
+        });
 
         const req = new NextRequest("http://localhost/api/authors/search?q=alice&limit=10");
         const res = await GET(req);


### PR DESCRIPTION
🎯 **What:** Removed the `as any` type assertion in the mock setup for `searchAuthors` in `packages/web/src/app/api/authors/search/route.test.ts`.

💡 **Why:** `as any` bypasses TypeScript's strict type checking. By removing `as any`, we ensure that the mock response safely matches the actual `Promise<S2AuthorSearchResponse>` expected by `searchAuthors`. The current mock shape exactly aligned with the `S2AuthorSearchResponse` type (which includes `data`, `total`, and `offset` with perfectly shaped `S2AuthorSummary` contents), so this removal cleanly resolves the issue and improves type safety, maintainability, and readability.

✅ **Verification:** Verified by running the local Vitest test suite (`pnpm --filter @paper-tools/web test`) which passed flawlessly. Also confirmed type compatibility locally by running the full monorepo TypeScript build (`pnpm run build`), proving that no compiler errors were introduced because the mocked shape was already correct.

✨ **Result:** Improved typing and code health in the author search tests by leveraging TypeScript's built-in definitions instead of an `any` override.

---
*PR created automatically by Jules for task [17247761618880403358](https://jules.google.com/task/17247761618880403358) started by @is0692vs*