### PR TITLE
🧪 Add error path test for undefined author search results

### DIFF
--- a/packages/author-profiler/src/tests/author-resolver.test.ts
+++ b/packages/author-profiler/src/tests/author-resolver.test.ts
@@ -133,6 +133,12 @@ describe("author-resolver", () => {
             { authorId: "id2", name: "John Doe 2", hIndex: 5, paperCount: 20, affiliations: ["Univ B"] }
         ];
 
+        it("should throw error if search returns undefined data", async () => {
+            vi.mocked(searchAuthors).mockResolvedValueOnce({ data: undefined } as any);
+
+            await expect(resolveAuthorId("Ghost Author")).rejects.toThrow("著者が見つかりませんでした: Ghost Author");
+        });
+
         it("should throw error if search returns no candidates", async () => {
             mockSearchResponse([]);
 


### PR DESCRIPTION
## 🎯 What
This PR addresses a missing test case in `packages/author-profiler/src/services/author-resolver.ts` where `response.data` from `searchAuthors` could return `undefined`. Previously, the fallback logic `const candidates = response.data ?? [];` correctly captured this but lacked dedicated test coverage.

## 📊 Coverage
Added a new test in `packages/author-profiler/src/tests/author-resolver.test.ts` that mocks `searchAuthors` to return `{ data: undefined }` and verifies that the `resolveAuthorId` function correctly throws the "著者が見つかりませんでした" (author not found) error.

## ✨ Result
Improved test coverage and reliability for error paths in the author resolution service, ensuring the fallback logic for undefined API responses functions correctly and prevents unexpected runtime crashes.

---
*PR created automatically by Jules for task [2113081780730508484](https://jules.google.com/task/2113081780730508484) started by @is0692vs*