### PR TITLE
🧹 Code Health: Remove any type from toPaperDetail parameter

### DIFF
--- a/packages/web/src/app/api/paper/[paperId]/route.ts
+++ b/packages/web/src/app/api/paper/[paperId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { RateLimiter, getPaper } from "@paper-tools/core";
 import type { PaperDetail } from "@/types/paper";
+import type { S2Paper, S2Author } from "@paper-tools/core";
 
 export const runtime = "nodejs";
 
@@ -42,10 +43,22 @@ function getStatusCodeFromError(error: unknown): number | null {
     return Number.isInteger(status) ? status : null;
 }
 
-function toPaperDetail(input: any): PaperDetail {
+type ExtendedS2Paper = Omit<S2Paper, "fieldsOfStudy"> & {
+    influentialCitationCount?: number;
+    tldr?: { model?: string; text?: string };
+    fieldsOfStudy?: Array<string | { category?: string; source?: string }>;
+    publicationDate?: string;
+    journal?: {
+        name?: string;
+        volume?: string | number;
+        pages?: string | number;
+    };
+};
+
+function toPaperDetail(input: ExtendedS2Paper): PaperDetail {
     const rawFields = Array.isArray(input?.fieldsOfStudy) ? input.fieldsOfStudy : null;
     const fieldsOfStudy = rawFields
-        ? rawFields.map((f: any) => {
+        ? rawFields.map((f: string | { category?: string; source?: string }) => {
             if (typeof f === "string") {
                 return { category: f, source: "unknown" };
             }
@@ -69,7 +82,7 @@ function toPaperDetail(input: any): PaperDetail {
         title: String(input?.title ?? "Untitled"),
         abstract: input?.abstract ?? null,
         authors: Array.isArray(input?.authors)
-            ? input.authors.map((a: any) => ({
+            ? input.authors.map((a: S2Author) => ({
                 authorId: String(a?.authorId ?? ""),
                 name: String(a?.name ?? "Unknown"),
             }))
@@ -113,7 +126,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     try {
         await detailLimiter.acquire();
         const paper = await getPaper(paperId, SEMANTIC_SCHOLAR_FIELDS);
-        const normalized = toPaperDetail(paper);
+        const normalized = toPaperDetail(paper as ExtendedS2Paper);
 
         if (!normalized.paperId) {
             return NextResponse.json({ error: "Paper not found" }, { status: 404 });


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the use of `any` type for the parameter in the `toPaperDetail` function in `packages/web/src/app/api/paper/[paperId]/route.ts`. 

💡 **Why:** How this improves maintainability
Using `any` disabled TypeScript's type checking, making the code prone to runtime errors if the API response structure changes or if properties are accessed incorrectly. By defining `ExtendedS2Paper` (which extends the core `S2Paper` type with the specific missing fields returned by Semantic Scholar), we restore type safety, improve IDE autocompletion, and make the code's expected input shape explicit. This significantly improves maintainability and readability.

✅ **Verification:** How you confirmed the change is safe
- Verified the `SEMANTIC_SCHOLAR_FIELDS` list matches the fields being used in `ExtendedS2Paper`.
- Replaced all nested `any` usages within the `.map` callbacks with appropriate types (`string | { category?: string; source?: string }` for fields of study, and `S2Author` for authors).
- Ran all tests for the web workspace (`pnpm --filter @paper-tools/web test`), which passed successfully. 

✨ **Result:** The improvement achieved
The `toPaperDetail` function is now fully typed, ensuring safe and predictable handling of the Semantic Scholar API response without any runtime behavior changes.

---
*PR created automatically by Jules for task [7859234260566391413](https://jules.google.com/task/7859234260566391413) started by @is0692vs*