### PR TITLE
🧹 [code health improvement] Avoid using 'any' type when accessing dataSource properties

### DIFF
--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -9,6 +9,13 @@ type NotionProperty = {
     url?: string | null;
 };
 
+type NotionDataSource = {
+    id: string;
+    object: "data_source";
+    properties: Record<string, NotionProperty>;
+    title?: Array<{ plain_text?: string }>;
+};
+
 function getPlainText(items: Array<{ plain_text?: string }> | undefined) {
     return (items ?? []).map((item) => item.plain_text ?? "").join("").trim();
 }
@@ -66,7 +73,7 @@ export async function GET(request: NextRequest) {
 
     try {
         const notion = getNotionClient(auth.accessToken);
-        let dataSourceRes: any;
+        let dataSourceRes: unknown;
         try {
             dataSourceRes = await notion.dataSources.retrieve({ data_source_id: auth.dataSourceId });
         } catch {
@@ -74,19 +81,21 @@ export async function GET(request: NextRequest) {
             if (databaseRes.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }
-            const firstDataSourceId = (databaseRes as any).data_sources?.[0]?.id as string | undefined;
+            const firstDataSourceId = (databaseRes as unknown as { data_sources?: Array<{ id: string }> }).data_sources?.[0]?.id;
             if (!firstDataSourceId) {
                 return NextResponse.json({ error: "No data source found in database" }, { status: 400 });
             }
             dataSourceRes = await notion.dataSources.retrieve({ data_source_id: firstDataSourceId });
         }
 
-        if (dataSourceRes.object !== "data_source") {
+        const dataSourceObj = dataSourceRes as Record<string, unknown>;
+        if (dataSourceObj.object !== "data_source") {
             return NextResponse.json({ error: "Database not found" }, { status: 404 });
         }
 
+        const dataSource = dataSourceObj as unknown as NotionDataSource;
         const recordsRes = await notion.dataSources.query({
-            data_source_id: dataSourceRes.id,
+            data_source_id: dataSource.id,
             page_size: 100,
         });
 
@@ -95,16 +104,14 @@ export async function GET(request: NextRequest) {
             .map((page) => mapPageRecord(page as { id: string; properties: Record<string, NotionProperty> }));
 
         const userInfo = getUserInfo(request.cookies);
-        const databaseTitle = "title" in dataSourceRes
-            ? (dataSourceRes.title as Array<{ plain_text?: string }>)
-            : [];
+        const databaseTitle = dataSource.title ?? [];
         const databaseName = getPlainText(databaseTitle) || "(untitled database)";
 
         return NextResponse.json({
             records,
             total: records.length,
             database: {
-                databaseId: dataSourceRes.id,
+                databaseId: dataSource.id,
                 databaseName,
                 workspaceName: userInfo?.workspaceName ?? "Notion Workspace",
             },
@@ -130,26 +137,28 @@ export async function POST(request: NextRequest) {
         }
 
         const notion = getNotionClient(auth.accessToken);
-        let dataSource: any;
+        let dataSourceRes: unknown;
         try {
-            dataSource = await notion.dataSources.retrieve({ data_source_id: auth.dataSourceId });
+            dataSourceRes = await notion.dataSources.retrieve({ data_source_id: auth.dataSourceId });
         } catch {
             const database = await notion.databases.retrieve({ database_id: auth.dataSourceId });
             if (database.object !== "database") {
                 return NextResponse.json({ error: "Database not found" }, { status: 404 });
             }
-            const firstDataSourceId = (database as any).data_sources?.[0]?.id as string | undefined;
+            const firstDataSourceId = (database as unknown as { data_sources?: Array<{ id: string }> }).data_sources?.[0]?.id;
             if (!firstDataSourceId) {
                 return NextResponse.json({ error: "No data source found in database" }, { status: 400 });
             }
-            dataSource = await notion.dataSources.retrieve({ data_source_id: firstDataSourceId });
+            dataSourceRes = await notion.dataSources.retrieve({ data_source_id: firstDataSourceId });
         }
 
-        if (dataSource.object !== "data_source") {
+        const dataSourceObj = dataSourceRes as Record<string, unknown>;
+        if (dataSourceObj.object !== "data_source") {
             return NextResponse.json({ error: "Data source not found" }, { status: 404 });
         }
 
-        const props = (dataSource as any).properties as Record<string, NotionProperty>;
+        const dataSource = dataSourceObj as unknown as NotionDataSource;
+        const props = dataSource.properties;
         const titleKey = findTitleProperty(props);
         const doiKey = findPropertyByKeyword(props, "doi");
         const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");


### PR DESCRIPTION
🎯 **What:** Removed the `any` casting when accessing properties from the Notion `dataSource` API response in the archive route.
💡 **Why:** By explicitly defining a `NotionDataSource` interface and using `unknown` casting followed by structured object typing, this improves the readability and type safety of the Next.js API route without importing deep internal Notion SDK types that cause module resolution errors.
✅ **Verification:** Verified by running the test suite via `pnpm --filter @paper-tools/web test` and confirming all existing route tests pass successfully.
✨ **Result:** The codebase no longer relies on bypassing TypeScript compiler checks when resolving Notion database source properties.

---
*PR created automatically by Jules for task [4330718880258111790](https://jules.google.com/task/4330718880258111790) started by @is0692vs*