### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hiroki-org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.18.3",
   "description": "論文関連ツール群のモノレポ",
+  "license": "MIT",
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/packages/author-profiler/package.json
+++ b/packages/author-profiler/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/author-profiler",
   "version": "0.1.0",
   "description": "Author profiling CLI and shared services for paper-tools",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/bibtex/package.json
+++ b/packages/bibtex/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/bibtex",
   "version": "0.1.0",
   "description": "BibTeX generator CLI for Notion paper archives",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/core",
   "version": "0.1.0",
   "description": "共通モジュール（型定義・APIクライアント）",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/drilldown/package.json
+++ b/packages/drilldown/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/drilldown",
   "version": "0.1.0",
   "description": "DBLP + Crossref キーワード検索・深掘りCLI",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/recommender/package.json
+++ b/packages/recommender/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/recommender",
   "version": "0.1.0",
   "description": "Paper recommendation engine (placeholder)",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/scraper",
   "version": "0.1.0",
   "description": "Conference scraper for conf.researchr.org with DBLP integration",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/visualizer",
   "version": "0.1.0",
   "description": "OpenCitations 引用グラフ可視化CLI（DOT / Mermaid / JSON）",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,6 +2,7 @@
   "name": "@paper-tools/web",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- add a top-level MIT LICENSE file
- declare MIT license metadata in the workspace and package manifests

## Testing
- not run (metadata-only change)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

このPRは、トップレベルに標準的なMITライセンスファイルを追加し、ルートワークスペースおよびすべてのサブパッケージの `package.json` に `"license": "MIT"` メタデータを一括追加するものです。コードの変更は一切なく、ライセンス表記の整備のみを目的とした変更です。

- `LICENSE` ファイルに標準的なMITライセンステキストを追加（著作権年: 2026、著作権者: Hiroki-org）
- ルート `package.json` に `"license": "MIT"` フィールドを追加
- `packages/` 配下の全7パッケージの `package.json` に `"license": "MIT"` フィールドを追加
- `packages/web` は `"private": true` のため npm には公開されないが、ライセンスフィールドを明示すること自体は問題なし
- `AGENTS.md` がリポジトリに存在しないため、カスタムインストラクションで参照されているガイドを確認できなかった点は留意

<h3>Confidence Score: 5/5</h3>

- メタデータのみの変更であり、コードへの影響は一切ないため安全にマージ可能です。
- 全変更がLICENSEファイルの追加とpackage.jsonへのlicenseフィールド追加のみで、既存のロジック・設定・依存関係への影響がまったくない。ライセンステキストは標準的なMITライセンスに準拠しており、著作権情報も適切。
- 特に注意が必要なファイルはありません。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| LICENSE | 標準的なMITライセンステキストを新規追加。著作権年（2026）・著作権者（Hiroki-org）ともに適切。 |
| package.json | ルートワークスペースに `"license": "MIT"` を追加。他フィールドへの影響なし。 |
| packages/author-profiler/package.json | `"license": "MIT"` を追加。問題なし。 |
| packages/bibtex/package.json | `"license": "MIT"` を追加。問題なし。 |
| packages/core/package.json | `"license": "MIT"` を追加。問題なし。 |
| packages/drilldown/package.json | `"license": "MIT"` を追加。問題なし。 |
| packages/recommender/package.json | `"license": "MIT"` を追加。問題なし。 |
| packages/scraper/package.json | `"license": "MIT"` を追加。問題なし。 |
| packages/visualizer/package.json | `"license": "MIT"` を追加。問題なし。 |
| packages/web/package.json | `"private": true` のパッケージに `"license": "MIT"` を追加。npm非公開パッケージではライセンスフィールドは不要だが、明示しても問題なし。 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    L["LICENSE\n（MIT License 2026 Hiroki-org）"]
    R["package.json\n（root workspace）\nlicense: MIT"]
    L --> R

    R --> P1["packages/author-profiler\nlicense: MIT"]
    R --> P2["packages/bibtex\nlicense: MIT"]
    R --> P3["packages/core\nlicense: MIT"]
    R --> P4["packages/drilldown\nlicense: MIT"]
    R --> P5["packages/recommender\nlicense: MIT"]
    R --> P6["packages/scraper\nlicense: MIT"]
    R --> P7["packages/visualizer\nlicense: MIT"]
    R --> P8["packages/web\nlicense: MIT\n（private: true）"]
```

<sub>Last reviewed commit: 757a9de</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->