### PR TITLE
🧹 [Code Health] Empty catch block warning

### DIFF
--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -116,7 +116,7 @@ export async function getDatabaseInfo(
         const me = await client.users.me({});
         workspaceName = (me as any)?.name?.trim() || workspaceName;
     } catch (e) {
-        console.warn("Failed to retrieve Notion workspace name. Falling back to default. Error:", e);
+        console.warn("Failed to retrieve Notion workspace name, falling back to default:", e);
     }
 
     return {

--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -116,7 +116,7 @@ export async function getDatabaseInfo(
         const me = await client.users.me({});
         workspaceName = (me as any)?.name?.trim() || workspaceName;
     } catch (e) {
-        console.warn("Failed to retrieve Notion workspace name:", e);
+        console.warn("Failed to retrieve Notion workspace name. Falling back to default. Error:", e);
     }
 
     return {

--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -115,7 +115,8 @@ export async function getDatabaseInfo(
     try {
         const me = await client.users.me({});
         workspaceName = (me as any)?.name?.trim() || workspaceName;
-    } catch {
+    } catch (e) {
+        console.warn("Failed to retrieve Notion workspace name:", e);
     }
 
     return {


### PR DESCRIPTION
🎯 **What:** The empty catch block in `notion-client.ts` was replaced with a `catch (e) { console.warn(...) }`.
💡 **Why:** Empty catch blocks hide errors silently, making debugging difficult. This adds clarity and logging while preserving the fallback to "Notion Workspace".
✅ **Verification:** Verified with `pnpm --filter @paper-tools/recommender test` locally to ensure the functionality and other code remain unharmed.
✨ **Result:** Improved maintainability and debugging visibility without altering the existing recommendation pipeline logic.

---
*PR created automatically by Jules for task [1885055023195974801](https://jules.google.com/task/1885055023195974801) started by @is0692vs*