### PR TITLE
ci: setup Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,14 @@ jobs:
           path: packages
       - name: Test
         run: pnpm --filter @paper-tools/${{ matrix.package }} test
+
+      - name: Generate coverage (lcov)
+        run: pnpm --filter @paper-tools/${{ matrix.package }} exec vitest run --coverage.enabled --coverage.reporter=lcov
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: packages/${{ matrix.package }}/coverage/lcov.info
+          flags: ${{ matrix.package }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
+    "@vitest/coverage-v8": "3.2.4",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/packages/drilldown/package.json
+++ b/packages/drilldown/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
+    "@vitest/coverage-v8": "3.2.4",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.0",
     "vitest": "^3.2.0"

--- a/packages/recommender/package.json
+++ b/packages/recommender/package.json
@@ -21,13 +21,14 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@paper-tools/core": "workspace:*",
     "@notionhq/client": "^2.3.0",
+    "@paper-tools/core": "workspace:*",
     "commander": "^13.0.0",
     "dotenv": "^16.4.7"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
+    "@vitest/coverage-v8": "3.2.4",
     "typescript": "^5.8.0",
     "vitest": "^3.2.0"
   }

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -20,8 +20,9 @@
     "commander": "^13.0.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "3.2.4",
     "typescript": "^5.8.0",
-    "vitest": "^3.2.0",
-    "@types/node": "^22.0.0"
+    "vitest": "^3.2.0"
   }
 }

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
+    "@vitest/coverage-v8": "3.2.4",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.0",
     "vitest": "^3.2.0"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^22.19.11",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@vitest/coverage-v8": "3.2.4",
     "rimraf": "^6.1.2",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -121,6 +124,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -149,6 +155,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -171,6 +180,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -193,6 +205,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -266,6 +281,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2


### PR DESCRIPTION
## Summary
- add Codecov upload step in CI test matrix
- generate lcov coverage for each package in matrix jobs
- add missing @vitest/coverage-v8 devDependency to packages that run coverage

## Verification
- pnpm build
- package tests passed for all workspaces
- direct coverage command produces packages/<pkg>/coverage/lcov.info

## Notes
- Confirmed CODECOV_TOKEN exists in repository secrets.
- This PR only wires coverage upload; no runtime behavior changes.
