### PR TITLE
🧹 Avoid using 'any' type when reading Notion data_sources

### DIFF
--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -9,6 +9,11 @@ type NotionProperty = {
     url?: string | null;
 };
 
+function isDatabaseWithDataSources(db: unknown): db is { data_sources: Array<{ id: string }> } {
+    if (typeof db !== "object" || db === null) return false;
+    return "data_sources" in db && Array.isArray((db as Record<string, unknown>).data_sources);
+}
+
 function getPlainText(items: Array<{ plain_text?: string }> | undefined) {
     return (items ?? []).map((item) => item.plain_text ?? "").join("").trim();
 }
@@ -74,7 +79,7 @@ export async function GET(request: NextRequest) {
             if (databaseRes.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }
-            const firstDataSourceId = (databaseRes as any).data_sources?.[0]?.id as string | undefined;
+            const firstDataSourceId = isDatabaseWithDataSources(databaseRes) ? databaseRes.data_sources[0]?.id : undefined;
             if (!firstDataSourceId) {
                 return NextResponse.json({ error: "No data source found in database" }, { status: 400 });
             }
@@ -138,7 +143,7 @@ export async function POST(request: NextRequest) {
             if (database.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }
-            const firstDataSourceId = (database as any).data_sources?.[0]?.id as string | undefined;
+            const firstDataSourceId = isDatabaseWithDataSources(database) ? database.data_sources[0]?.id : undefined;
             if (!firstDataSourceId) {
                 return NextResponse.json({ error: "No data source found in database" }, { status: 400 });
             }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of `any` type casting when reading Notion `data_sources` from database responses in the `GET` and `POST` handlers of `packages/web/src/app/api/archive/route.ts`. A custom type guard `isDatabaseWithDataSources` was introduced to safely narrow the type.
💡 **Why:** Replacing `any` with a proper type guard improves type safety, predictability, and readability. It ensures that runtime structures match assumptions and allows the compiler to catch errors, significantly improving the maintainability of the codebase.
✅ **Verification:** I confirmed the change is safe by running the TypeScript compiler (`pnpm --filter @paper-tools/web exec tsc --noEmit`) to ensure type safety, and executing the full test suite (`pnpm --filter @paper-tools/web test`) which passed successfully. A thorough code review also approved the logic.
✨ **Result:** The improvement successfully removes unsafe `any` casts while preserving existing behavior and adding robust defensive checks against unexpected API responses.

---
*PR created automatically by Jules for task [5114922299551029746](https://jules.google.com/task/5114922299551029746) started by @is0692vs*