### PR TITLE
🧹 [Code Health] notion-client.ts の不要な 'any' キャストを削除

### DIFF
--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -1,6 +1,9 @@
 import { Client } from "@notionhq/client";
 import type { S2Paper } from "@paper-tools/core";
 
+type CreatePageParameters = Parameters<Client["pages"]["create"]>[0];
+type NotionProperties = CreatePageParameters["properties"];
+
 export interface NotionPaperRecord {
     pageId: string;
     title: string;
@@ -194,7 +197,7 @@ export async function createPaperPage(
     const doi = paper.externalIds?.DOI ?? "";
     const fieldsOfStudy = paper.fieldsOfStudy ?? [];
 
-    const notionProperties: Record<string, unknown> = {
+    const notionProperties: NotionProperties = {
         "タイトル": {
             title: [{ text: { content: paper.title || "(untitled)" } }],
         },
@@ -235,7 +238,7 @@ export async function createPaperPage(
 
     await client.pages.create({
         parent: { database_id: databaseId },
-        properties: notionProperties as any,
+        properties: notionProperties,
     });
 }
 


### PR DESCRIPTION
* 🎯 **What:** `notion-client.ts`の238行目で `client.pages.create` に渡すプロパティに対する `any` キャストを削除し、適切な型 `NotionProperties` を定義して適用した。
* 💡 **Why:** Notion APIの厳密な型チェックを有効にすることで、将来の予期せぬエラーを防ぎ、コードの保守性と安全性を向上させるため。
* ✅ **Verification:** 修正後に `pnpm run build` と `pnpm test` を実行し、ビルドエラーとテストの失敗がないことを確認した。
* ✨ **Result:** 不要な `any` キャストがなくなり、型安全性が確保された。

---
*PR created automatically by Jules for task [4583142868203980297](https://jules.google.com/task/4583142868203980297) started by @is0692vs*