### PR TITLE
🧪 [testing improvement] Add comprehensive tests for resolveNotionDataSource

### DIFF
--- a/packages/web/src/lib/notion-data-source.test.ts
+++ b/packages/web/src/lib/notion-data-source.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveNotionDataSource, getStatusCodeFromError } from "./notion-data-source";
+
+describe("notion-data-source", () => {
+    describe("getStatusCodeFromError", () => {
+        it("returns null if error is not an Error instance", () => {
+            expect(getStatusCodeFromError("string error")).toBeNull();
+            expect(getStatusCodeFromError(123)).toBeNull();
+            expect(getStatusCodeFromError(null)).toBeNull();
+            expect(getStatusCodeFromError(undefined)).toBeNull();
+            expect(getStatusCodeFromError({})).toBeNull();
+        });
+
+        it("returns null if error message does not match API error pattern", () => {
+            expect(getStatusCodeFromError(new Error("Unknown error"))).toBeNull();
+            expect(getStatusCodeFromError(new Error("API error: xyz"))).toBeNull();
+        });
+
+        it("extracts status code from API error", () => {
+            expect(getStatusCodeFromError(new Error("API error: 404"))).toBe(404);
+            expect(getStatusCodeFromError(new Error("Notion API error: 400"))).toBe(400);
+            expect(getStatusCodeFromError(new Error("Semantic Scholar API error: 500"))).toBe(500);
+            expect(getStatusCodeFromError(new Error("API error: 1234"))).toBeNull();
+        });
+    });
+
+    describe("resolveNotionDataSource", () => {
+        const createMockClient = () => ({
+            dataSources: {
+                retrieve: vi.fn(),
+            },
+            databases: {
+                retrieve: vi.fn(),
+            },
+        });
+
+        const validDataSource = {
+            object: "data_source",
+            id: "ds-123",
+            properties: { title: { id: "title", type: "title", title: {} } },
+        };
+
+        const validDatabase = {
+            object: "database",
+            id: "db-123",
+            data_sources: [{ id: "ds-123" }]
+        };
+
+        it("returns the data source directly if the initial retrieve succeeds and is valid", async () => {
+            const client = createMockClient();
+            client.dataSources.retrieve.mockResolvedValue(validDataSource);
+
+            const result = await resolveNotionDataSource(client, "db-123");
+
+            expect(result).toEqual(validDataSource);
+            expect(client.dataSources.retrieve).toHaveBeenCalledWith({ data_source_id: "db-123" });
+            expect(client.databases.retrieve).not.toHaveBeenCalled();
+        });
+
+        it("falls back to database retrieve if initial data source retrieve fails with 404", async () => {
+            const client = createMockClient();
+            client.dataSources.retrieve
+                .mockRejectedValueOnce(new Error("Notion API error: 404"))
+                .mockResolvedValueOnce(validDataSource);
+            client.databases.retrieve.mockResolvedValue(validDatabase);
+
+            const result = await resolveNotionDataSource(client, "db-123");
+
+            expect(result).toEqual(validDataSource);
+            expect(client.dataSources.retrieve).toHaveBeenCalledTimes(2);
+            expect(client.dataSources.retrieve).toHaveBeenNthCalledWith(1, { data_source_id: "db-123" });
+            expect(client.databases.retrieve).toHaveBeenCalledWith({ database_id: "db-123" });
+            expect(client.dataSources.retrieve).toHaveBeenNthCalledWith(2, { data_source_id: "ds-123" });
+        });
+
+        it("falls back to database retrieve if initial data source retrieve fails with 400", async () => {
+            const client = createMockClient();
+            client.dataSources.retrieve
+                .mockRejectedValueOnce(new Error("Notion API error: 400"))
+                .mockResolvedValueOnce(validDataSource);
+            client.databases.retrieve.mockResolvedValue(validDatabase);
+
+            const result = await resolveNotionDataSource(client, "db-123");
+
+            expect(result).toEqual(validDataSource);
+        });
+
+        it("falls back to database retrieve if initial data source is invalid", async () => {
+            const client = createMockClient();
+            client.dataSources.retrieve
+                .mockResolvedValueOnce({ id: "ds-123", properties: {} })
+                .mockResolvedValueOnce(validDataSource);
+            client.databases.retrieve.mockResolvedValue(validDatabase);
+
+            const result = await resolveNotionDataSource(client, "db-123");
+
+            expect(result).toEqual(validDataSource);
+        });
+
+        it("throws if initial data source retrieve fails with non-400/404 error", async () => {
+            const client = createMockClient();
+            const error500 = new Error("Notion API error: 500");
+            client.dataSources.retrieve.mockRejectedValueOnce(error500);
+
+            await expect(resolveNotionDataSource(client, "db-123")).rejects.toThrow(error500);
+            expect(client.databases.retrieve).not.toHaveBeenCalled();
+        });
+
+        it("throws if fallback database does not contain a data source", async () => {
+            const client = createMockClient();
+            client.dataSources.retrieve.mockRejectedValueOnce(new Error("Notion API error: 404"));
+
+            client.databases.retrieve.mockResolvedValue({
+                object: "database",
+                id: "db-123",
+            });
+
+            await expect(resolveNotionDataSource(client, "db-123")).rejects.toThrow("No data source found in selected database");
+        });
+
+        it("throws if fallback data source is not valid", async () => {
+            const client = createMockClient();
+            client.dataSources.retrieve
+                .mockRejectedValueOnce(new Error("Notion API error: 404"))
+                .mockResolvedValueOnce({ object: "data_source", id: "ds-123" });
+            client.databases.retrieve.mockResolvedValue(validDatabase);
+
+            await expect(resolveNotionDataSource(client, "db-123")).rejects.toThrow("Data source not found");
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the Notion integration helper `resolveNotionDataSource` and its internal utility `getStatusCodeFromError` in `packages/web/src/lib/notion-data-source.ts`.

📊 **Coverage:** The new test suite comprehensively covers:
- `getStatusCodeFromError`: Correct parsing of numeric HTTP statuses from API errors, and correct handling of non-matching error messages and non-Error objects.
- `resolveNotionDataSource`: Direct successful data source retrieval, successful fallback database logic when encountering a 400 or 404 error, correctly propagating non-400/404 errors (like 500), returning fallback data sources when the initially requested source returns an invalid object structure, throwing "No data source found in selected database" when the fallback DB lacks one, and throwing "Data source not found" when the fallback data source is itself invalid.

✨ **Result:** Test coverage for this module is completely filled, greatly improving reliability of the Notion data source resolution and fallback retrieval logic. Tests pass correctly without any flaky or non-deterministic behaviors.

---
*PR created automatically by Jules for task [11562920165976609819](https://jules.google.com/task/11562920165976609819) started by @is0692vs*