### PR TITLE
docs(copilot-instructions): fix mock fetch pattern in test setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -995,6 +995,11 @@ import { fn } from "./module.js"
 // Fix: Mock fetch in test setup
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  // Reset mock state before each test for proper isolation
+  mockFetch.mockReset();
+});
 ```
 
 **"Timeout: not all promises completed"**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -993,9 +993,8 @@ import { fn } from "./module.js"
 
 ```typescript
 // Fix: Mock fetch in test setup
-beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn());
-});
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
 ```
 
 **"Timeout: not all promises completed"**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -997,8 +997,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 beforeEach(() => {
-  // Reset mock state before each test for proper isolation
-  mockFetch.mockReset();
+    mockFetch.mockReset();
 });
 ```
 


### PR DESCRIPTION
Replaced the incorrect `beforeEach(() => { vi.stubGlobal("fetch", vi.fn()); });` pattern with the correct `const mockFetch = vi.fn(); vi.stubGlobal("fetch", mockFetch);` pattern to match project test conventions.

---
*PR created automatically by Jules for task [4957480332401834512](https://jules.google.com/task/4957480332401834512) started by @is0692vs*