### PR TITLE
fix(codeql #7): sanitize visualizer graph error logging format

### DIFF
--- a/packages/visualizer/src/graph.ts
+++ b/packages/visualizer/src/graph.ts
@@ -83,7 +83,11 @@ export async function buildCitationGraph(
                     }
                     return { citations, currentDoi };
                 } catch (error) {
-                    console.error(`Error fetching citations for ${currentDoi}:`, error);
+                    const errorDetail = error instanceof Error ? error.message : String(error);
+                    console.error("[visualizer] Failed to fetch citations", {
+                        doi: currentDoi,
+                        error: errorDetail,
+                    });
                     return { citations: [], currentDoi, error };
                 }
             })


### PR DESCRIPTION
## Summary
- replace interpolated log string with a constant message in citation graph fetch loop
- move DOI and error text into structured log metadata

## Alert addressed
- Code scanning alert #7: Use of externally-controlled format string (in `packages/visualizer/src/graph.ts:86`)

## Validation
- `pnpm --filter @paper-tools/visualizer test` passes