### PR TITLE
🧹 [Code Health] Remove any cast for data_sources in archive API route

### DIFF
--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -74,7 +74,10 @@ export async function GET(request: NextRequest) {
             if (databaseRes.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }
-            const firstDataSourceId = (databaseRes as any).data_sources?.[0]?.id as string | undefined;
+            const firstDataSourceId =
+                "data_sources" in databaseRes && Array.isArray(databaseRes.data_sources)
+                    ? (databaseRes.data_sources[0] as { id?: string })?.id
+                    : undefined;
             if (!firstDataSourceId) {
                 return NextResponse.json({ error: "No data source found in database" }, { status: 400 });
             }
@@ -138,7 +141,10 @@ export async function POST(request: NextRequest) {
             if (database.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }
-            const firstDataSourceId = (database as any).data_sources?.[0]?.id as string | undefined;
+            const firstDataSourceId =
+                "data_sources" in database && Array.isArray(database.data_sources)
+                    ? (database.data_sources[0] as { id?: string })?.id
+                    : undefined;
             if (!firstDataSourceId) {
                 return NextResponse.json({ error: "No data source found in database" }, { status: 400 });
             }


### PR DESCRIPTION
## 🎯 What
Removed the unsafe `any` cast when extracting `data_sources` from the Notion database object in `packages/web/src/app/api/archive/route.ts`.

## 💡 Why
The previous code used `(databaseRes as any).data_sources?.[0]?.id` to extract the `id` from the extended Notion API response. Force-casting to `any` bypasses TypeScript checks and reduces the maintainability and readability of the codebase. By applying type guards (`"data_sources" in databaseRes && Array.isArray(databaseRes.data_sources)`), the code now strictly validates the runtime shape of the object before safely accessing its nested properties.

## ✅ Verification
- Modified both the `GET` and `POST` handlers symmetrically to ensure consistency.
- Ran `pnpm build` across all workspace packages (`@paper-tools/web` included) to confirm there are no TypeScript compilation errors.
- Executed the full Vitest suite (`pnpm test`) to ensure all assertions pass and no regressions were introduced.
- Verified that the resulting value assignment and fallback to `undefined` remains functionally identical to the previous explicit cast.

## ✨ Result
The codebase is now cleaner, fully type-safe, and easier to maintain without changing any of the application's runtime behavior.

---
*PR created automatically by Jules for task [15595805081642666822](https://jules.google.com/task/15595805081642666822) started by @is0692vs*