### PR TITLE
🧹 Replace 'any' with explicit Notion API response types in archive route

### DIFF
--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { S2Paper } from "@paper-tools/core";
 import { getAccessToken, getNotionClient, getSelectedDatabaseId, getUserInfo } from "@/lib/auth";
+import type { GetDataSourceResponse, GetDatabaseResponse } from "@notionhq/client/build/src/api-endpoints";
 
 type NotionProperty = {
     type?: string;
@@ -66,11 +67,11 @@ export async function GET(request: NextRequest) {
 
     try {
         const notion = getNotionClient(auth.accessToken);
-        let dataSourceRes: any;
+        let dataSourceRes: GetDataSourceResponse;
         try {
             dataSourceRes = await notion.dataSources.retrieve({ data_source_id: auth.dataSourceId });
         } catch {
-            const databaseRes = await notion.databases.retrieve({ database_id: auth.dataSourceId });
+            const databaseRes: GetDatabaseResponse = await notion.databases.retrieve({ database_id: auth.dataSourceId });
             if (databaseRes.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }
@@ -130,11 +131,11 @@ export async function POST(request: NextRequest) {
         }
 
         const notion = getNotionClient(auth.accessToken);
-        let dataSource: any;
+        let dataSource: GetDataSourceResponse;
         try {
             dataSource = await notion.dataSources.retrieve({ data_source_id: auth.dataSourceId });
         } catch {
-            const database = await notion.databases.retrieve({ database_id: auth.dataSourceId });
+            const database: GetDatabaseResponse = await notion.databases.retrieve({ database_id: auth.dataSourceId });
             if (database.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }


### PR DESCRIPTION
🎯 **What:** The `packages/web/src/app/api/archive/route.ts` file used the `any` type for `dataSourceRes` (and `dataSource`), which degraded code quality and bypassed TypeScript's strict type checking. This PR imports and applies the `GetDataSourceResponse` and `GetDatabaseResponse` types directly from `@notionhq/client/build/src/api-endpoints` to correctly type the responses from the Notion API calls.

💡 **Why:** Using `any` causes a loss of type safety, leading to potential unhandled runtime errors if the API structure changes or isn't validated correctly. Utilizing the exact Response interfaces from `@notionhq/client` significantly improves code maintainability and allows the TS compiler to effectively guide future modifications.

✅ **Verification:** 
- The types `GetDataSourceResponse` and `GetDatabaseResponse` were verified to exist and perfectly match the return values from the `@notionhq/client` endpoints.
- Replaced occurrences of `any` with these types.
- Ran `pnpm --filter @paper-tools/web test` successfully.
- Ran `pnpm --filter @paper-tools/web build` successfully.
- Ensured there were no residual build artifacts.

✨ **Result:** The `archive` route now strictly enforces Notion API response structures, making the codebase more resilient, readable, and robust against type-related regressions.

---
*PR created automatically by Jules for task [13718468975696896883](https://jules.google.com/task/13718468975696896883) started by @is0692vs*