### PR TITLE
fix(codeql #5): sanitize Semantic Scholar fallback logging in bibtex-fetcher

### DIFF
--- a/packages/bibtex/src/bibtex-fetcher.ts
+++ b/packages/bibtex/src/bibtex-fetcher.ts
@@ -93,7 +93,8 @@ export async function fetchBibtex(identifier: BibtexIdentifier): Promise<FetchBi
                 return { bibtex, source: "semanticScholar" };
             }
         } catch (error) {
-            console.warn(`[bibtex] Semantic Scholar fallback failed for title \"${title}\":`, error instanceof Error ? error.message : error);
+            const errorDetail = error instanceof Error ? error.message : String(error);
+            console.warn("[bibtex] Semantic Scholar fallback failed", { title, error: errorDetail });
         }
     }
 

--- a/packages/bibtex/tests/bibtex-fetcher.test.ts
+++ b/packages/bibtex/tests/bibtex-fetcher.test.ts
@@ -192,8 +192,11 @@ describe("fetchBibtex", () => {
             "DBLP Error"
         );
         expect(console.warn).toHaveBeenCalledWith(
-            expect.stringContaining("[bibtex] Semantic Scholar fallback failed for title \"Fuzzing\":"),
-            "Semantic Scholar Error"
+            "[bibtex] Semantic Scholar fallback failed",
+            {
+                title: "Fuzzing",
+                error: "Semantic Scholar Error",
+            }
         );
     });
 
@@ -268,7 +271,13 @@ describe("additional edge cases", () => {
         expect(result).toBeNull();
         expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Crossref fetch failed"), "String error crossref");
         expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("DBLP fetch failed"), "String error dblp");
-        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Semantic Scholar fallback failed"), "String error semanticscholar");
+        expect(console.warn).toHaveBeenCalledWith(
+            "[bibtex] Semantic Scholar fallback failed",
+            {
+                title: "Fuzzing",
+                error: "String error semanticscholar",
+            }
+        );
     });
 });
 


### PR DESCRIPTION
## Summary
- replace interpolated warning string with a constant log message for Semantic Scholar fallback
- move user-derived values (`title`, error text) into structured log metadata
- update tests to validate the new logging shape

## Alert addressed
- Code scanning alert #5: Use of externally-controlled format string (in `packages/bibtex/src/bibtex-fetcher.ts:96`)

## Validation
- `pnpm --filter @paper-tools/bibtex test` passes