### PR TITLE
🧹 Remove unused buildCitationGraph import from test_benchmark.bench.ts

### DIFF
--- a/packages/visualizer/test_benchmark.bench.ts
+++ b/packages/visualizer/test_benchmark.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from "vitest";
-import { mergeGraphs, buildCitationGraph } from "./src/graph.js";
+import { mergeGraphs } from "./src/graph.js";
 import type { CitationGraph } from "./src/graph.js";
 
 const generateMockGraph = (size: number, startNode: string): CitationGraph => {


### PR DESCRIPTION
🎯 **What:** Removed the unused `buildCitationGraph` import from `packages/visualizer/test_benchmark.bench.ts`.

💡 **Why:** To improve code health and maintainability by removing unused dependencies and keeping the benchmark file clean.

✅ **Verification:** Verified by running `pnpm test` in the `packages/visualizer` directory. All 20 tests passed successfully, confirming the removal of the unused import did not introduce regressions.

✨ **Result:** A cleaner and more maintainable `test_benchmark.bench.ts` file without unnecessary imports.

---
*PR created automatically by Jules for task [17606431403624060979](https://jules.google.com/task/17606431403624060979) started by @is0692vs*