### PR TITLE
🧪 test: add test file for graph export API route

### DIFF
--- a/packages/web/src/app/api/graph/export/route.test.ts
+++ b/packages/web/src/app/api/graph/export/route.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
@@ -13,8 +13,7 @@ const { POST } = await import("./route");
 
 describe("/api/graph/export POST", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.resetAllMocks();
   });
 
   const mockGraph = {
@@ -22,7 +21,7 @@ describe("/api/graph/export POST", () => {
     edges: [],
   };
 
-  const createRequest = (body: any) => {
+  const createRequest = (body: unknown) => {
     return new NextRequest("http://localhost/api/graph/export", {
       method: "POST",
       body: JSON.stringify(body),
@@ -43,13 +42,11 @@ describe("/api/graph/export POST", () => {
     // Only format present
     req = createRequest({ format: "json" });
     res = await POST(req);
-    data = await res.json();
     expect(res.status).toBe(400);
 
     // Only graph present
     req = createRequest({ graph: mockGraph });
     res = await POST(req);
-    data = await res.json();
     expect(res.status).toBe(400);
   });
 

--- a/packages/web/src/app/api/graph/export/route.test.ts
+++ b/packages/web/src/app/api/graph/export/route.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@paper-tools/visualizer", () => ({
+  toJson: vi.fn(),
+  toDot: vi.fn(),
+  toMermaid: vi.fn(),
+}));
+
+const visualizer = await import("@paper-tools/visualizer");
+const { POST } = await import("./route");
+
+describe("/api/graph/export POST", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  const mockGraph = {
+    nodes: [{ id: "1", title: "Paper 1" }],
+    edges: [],
+  };
+
+  const createRequest = (body: any) => {
+    return new NextRequest("http://localhost/api/graph/export", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  };
+
+  it("graphとformatが必須であることをチェックする", async () => {
+    // Both missing
+    let req = createRequest({});
+    let res = await POST(req);
+    let data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.error).toBe("graph and format are required");
+
+    // Only format present
+    req = createRequest({ format: "json" });
+    res = await POST(req);
+    data = await res.json();
+    expect(res.status).toBe(400);
+
+    // Only graph present
+    req = createRequest({ graph: mockGraph });
+    res = await POST(req);
+    data = await res.json();
+    expect(res.status).toBe(400);
+  });
+
+  it("サポートされていないformatで400を返す", async () => {
+    const req = createRequest({ graph: mockGraph, format: "xml" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain("Unsupported format");
+  });
+
+  it("formatがjsonのとき、toJsonの結果を返す", async () => {
+    const mockOutput = '{"mocked": "json"}';
+    vi.mocked(visualizer.toJson).mockReturnValueOnce(mockOutput);
+
+    const req = createRequest({ graph: mockGraph, format: "json" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.output).toBe(mockOutput);
+    expect(data.format).toBe("json");
+    expect(visualizer.toJson).toHaveBeenCalledWith(mockGraph);
+  });
+
+  it("formatがdotのとき、toDotの結果を返す", async () => {
+    const mockOutput = "digraph { mock }";
+    vi.mocked(visualizer.toDot).mockReturnValueOnce(mockOutput);
+
+    const req = createRequest({ graph: mockGraph, format: "dot" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.output).toBe(mockOutput);
+    expect(data.format).toBe("dot");
+    expect(visualizer.toDot).toHaveBeenCalledWith(mockGraph);
+  });
+
+  it("formatがmermaidのとき、toMermaidの結果を返す", async () => {
+    const mockOutput = "graph TD; mock;";
+    vi.mocked(visualizer.toMermaid).mockReturnValueOnce(mockOutput);
+
+    const req = createRequest({ graph: mockGraph, format: "mermaid" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.output).toBe(mockOutput);
+    expect(data.format).toBe("mermaid");
+    expect(visualizer.toMermaid).toHaveBeenCalledWith(mockGraph);
+  });
+
+  it("予期せぬエラー発生時に500を返す", async () => {
+    // 異常なJSONを渡してエラーを誘発する
+    const req = new NextRequest("http://localhost/api/graph/export", {
+      method: "POST",
+      body: "invalid json",
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(data.error).toBeDefined();
+  });
+});

--- a/packages/web/src/app/api/graph/export/route.test.ts
+++ b/packages/web/src/app/api/graph/export/route.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment node
+// @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
@@ -13,7 +13,8 @@ const { POST } = await import("./route");
 
 describe("/api/graph/export POST", () => {
   beforeEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   const mockGraph = {
@@ -21,7 +22,7 @@ describe("/api/graph/export POST", () => {
     edges: [],
   };
 
-  const createRequest = (body: unknown) => {
+  const createRequest = (body: any) => {
     return new NextRequest("http://localhost/api/graph/export", {
       method: "POST",
       body: JSON.stringify(body),
@@ -42,11 +43,13 @@ describe("/api/graph/export POST", () => {
     // Only format present
     req = createRequest({ format: "json" });
     res = await POST(req);
+    data = await res.json();
     expect(res.status).toBe(400);
 
     // Only graph present
     req = createRequest({ graph: mockGraph });
     res = await POST(req);
+    data = await res.json();
     expect(res.status).toBe(400);
   });
 

--- a/packages/web/src/app/api/graph/export/route.test.ts
+++ b/packages/web/src/app/api/graph/export/route.test.ts
@@ -13,8 +13,7 @@ const { POST } = await import("./route");
 
 describe("/api/graph/export POST", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.resetAllMocks();
   });
 
   const mockGraph = {
@@ -22,7 +21,7 @@ describe("/api/graph/export POST", () => {
     edges: [],
   };
 
-  const createRequest = (body: any) => {
+  const createRequest = (body: unknown) => {
     return new NextRequest("http://localhost/api/graph/export", {
       method: "POST",
       body: JSON.stringify(body),
@@ -43,13 +42,11 @@ describe("/api/graph/export POST", () => {
     // Only format present
     req = createRequest({ format: "json" });
     res = await POST(req);
-    data = await res.json();
     expect(res.status).toBe(400);
 
     // Only graph present
     req = createRequest({ graph: mockGraph });
     res = await POST(req);
-    data = await res.json();
     expect(res.status).toBe(400);
   });
 


### PR DESCRIPTION
🎯 **What:** 
Added a missing test file for the `graph/export` API route (`packages/web/src/app/api/graph/export/route.ts`).

📊 **Coverage:**
The new test file `packages/web/src/app/api/graph/export/route.test.ts` covers the following scenarios:
- Request validation (returns 400 when `graph` or `format` is missing)
- Format validation (returns 400 when `format` is unsupported)
- Successful export paths (returns 200 with the correctly formatted output when format is `json`, `dot`, or `mermaid`)
- Unexpected error handling (returns 500 when processing fails or an invalid payload is sent)

✨ **Result:**
The test suite now properly covers the API logic and visualizer integration, allowing safe refactoring for graph export features without breaking existing functionalities. Tests use correct vitest mocking for `@paper-tools/visualizer` ensuring pure unit test execution logic.

---
*PR created automatically by Jules for task [12466848171482193117](https://jules.google.com/task/12466848171482193117) started by @is0692vs*