### PR TITLE
fix(codeql #3): sanitize Crossref warning logging in bibtex-fetcher

### DIFF
--- a/packages/bibtex/src/bibtex-fetcher.ts
+++ b/packages/bibtex/src/bibtex-fetcher.ts
@@ -70,7 +70,8 @@ export async function fetchBibtex(identifier: BibtexIdentifier): Promise<FetchBi
             const bibtex = await fetchCrossrefBibtexByDoi(doi);
             return { bibtex, source: "crossref" };
         } catch (error) {
-            console.warn(`[bibtex] Crossref fetch failed for DOI ${doi}:`, error instanceof Error ? error.message : error);
+            const errorDetail = error instanceof Error ? error.message : String(error);
+            console.warn("[bibtex] Crossref fetch failed", { doi, error: errorDetail });
             // fall through to title-based methods
         }
     }

--- a/packages/bibtex/tests/bibtex-fetcher.test.ts
+++ b/packages/bibtex/tests/bibtex-fetcher.test.ts
@@ -69,8 +69,11 @@ describe("fetchBibtex", () => {
         expect(result?.source).toBe("dblp");
         // Warning should be logged
         expect(console.warn).toHaveBeenCalledWith(
-            expect.stringContaining("[bibtex] Crossref fetch failed for DOI 10.1000/xyz:"),
-            "Crossref returned non-BibTeX response"
+            "[bibtex] Crossref fetch failed",
+            {
+                doi: "10.1000/xyz",
+                error: "Crossref returned non-BibTeX response",
+            }
         );
     });
 
@@ -266,7 +269,13 @@ describe("additional edge cases", () => {
 
         const result = await fetchBibtex({ doi: "10.1000/xyz", title: "Fuzzing" });
         expect(result).toBeNull();
-        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Crossref fetch failed"), "String error crossref");
+        expect(console.warn).toHaveBeenCalledWith(
+            "[bibtex] Crossref fetch failed",
+            {
+                doi: "10.1000/xyz",
+                error: "String error crossref",
+            }
+        );
         expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("DBLP fetch failed"), "String error dblp");
         expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Semantic Scholar fallback failed"), "String error semanticscholar");
     });


### PR DESCRIPTION
## Summary
- replace interpolated warning string with a constant log message for Crossref fallback
- move user-derived values (`doi`, error text) into structured log metadata
- update tests to validate the new logging shape

## Alert addressed
- Code scanning alert #3: Use of externally-controlled format string (in `packages/bibtex/src/bibtex-fetcher.ts:73`)

## Validation
- `pnpm --filter @paper-tools/bibtex test` passes