### PR TITLE
🧹 [refactor] Replace 'any' with GetDataSourceResponse in archive route

### DIFF
--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { S2Paper } from "@paper-tools/core";
 import { getAccessToken, getNotionClient, getSelectedDatabaseId, getUserInfo } from "@/lib/auth";
+import { GetDataSourceResponse } from "@notionhq/client/build/src/api-endpoints";
 
 type NotionProperty = {
     type?: string;
@@ -66,7 +67,7 @@ export async function GET(request: NextRequest) {
 
     try {
         const notion = getNotionClient(auth.accessToken);
-        let dataSourceRes: any;
+        let dataSourceRes: GetDataSourceResponse;
         try {
             dataSourceRes = await notion.dataSources.retrieve({ data_source_id: auth.dataSourceId });
         } catch {
@@ -130,7 +131,7 @@ export async function POST(request: NextRequest) {
         }
 
         const notion = getNotionClient(auth.accessToken);
-        let dataSource: any;
+        let dataSource: GetDataSourceResponse;
         try {
             dataSource = await notion.dataSources.retrieve({ data_source_id: auth.dataSourceId });
         } catch {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `any` type for `dataSource` and `dataSourceRes` variables with `GetDataSourceResponse` in the `POST` and `GET` handlers of the archive route (`packages/web/src/app/api/archive/route.ts`).

💡 **Why:** How this improves maintainability
Using `any` bypasses TypeScript's type checking system. By explicitly typing the response from `notion.dataSources.retrieve` using the type definition provided by the `@notionhq/client` SDK (`GetDataSourceResponse`), we improve type safety, help the IDE provide correct autocomplete, and prevent potential runtime type mismatch errors during future refactoring.

✅ **Verification:** How you confirmed the change is safe
- Verified that `@notionhq/client` is correctly referenced and that the `GetDataSourceResponse` type is properly imported via `@notionhq/client/build/src/api-endpoints`.
- Ran the TypeScript compiler explicitly for the `@paper-tools/web` package to ensure no new type errors were introduced.
- Executed the full test suite (`pnpm test`), passing all tests, to confirm that this purely structural change didn't cause unintended runtime bugs.

✨ **Result:** The improvement achieved
Eliminated `any` from the archive route code related to Notion API calls, leading to safer and more robust code logic without changing its existing runtime behavior.

---
*PR created automatically by Jules for task [7714010997366391441](https://jules.google.com/task/7714010997366391441) started by @is0692vs*