### PR TITLE
fix(codeql #2): add permissions to CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     name: Test ${{ matrix.package }}
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- add explicit minimal `permissions` block to the CI `test` job
- set `contents: read` as recommended by CodeQL

## Alert addressed
- Code scanning alert #2: Workflow does not contain permissions (in `.github/workflows/ci.yml:41`)

## Validation
- YAML change only; workflow syntax remains valid