### PR TITLE
🧹 冗長なラッパー関数 `deriveCustomKey` の削除によるコード健全性の向上

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -38,9 +38,6 @@ function parseFormat(value: string | undefined): BibtexFormat {
     return "bibtex";
 }
 
-function deriveCustomKey(rawBibtex: string, keyFormat: BibtexKeyFormat): string | undefined {
-    return deriveBibtexKey(rawBibtex, keyFormat);
-}
 
 async function readStdinText(): Promise<string> {
     const chunks: Buffer[] = [];
@@ -116,7 +113,7 @@ program
                 throw new Error("BibTeX を取得できませんでした");
             }
 
-            const customKey = deriveCustomKey(result.bibtex, keyFormat);
+            const customKey = deriveBibtexKey(result.bibtex, keyFormat);
             const formatted = formatBibtex(result.bibtex, {
                 format,
                 key: customKey,
@@ -168,7 +165,7 @@ program
                             return null;
                         }
 
-                        const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
+                        const customKey = deriveBibtexKey(fetched.bibtex, keyFormat);
                         const formatted = formatBibtex(fetched.bibtex, {
                             format,
                             key: customKey,


### PR DESCRIPTION
🎯 **What:** Removed the `deriveCustomKey` function and updated all its call sites to directly use `deriveBibtexKey` in `packages/bibtex/src/index.ts`.
💡 **Why:** The `deriveCustomKey` function was a redundant wrapper around `deriveBibtexKey` that added unnecessary indirection. Removing it improves code readability and maintainability.
✅ **Verification:** Verified that the function was entirely removed and its references updated. Ran `pnpm run build` and `pnpm test` at the workspace root to ensure no functionality or tests were broken.
✨ **Result:** A cleaner, more direct codebase with one less layer of unnecessary indirection.

---
*PR created automatically by Jules for task [7617237115391167399](https://jules.google.com/task/7617237115391167399) started by @is0692vs*