### PR TITLE
🧹 [コードの健全性向上] 不要なawaitの削除 (openalex-client)

### DIFF
--- a/packages/core/src/openalex-client.ts
+++ b/packages/core/src/openalex-client.ts
@@ -86,7 +86,8 @@ export async function getOpenAlexAuthor(authorId: string): Promise<OpenAlexAutho
         throw new Error(`OpenAlex API error: ${response.status} ${response.statusText} - ${body}`);
     }
 
-    return response.json() as Promise<OpenAlexAuthor>;
+    const payload = await response.json();
+    return payload as OpenAlexAuthor;
 }
 
 function scoreCandidate(candidate: OpenAlexAuthor, name?: string, affiliation?: string, orcid?: string): number {

--- a/packages/core/src/openalex-client.ts
+++ b/packages/core/src/openalex-client.ts
@@ -86,7 +86,7 @@ export async function getOpenAlexAuthor(authorId: string): Promise<OpenAlexAutho
         throw new Error(`OpenAlex API error: ${response.status} ${response.statusText} - ${body}`);
     }
 
-    return await response.json() as OpenAlexAuthor;
+    return response.json() as Promise<OpenAlexAuthor>;
 }
 
 function scoreCandidate(candidate: OpenAlexAuthor, name?: string, affiliation?: string, orcid?: string): number {


### PR DESCRIPTION
🎯 **What:** Removed the redundant `await` from the `return` statement in `getOpenAlexAuthor` method in `packages/core/src/openalex-client.ts`. The code `return await response.json() as OpenAlexAuthor;` has been updated to `return response.json() as Promise<OpenAlexAuthor>;`.
💡 **Why:** Removing the `await` keyword from `return await` when returning a Promise from an `async` function is a trivial, self-contained fix that improves code hygiene without altering behavior.
✅ **Verification:** Ran `pnpm test` in the `packages/core` workspace. All tests passed. The modified logic maintains the identical functional output and correctly satisfies TypeScript types.
✨ **Result:** Improved codebase maintainability by removing redundant code, following clean code practices.

---
*PR created automatically by Jules for task [4826892572638729237](https://jules.google.com/task/4826892572638729237) started by @is0692vs*