### PR TITLE
fix(codeql #6): sanitize opencitations error logging format

### DIFF
--- a/packages/core/src/opencitations-client.ts
+++ b/packages/core/src/opencitations-client.ts
@@ -29,7 +29,12 @@ async function fetchByEndpoint(endpoint: "citations" | "references", doi: string
             creationDate: entry.creation,
         }));
     } catch (error) {
-        console.error(`[opencitations] failed to fetch ${endpoint} for DOI ${doi}:`, error);
+        const errorDetail = error instanceof Error ? error.message : String(error);
+        console.error("[opencitations] failed to fetch endpoint", {
+            endpoint,
+            doi,
+            error: errorDetail,
+        });
         return [];
     }
 }


### PR DESCRIPTION
## Summary
- replace interpolated error log string with a constant message in OpenCitations client
- log endpoint/doi/error as structured metadata to avoid tainted format strings

## Alert addressed
- Code scanning alert #6: Use of externally-controlled format string (in `packages/core/src/opencitations-client.ts:32`)

## Validation
- `pnpm --filter @paper-tools/core test` passes