### PR TITLE
🔒 fix(web): /api/resolve エンドポイントへの認証チェックの追加

### DIFF
--- a/packages/web/src/app/api/resolve/route.test.ts
+++ b/packages/web/src/app/api/resolve/route.test.ts
@@ -24,7 +24,7 @@ function makeRequest(body: unknown) {
 
 describe("/api/resolve POST", () => {
     beforeEach(() => {
-        vi.restoreAllMocks();
+        vi.resetAllMocks();
         vi.mocked(getAccessToken).mockReturnValue("fake-token");
     });
 

--- a/packages/web/src/app/api/resolve/route.test.ts
+++ b/packages/web/src/app/api/resolve/route.test.ts
@@ -6,8 +6,13 @@ vi.mock("@paper-tools/core", () => ({
     searchPapers: vi.fn(),
 }));
 
+vi.mock("@/lib/auth", () => ({
+    getAccessToken: vi.fn(),
+}));
+
 const core = await import("@paper-tools/core");
 const { POST } = await import("./route");
+const { getAccessToken } = await import("@/lib/auth");
 
 function makeRequest(body: unknown) {
     return new NextRequest("http://localhost/api/resolve", {
@@ -19,7 +24,16 @@ function makeRequest(body: unknown) {
 
 describe("/api/resolve POST", () => {
     beforeEach(() => {
-        vi.clearAllMocks();
+        vi.restoreAllMocks();
+        vi.mocked(getAccessToken).mockReturnValue("fake-token");
+    });
+
+    it("アクセストークンがない場合は401を返す", async () => {
+        vi.mocked(getAccessToken).mockReturnValue(null);
+        const res = await POST(makeRequest({ doi: "10.1000/xyz" }));
+        const data = await res.json();
+        expect(res.status).toBe(401);
+        expect(data.error).toBe("Unauthorized");
     });
 
     it("doi から論文を解決する", async () => {

--- a/packages/web/src/app/api/resolve/route.ts
+++ b/packages/web/src/app/api/resolve/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getAccessToken } from "@/lib/auth";
 import { getPaper, searchPapers } from "@paper-tools/core";
 
 interface ResolveBody {
@@ -12,6 +13,11 @@ function normalizeDoi(input: string) {
 }
 
 export async function POST(request: NextRequest) {
+    const accessToken = getAccessToken(request.cookies);
+    if (!accessToken) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     try {
         const body = (await request.json()) as ResolveBody;
         const doi = body.doi?.trim();


### PR DESCRIPTION
🎯 **What:** `packages/web/src/app/api/resolve/route.ts` の `POST` エンドポイントに認証チェック (`getAccessToken`) を追加しました。
⚠️ **Risk:** 認証チェックがないと、誰でもこの API を呼び出して論文情報を解決できる状態でした。
🛡️ **Solution:** `request.cookies` から `getAccessToken` を用いてトークンを取得し、トークンが存在しない場合は `401 Unauthorized` を返すように修正しました。また、これに対するテストを追加しました。

---
*PR created automatically by Jules for task [2541968607499706274](https://jules.google.com/task/2541968607499706274) started by @is0692vs*