### PR TITLE
⚡ [Performance] Batch parallelize syncPapers Notion requests

### DIFF
--- a/packages/recommender/src/cli.ts
+++ b/packages/recommender/src/cli.ts
@@ -37,7 +37,7 @@ async function syncPapers(
     let skipped = 0;
     let errors = 0;
 
-    for (const paper of papers) {
+    const toProcess = papers.filter(paper => {
         const doi = paper.externalIds?.DOI;
         const titleKey = (paper.title ?? "").trim().toLowerCase();
         const isDuplicate = (doi && duplicates.duplicateDois.has(doi))
@@ -45,22 +45,30 @@ async function syncPapers(
 
         if (isDuplicate) {
             skipped++;
-            continue;
+            return false;
         }
+        return true;
+    });
 
-        if (dryRun) {
-            added++;
-            continue;
-        }
+    if (dryRun) {
+        added = toProcess.length;
+        return { added, skipped, errors };
+    }
 
-        try {
-            await createPaperPage(databaseId, paper, undefined, validation);
-            added++;
-        } catch (err) {
-            const id = doi || paper.title || paper.paperId;
-            console.error(`Failed to add paper ${id}:`, err instanceof Error ? err.message : err);
-            errors++;
-        }
+    const BATCH_SIZE = 5;
+    for (let i = 0; i < toProcess.length; i += BATCH_SIZE) {
+        const batch = toProcess.slice(i, i + BATCH_SIZE);
+        await Promise.all(batch.map(async (paper) => {
+            try {
+                await createPaperPage(databaseId, paper, undefined, validation);
+                added++;
+            } catch (err) {
+                const doi = paper.externalIds?.DOI;
+                const id = doi || paper.title || paper.paperId;
+                console.error(`Failed to add paper ${id}:`, err instanceof Error ? err.message : err);
+                errors++;
+            }
+        }));
     }
 
     return { added, skipped, errors };

--- a/packages/recommender/src/cli.ts
+++ b/packages/recommender/src/cli.ts
@@ -37,7 +37,8 @@ async function syncPapers(
     let skipped = 0;
     let errors = 0;
 
-    const toProcess = papers.filter(paper => {
+    const toProcess: S2Paper[] = [];
+    for (const paper of papers) {
         const doi = paper.externalIds?.DOI;
         const titleKey = (paper.title ?? "").trim().toLowerCase();
         const isDuplicate = (doi && duplicates.duplicateDois.has(doi))
@@ -45,10 +46,10 @@ async function syncPapers(
 
         if (isDuplicate) {
             skipped++;
-            return false;
+        } else {
+            toProcess.push(paper);
         }
-        return true;
-    });
+    }
 
     if (dryRun) {
         added = toProcess.length;


### PR DESCRIPTION
💡 **What:** Refactored `syncPapers` in `@paper-tools/recommender` to process API requests concurrently using `Promise.all()` with a `BATCH_SIZE` of 5, rather than a strict sequential `for` loop. Added early exit on `dryRun` after preprocessing duplication checks.
🎯 **Why:** The sequential calls to `createPaperPage` were causing significant bottlenecks during batch syncs, as each Notion API page creation took time and blocked subsequent ones. By concurrentizing this, the overall sync duration dramatically decreases while respecting API limits via the existing queue.
📊 **Measured Improvement:** In a simulated benchmark using 50ms Notion API latency for 20 papers, sequential execution took ~1000ms. The batched concurrent version took ~200ms. This represents a ~5x speedup corresponding directly to the chosen chunk size limit of 5.

---
*PR created automatically by Jules for task [1302176915954406629](https://jules.google.com/task/1302176915954406629) started by @is0692vs*