### PR TITLE
🧹 [code health] Avoid using any type when mapping array properties

### DIFF
--- a/packages/web/src/app/api/paper/[paperId]/route.ts
+++ b/packages/web/src/app/api/paper/[paperId]/route.ts
@@ -45,13 +45,13 @@ function getStatusCodeFromError(error: unknown): number | null {
 function toPaperDetail(input: any): PaperDetail {
     const rawFields = Array.isArray(input?.fieldsOfStudy) ? input.fieldsOfStudy : null;
     const fieldsOfStudy = rawFields
-        ? rawFields.map((f: any) => {
+        ? rawFields.map((f: unknown) => {
             if (typeof f === "string") {
                 return { category: f, source: "unknown" };
             }
             return {
-                category: String(f?.category ?? "Unknown"),
-                source: String(f?.source ?? "unknown"),
+                category: String((f as Record<string, unknown>)?.category ?? "Unknown"),
+                source: String((f as Record<string, unknown>)?.source ?? "unknown"),
             };
         })
         : null;
@@ -69,9 +69,9 @@ function toPaperDetail(input: any): PaperDetail {
         title: String(input?.title ?? "Untitled"),
         abstract: input?.abstract ?? null,
         authors: Array.isArray(input?.authors)
-            ? input.authors.map((a: any) => ({
-                authorId: String(a?.authorId ?? ""),
-                name: String(a?.name ?? "Unknown"),
+            ? input.authors.map((a: unknown) => ({
+                authorId: String((a as Record<string, unknown>)?.authorId ?? ""),
+                name: String((a as Record<string, unknown>)?.name ?? "Unknown"),
             }))
             : [],
         year: typeof input?.year === "number" ? input.year : null,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `any` type with `unknown` when mapping the `fieldsOfStudy` and `authors` array properties in `packages/web/src/app/api/paper/[paperId]/route.ts`. 

💡 **Why:** How this improves maintainability
Using `any` disables TypeScript's type checking, which can hide potential runtime errors. Using `unknown` is the type-safe counterpart of `any` and forces the developer to perform type checking before interacting with the variable. By using type casts like `Record<string, unknown>`, it ensures safe property access while retaining strict type checks.

✅ **Verification:** How you confirmed the change is safe
Ran `pnpm --filter @paper-tools/web test` and specifically executed `pnpm --filter @paper-tools/web test src/app/api/paper/[paperId]/route.test.ts` to ensure that the code behaves correctly and preserves existing functionality. Tests passed.

✨ **Result:** The improvement achieved
A more strictly typed and robust implementation of the `toPaperDetail` normalization function, improving code health and reducing the risk of unsafe type usages.

---
*PR created automatically by Jules for task [2474802765470858615](https://jules.google.com/task/2474802765470858615) started by @is0692vs*