### PR TITLE
🧹 chore(web): remove unused BookOpen import from recommend page

### DIFF
--- a/packages/web/src/app/recommend/page.tsx
+++ b/packages/web/src/app/recommend/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import {
-  BookOpen,
   LayoutGrid,
   Lightbulb,
   Network,


### PR DESCRIPTION
🎯 **What:** Removed the unused `BookOpen` import from `lucide-react` in `packages/web/src/app/recommend/page.tsx`.
💡 **Why:** Improves code hygiene and maintainability by removing dead code.
✅ **Verification:** Ran test suite to ensure no regressions. Verified using `grep` that `BookOpen` is no longer imported or used in the file.
✨ **Result:** Cleaner imports and marginally smaller bundle size.

---
*PR created automatically by Jules for task [16272164939543410673](https://jules.google.com/task/16272164939543410673) started by @is0692vs*