### PR TITLE
fix(codeql #8): remove polynomial-regex header parsing in bibtex formatter

### DIFF
--- a/packages/bibtex/src/bibtex-formatter.ts
+++ b/packages/bibtex/src/bibtex-formatter.ts
@@ -92,14 +92,34 @@ function parseFieldValue(body: string, start: number): { value: string; nextInde
 
 export function parseBibtexEntry(raw: string): ParsedBibtexEntry {
     const text = raw.trim();
-    const headerMatch = text.match(/^@(\w+)\s*\{\s*([^,]+)\s*,([\s\S]*)\}$/);
-    if (!headerMatch) {
+    if (!text.startsWith("@")) {
         throw new Error("Invalid BibTeX entry format");
     }
 
-    const entryType = (headerMatch[1] ?? "article").toLowerCase();
-    const key = (headerMatch[2] ?? "").trim();
-    const body = (headerMatch[3] ?? "").trim();
+    const braceIndex = text.indexOf("{");
+    if (braceIndex === -1) {
+        throw new Error("Invalid BibTeX entry format");
+    }
+
+    const entryTypeRaw = text.slice(1, braceIndex).trim();
+    if (!/^\w+$/.test(entryTypeRaw)) {
+        throw new Error("Invalid BibTeX entry format");
+    }
+
+    const payload = text.slice(braceIndex + 1).trim();
+    if (!payload.endsWith("}")) {
+        throw new Error("Invalid BibTeX entry format");
+    }
+
+    const content = payload.slice(0, -1);
+    const commaIndex = content.indexOf(",");
+    if (commaIndex === -1) {
+        throw new Error("Invalid BibTeX entry format");
+    }
+
+    const key = content.slice(0, commaIndex).trim();
+    const body = content.slice(commaIndex + 1).trim();
+    const entryType = entryTypeRaw.toLowerCase();
 
     const fields: Record<string, string> = {};
     let i = 0;

--- a/packages/bibtex/tests/bibtex-formatter.test.ts
+++ b/packages/bibtex/tests/bibtex-formatter.test.ts
@@ -60,5 +60,10 @@ describe("bibtex-formatter", () => {
 }`);
         expect(parsed.fields.title).toBe("An article with {nested {curly braces}} in title");
     });
+
+    it("throws for malformed header patterns that used to trigger regex backtracking", () => {
+        const malicious = `@a{{${" ".repeat(5000)}}`;
+        expect(() => parseBibtexEntry(malicious)).toThrow("Invalid BibTeX entry format");
+    });
 }
 );


### PR DESCRIPTION
## Summary
- replace regex-based BibTeX header parsing with explicit linear string parsing
- keep existing format validation behavior for malformed entries
- add regression test for malformed header input that previously triggered polynomial regex analysis

## Alert addressed
- Code scanning alert #8: Polynomial regular expression used on uncontrolled data (in `packages/bibtex/src/bibtex-formatter.ts:95`)

## Validation
- `pnpm --filter @paper-tools/bibtex test` passes