### PR TITLE
🧹 Avoid using any type in CoauthorNetworkGraph configuration

### DIFF
--- a/packages/web/src/components/author/CoauthorNetworkGraph.tsx
+++ b/packages/web/src/components/author/CoauthorNetworkGraph.tsx
@@ -93,10 +93,10 @@ export default function CoauthorNetworkGraph({
         layout: {
           name: "cose",
           animate: false,
-          nodeRepulsion: 50000,
-          idealEdgeLength: 140,
+          nodeRepulsion: () => 50000,
+          idealEdgeLength: () => 140,
           padding: 25,
-        } as any,
+        } as import("cytoscape").CoseLayoutOptions,
       });
     };
 


### PR DESCRIPTION
🎯 **What:** The `any` type cast for the `layout` option in `CoauthorNetworkGraph.tsx` was removed and replaced with the explicitly imported `import("cytoscape").CoseLayoutOptions` type. Additionally, `nodeRepulsion` and `idealEdgeLength` properties were updated from primitive numbers to arrow functions returning numbers (e.g., `() => 50000`), adhering to Cytoscape's type requirements for these layout parameters.

💡 **Why:** Relying on `any` obscures potential runtime errors and circumvents TypeScript's safety features. In this specific case, the `any` cast hid a type mismatch between primitive numbers and expected functions for layout dimensions, which could have led to unintended behavior within Cytoscape. Explicitly typing the layout options and fixing the misaligned property types improves code maintainability and robustness.

✅ **Verification:** Verified that the component types compile correctly and the overall build succeeds without TypeScript errors via `pnpm --filter @paper-tools/web run build`. Confirmed there are no regressions by passing the existing test suite via `pnpm --filter @paper-tools/web test`.

✨ **Result:** The codebase is safer, strictly typed, and compliant with standard Cytoscape configurations, successfully replacing the ambiguous `any` typing.

---
*PR created automatically by Jules for task [459233155212647659](https://jules.google.com/task/459233155212647659) started by @is0692vs*