### PR TITLE
🧪 test: add venue format tests for generateBibtexKey

### DIFF
--- a/packages/bibtex/tests/bibtex-key.test.ts
+++ b/packages/bibtex/tests/bibtex-key.test.ts
@@ -28,4 +28,23 @@ describe("generateBibtexKey", () => {
         }, "short");
         expect(key).toBe("mukai2026");
     });
+
+    it("supports venue format", () => {
+        const key = generateBibtexKey({
+            authors: ["Alice Smith"],
+            year: 2023,
+            title: "Deep Learning Advances",
+            venue: "NeurIPS",
+        }, "venue");
+        expect(key).toBe("smith2023neurips");
+    });
+
+    it("falls back to default format when venue is requested but missing", () => {
+        const key = generateBibtexKey({
+            authors: ["Bob Jones"],
+            year: 2024,
+            title: "Understanding Complex Systems",
+        }, "venue");
+        expect(key).toBe("jones2024understanding");
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `generateBibtexKey` format options.
📊 **Coverage:** Scenarios for the `"venue"` format are now tested, including happy paths (venue provided) and fallback edge cases (venue requested but missing).
✨ **Result:** Increased test coverage and ensured correct behavior for all format enum values in `generateBibtexKey`.

---
*PR created automatically by Jules for task [2352241155888367657](https://jules.google.com/task/2352241155888367657) started by @is0692vs*