### PR TITLE
fix(codeql #1): add permissions to CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build All
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add explicit minimal `permissions` block to the CI `build` job
- set `contents: read` as recommended by CodeQL

## Alert addressed
- Code scanning alert #1: Workflow does not contain permissions (in `.github/workflows/ci.yml:12`)

## Validation
- YAML change only; workflow syntax remains valid