### PR TITLE
🧪 [Testing Improvement] Add tests for buildCoauthorNetwork

### DIFF
--- a/packages/author-profiler/src/tests/coauthor-network.test.ts
+++ b/packages/author-profiler/src/tests/coauthor-network.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { aggregateCoauthorsFromPapers } from "../services/coauthor-network.js";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { aggregateCoauthorsFromPapers, buildCoauthorNetwork } from "../services/coauthor-network.js";
+import { getAuthorPapers } from "@paper-tools/core";
+
+vi.mock("@paper-tools/core", () => ({
+    getAuthorPapers: vi.fn(),
+}));
 
 describe("aggregateCoauthorsFromPapers", () => {
     it("aggregates coauthor counts and excludes self", () => {
@@ -28,5 +33,74 @@ describe("aggregateCoauthorsFromPapers", () => {
             { authorId: "a1", name: "Alice", paperCount: 2 },
             { authorId: "a2", name: "Bob", paperCount: 1 },
         ]);
+    });
+});
+
+describe("buildCoauthorNetwork", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("fetches papers and aggregates coauthors correctly", async () => {
+        const mockPapers = [
+            {
+                paperId: "p1",
+                title: "Paper 1",
+                authors: [
+                    { authorId: "target", name: "Target Author" },
+                    { authorId: "c1", name: "Coauthor One" },
+                ],
+            },
+            {
+                paperId: "p2",
+                title: "Paper 2",
+                authors: [
+                    { authorId: "target", name: "Target Author" },
+                    { authorId: "c1", name: "Coauthor One" },
+                    { authorId: "c2", name: "Coauthor Two" },
+                ],
+            },
+        ];
+
+        vi.mocked(getAuthorPapers).mockResolvedValue({
+            data: mockPapers as any,
+            total: 2,
+            offset: 0,
+            next: 0,
+        });
+
+        const result = await buildCoauthorNetwork("target", { limit: 10, sort: "paperCount" });
+
+        expect(getAuthorPapers).toHaveBeenCalledWith("target", { limit: 10, sort: "paperCount" });
+        expect(result).toEqual([
+            { authorId: "c1", name: "Coauthor One", paperCount: 2 },
+            { authorId: "c2", name: "Coauthor Two", paperCount: 1 },
+        ]);
+    });
+
+    it("uses default options when none are provided", async () => {
+        vi.mocked(getAuthorPapers).mockResolvedValue({
+            data: [],
+            total: 0,
+            offset: 0,
+            next: 0,
+        });
+
+        await buildCoauthorNetwork("target");
+
+        expect(getAuthorPapers).toHaveBeenCalledWith("target", { limit: 200, sort: undefined });
+    });
+
+    it("handles getAuthorPapers returning undefined data", async () => {
+        vi.mocked(getAuthorPapers).mockResolvedValue({
+            data: undefined,
+            total: 0,
+            offset: 0,
+            next: 0,
+        } as any);
+
+        const result = await buildCoauthorNetwork("target");
+
+        expect(result).toEqual([]);
     });
 });

--- a/packages/author-profiler/src/tests/coauthor-network.test.ts
+++ b/packages/author-profiler/src/tests/coauthor-network.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { aggregateCoauthorsFromPapers, buildCoauthorNetwork } from "../services/coauthor-network.js";
-import { getAuthorPapers, type S2AuthorPapersResponse, type S2Paper } from "@paper-tools/core";
+import { getAuthorPapers, type S2Paper, type S2AuthorPapersResponse } from "@paper-tools/core";
 
 vi.mock("@paper-tools/core", () => ({
     getAuthorPapers: vi.fn(),
@@ -28,7 +28,7 @@ describe("aggregateCoauthorsFromPapers", () => {
             },
         ];
 
-        const result = aggregateCoauthorsFromPapers("self", papers as unknown as S2Paper[]);
+        const result = aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[]);
         expect(result).toEqual([
             { authorId: "a1", name: "Alice", paperCount: 2 },
             { authorId: "a2", name: "Bob", paperCount: 1 },
@@ -63,7 +63,7 @@ describe("buildCoauthorNetwork", () => {
         ];
 
         vi.mocked(getAuthorPapers).mockResolvedValue({
-            data: mockPapers as unknown as S2Paper[],
+            data: mockPapers as Partial<S2Paper>[] as S2Paper[],
             total: 2,
             offset: 0,
             next: 0,

--- a/packages/author-profiler/src/tests/coauthor-network.test.ts
+++ b/packages/author-profiler/src/tests/coauthor-network.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { aggregateCoauthorsFromPapers, buildCoauthorNetwork } from "../services/coauthor-network.js";
-import { getAuthorPapers } from "@paper-tools/core";
+import { getAuthorPapers, type S2AuthorPapersResponse, type S2Paper } from "@paper-tools/core";
 
 vi.mock("@paper-tools/core", () => ({
     getAuthorPapers: vi.fn(),
@@ -28,7 +28,7 @@ describe("aggregateCoauthorsFromPapers", () => {
             },
         ];
 
-        const result = aggregateCoauthorsFromPapers("self", papers as any);
+        const result = aggregateCoauthorsFromPapers("self", papers as unknown as S2Paper[]);
         expect(result).toEqual([
             { authorId: "a1", name: "Alice", paperCount: 2 },
             { authorId: "a2", name: "Bob", paperCount: 1 },
@@ -63,7 +63,7 @@ describe("buildCoauthorNetwork", () => {
         ];
 
         vi.mocked(getAuthorPapers).mockResolvedValue({
-            data: mockPapers as any,
+            data: mockPapers as unknown as S2Paper[],
             total: 2,
             offset: 0,
             next: 0,
@@ -97,7 +97,7 @@ describe("buildCoauthorNetwork", () => {
             total: 0,
             offset: 0,
             next: 0,
-        } as any);
+        } as unknown as S2AuthorPapersResponse);
 
         const result = await buildCoauthorNetwork("target");
 


### PR DESCRIPTION
🎯 **What:** The missing tests for `buildCoauthorNetwork` within `packages/author-profiler/src/services/coauthor-network.ts`.
📊 **Coverage:** Covered multiple scenarios: the happy path testing successful paper retrieval and correctly matching expected author aggregations; empty return/fallback where `getAuthorPapers` returns `undefined`; missing inputs where the service assumes the correct default parameters (like default `limit` 200). 
✨ **Result:** Enhanced the overall code coverage reliability of `@paper-tools/author-profiler`.

---
*PR created automatically by Jules for task [6735508422561079487](https://jules.google.com/task/6735508422561079487) started by @is0692vs*