### PR TITLE
🧹 コード健全性の改善：不要な return await の削除

### DIFF
--- a/packages/core/src/openalex-client.ts
+++ b/packages/core/src/openalex-client.ts
@@ -86,7 +86,7 @@ export async function getOpenAlexAuthor(authorId: string): Promise<OpenAlexAutho
         throw new Error(`OpenAlex API error: ${response.status} ${response.statusText} - ${body}`);
     }
 
-    return response.json() as OpenAlexAuthor;
+    return (await response.json()) as OpenAlexAuthor;
 }
 
 function scoreCandidate(candidate: OpenAlexAuthor, name?: string, affiliation?: string, orcid?: string): number {

--- a/packages/core/src/openalex-client.ts
+++ b/packages/core/src/openalex-client.ts
@@ -86,7 +86,7 @@ export async function getOpenAlexAuthor(authorId: string): Promise<OpenAlexAutho
         throw new Error(`OpenAlex API error: ${response.status} ${response.statusText} - ${body}`);
     }
 
-    return (await response.json()) as OpenAlexAuthor;
+    return response.json();
 }
 
 function scoreCandidate(candidate: OpenAlexAuthor, name?: string, affiliation?: string, orcid?: string): number {

--- a/packages/core/src/openalex-client.ts
+++ b/packages/core/src/openalex-client.ts
@@ -86,7 +86,7 @@ export async function getOpenAlexAuthor(authorId: string): Promise<OpenAlexAutho
         throw new Error(`OpenAlex API error: ${response.status} ${response.statusText} - ${body}`);
     }
 
-    return response.json();
+    return await response.json() as OpenAlexAuthor;
 }
 
 function scoreCandidate(candidate: OpenAlexAuthor, name?: string, affiliation?: string, orcid?: string): number {

--- a/packages/core/src/openalex-client.ts
+++ b/packages/core/src/openalex-client.ts
@@ -86,7 +86,7 @@ export async function getOpenAlexAuthor(authorId: string): Promise<OpenAlexAutho
         throw new Error(`OpenAlex API error: ${response.status} ${response.statusText} - ${body}`);
     }
 
-    return await response.json() as OpenAlexAuthor;
+    return response.json() as OpenAlexAuthor;
 }
 
 function scoreCandidate(candidate: OpenAlexAuthor, name?: string, affiliation?: string, orcid?: string): number {

--- a/packages/core/src/semantic-scholar-client.ts
+++ b/packages/core/src/semantic-scholar-client.ts
@@ -134,7 +134,7 @@ function buildHeaders(): Record<string, string> {
 
 async function parseResponse<T>(response: Response): Promise<T> {
     if (response.ok) {
-        return response.json();
+        return await response.json() as T;
     }
 
     const bodyText = await response.text();

--- a/packages/core/src/semantic-scholar-client.ts
+++ b/packages/core/src/semantic-scholar-client.ts
@@ -134,7 +134,7 @@ function buildHeaders(): Record<string, string> {
 
 async function parseResponse<T>(response: Response): Promise<T> {
     if (response.ok) {
-        return await response.json() as T;
+        return response.json() as T;
     }
 
     const bodyText = await response.text();
@@ -159,7 +159,7 @@ export async function getRecommendationsForPaper(
 
     const url = `${SEMANTIC_SCHOLAR_API_BASE}/recommendations/v1/papers/forpaper/${encodeURIComponent(paperId)}?${params}`;
     const response = await fetchWithRetry(url, { headers: buildHeaders() });
-    return await parseResponse<S2RecommendationsResponse>(response);
+    return parseResponse<S2RecommendationsResponse>(response);
 }
 
 export async function getRecommendations(
@@ -183,7 +183,7 @@ export async function getRecommendations(
             negativePaperIds,
         }),
     });
-    return await parseResponse<S2RecommendationsResponse>(response);
+    return parseResponse<S2RecommendationsResponse>(response);
 }
 
 export async function getPaper(
@@ -195,7 +195,7 @@ export async function getPaper(
     const params = new URLSearchParams({ fields });
     const url = `${SEMANTIC_SCHOLAR_API_BASE}/graph/v1/paper/${encodeURIComponent(paperId)}?${params}`;
     const response = await fetchWithRetry(url, { headers: buildHeaders() });
-    return await parseResponse<S2Paper>(response);
+    return parseResponse<S2Paper>(response);
 }
 
 export async function searchPapers(
@@ -212,7 +212,7 @@ export async function searchPapers(
     });
     const url = `${SEMANTIC_SCHOLAR_API_BASE}/graph/v1/paper/search?${params}`;
     const response = await fetchWithRetry(url, { headers: buildHeaders() });
-    return await parseResponse<S2SearchResponse>(response);
+    return parseResponse<S2SearchResponse>(response);
 }
 
 export async function searchAuthors(
@@ -228,7 +228,7 @@ export async function searchAuthors(
     });
     const url = `${SEMANTIC_SCHOLAR_API_BASE}/graph/v1/author/search?${params}`;
     const response = await fetchWithRetry(url, { headers: buildHeaders() });
-    return await parseResponse<S2AuthorSearchResponse>(response);
+    return parseResponse<S2AuthorSearchResponse>(response);
 }
 
 export async function getAuthor(
@@ -260,7 +260,7 @@ export async function getAuthor(
     const params = new URLSearchParams({ fields: fields.join(",") });
     const url = `${SEMANTIC_SCHOLAR_API_BASE}/graph/v1/author/${encodeURIComponent(authorId)}?${params}`;
     const response = await fetchWithRetry(url, { headers: buildHeaders() });
-    return await parseResponse<S2AuthorDetail>(response);
+    return parseResponse<S2AuthorDetail>(response);
 }
 
 export async function getAuthorPapers(
@@ -279,5 +279,5 @@ export async function getAuthorPapers(
 
     const url = `${SEMANTIC_SCHOLAR_API_BASE}/graph/v1/author/${encodeURIComponent(authorId)}/papers?${params}`;
     const response = await fetchWithRetry(url, { headers: buildHeaders() });
-    return await parseResponse<S2AuthorPapersResponse>(response);
+    return parseResponse<S2AuthorPapersResponse>(response);
 }

--- a/packages/core/src/semantic-scholar-client.ts
+++ b/packages/core/src/semantic-scholar-client.ts
@@ -134,7 +134,7 @@ function buildHeaders(): Record<string, string> {
 
 async function parseResponse<T>(response: Response): Promise<T> {
     if (response.ok) {
-        return response.json() as T;
+        return response.json();
     }
 
     const bodyText = await response.text();


### PR DESCRIPTION
🎯 **What:** Removed redundant `await` keywords on `return` statements within async functions in `@paper-tools/core` API clients (`semantic-scholar-client.ts` and `openalex-client.ts`).

💡 **Why:** Async functions automatically wrap their returned values in a Promise. Explicitly awaiting a Promise right before returning it is redundant and doesn't affect execution flow (except in `try/catch` blocks, which aren't applicable here). This cleanup improves code hygiene and consistency.

✅ **Verification:** 
- Modified `packages/core/src/semantic-scholar-client.ts` and `packages/core/src/openalex-client.ts`.
- Ran the full `pnpm test` suite across all workspaces. All tests (including integration tests for the affected clients) passed successfully.
- Ran `pnpm run build` to ensure the project still compiles without type or resolution errors.

✨ **Result:** Cleaner, more idiomatic TypeScript code with slightly fewer unnecessary microtasks on the event loop.

---
*PR created automatically by Jules for task [10811475681691980333](https://jules.google.com/task/10811475681691980333) started by @is0692vs*