### PR TITLE
🧪 Add test for getAuthorPapers in Semantic Scholar Client

### DIFF
--- a/packages/core/tests/semantic-scholar-client.test.ts
+++ b/packages/core/tests/semantic-scholar-client.test.ts
@@ -10,6 +10,7 @@ const {
     getPaper,
     getAuthor,
     searchAuthors,
+    getAuthorPapers,
 } = await import("../src/semantic-scholar-client.js");
 
 describe("Semantic Scholar Client", () => {
@@ -158,5 +159,42 @@ describe("Semantic Scholar Client", () => {
 
         await expect(getPaper("bad-id")).rejects.toThrow("Semantic Scholar API error: 400 Bad Request - Invalid ID");
         spy.mockRestore();
+    });
+
+    it("getAuthorPapers should pass parameters and parse author papers", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                total: 2,
+                offset: 0,
+                next: 2,
+                data: [
+                    {
+                        paperId: "paper-1",
+                        title: "Test Paper 1",
+                        year: 2024,
+                        venue: "Test Venue",
+                    },
+                    {
+                        paperId: "paper-2",
+                        title: "Test Paper 2",
+                        year: 2023,
+                    }
+                ],
+            }),
+        });
+
+        const response = await getAuthorPapers("author-1", { limit: 10, sort: "citationCount:desc" });
+        expect(response.total).toBe(2);
+        expect(response.offset).toBe(0);
+        expect(response.data.length).toBe(2);
+        expect(response.data[0]?.paperId).toBe("paper-1");
+        expect(response.data[0]?.title).toBe("Test Paper 1");
+
+        const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+        expect(url).toContain("author/author-1/papers");
+        expect(url).toContain("limit=10");
+        expect(url).toContain("sort=citationCount%3Adesc");
     });
 });


### PR DESCRIPTION
🎯 **What:** Added a unit test for the `getAuthorPapers` function in the Semantic Scholar client, filling a missing test coverage gap.

📊 **Coverage:** Covered the happy path for retrieving author papers, ensuring the query parameters like `limit` and `sort` are appended to the URL correctly, and validating the correct parsing of the `S2AuthorPapersResponse` output.

✨ **Result:** Improved test coverage and reliability for `packages/core`.

---
*PR created automatically by Jules for task [1560582533456907597](https://jules.google.com/task/1560582533456907597) started by @is0692vs*