### PR TITLE
🧹 [Refactor] Avoid using 'any' type for page properties when creating Notion page

### DIFF
--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { S2Paper } from "@paper-tools/core";
+import type { CreatePageParameters } from "@notionhq/client/build/src/api-endpoints";
 import { getAccessToken, getNotionClient, getSelectedDatabaseId, getUserInfo } from "@/lib/auth";
 
 type NotionProperty = {
@@ -154,7 +155,7 @@ export async function POST(request: NextRequest) {
         const doiKey = findPropertyByKeyword(props, "doi");
         const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
 
-        const properties: Record<string, unknown> = {
+        const properties: NonNullable<CreatePageParameters["properties"]> = {
             [titleKey]: {
                 title: [{ text: { content: paper.title ?? "Untitled" } }],
             },
@@ -178,7 +179,7 @@ export async function POST(request: NextRequest) {
 
         await notion.pages.create({
             parent: { data_source_id: dataSource.id },
-            properties: properties as any,
+            properties,
         });
 
         return NextResponse.json({ success: true });

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,27 @@
+--- packages/web/src/app/api/archive/route.ts
++++ packages/web/src/app/api/archive/route.ts
+@@ -1,5 +1,6 @@
+ import { NextRequest, NextResponse } from "next/server";
+ import type { S2Paper } from "@paper-tools/core";
++import type { CreatePageParameters } from "@notionhq/client/build/src/api-endpoints";
+ import { getAccessToken, getNotionClient, getSelectedDatabaseId, getUserInfo } from "@/lib/auth";
+
+ type NotionProperty = {
+@@ -154,7 +155,7 @@
+         const doiKey = findPropertyByKeyword(props, "doi");
+         const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
+
+-        const properties: Record<string, unknown> = {
++        const properties: NonNullable<CreatePageParameters["properties"]> = {
+             [titleKey]: {
+                 title: [{ text: { content: paper.title ?? "Untitled" } }],
+             },
+@@ -178,7 +179,7 @@
+
+         await notion.pages.create({
+             parent: { data_source_id: dataSource.id },
+-            properties: properties as any,
++            properties,
+         });
+
+         return NextResponse.json({ success: true });


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `any` type in the `properties` argument of `notion.pages.create` in `packages/web/src/app/api/archive/route.ts` with the explicitly inferred type `CreatePageParameters["properties"]` from `@notionhq/client`.

💡 **Why:** How this improves maintainability
Using `any` undermines TypeScript's type-safety, allowing incorrect object shapes to compile but potentially crash at runtime when calling Notion's API. Changing it to `CreatePageParameters["properties"]` ensures proper typing corresponding with Notion client's expected payload, enhancing code readability, maintainability, and providing editor auto-completion.

✅ **Verification:** How you confirmed the change is safe
Ran `pnpm exec tsc --noEmit` and confirmed that compilation passes smoothly, verifying structural compatibility. Additionally, ran the test suite `pnpm test` and all 26 backend tests passed successfully.

✨ **Result:** The improvement achieved
Eliminated an instance of an unsafe `any` cast, promoting strict type usage with Notion's API integrations.

---
*PR created automatically by Jules for task [2770546367807980708](https://jules.google.com/task/2770546367807980708) started by @is0692vs*