### PR TITLE
🧹 Extract `useSaveToNotion` hook from `SaveToNotionButton`

### DIFF
--- a/packages/web/src/components/SaveToNotionButton.tsx
+++ b/packages/web/src/components/SaveToNotionButton.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { BookmarkPlus, Check, Loader2, RotateCcw } from "lucide-react";
-import { useCallback, useState } from "react";
 import type { S2Paper } from "@paper-tools/core";
+import { useSaveToNotion } from "@/hooks/useSaveToNotion";
 
 interface SaveToNotionButtonProps {
   paper?: S2Paper;
@@ -12,8 +12,6 @@ interface SaveToNotionButtonProps {
   onSaved?: () => void;
 }
 
-type SaveStatus = "idle" | "resolving" | "saving" | "done" | "error";
-
 export default function SaveToNotionButton({
   paper,
   doi,
@@ -21,69 +19,7 @@ export default function SaveToNotionButton({
   saved = false,
   onSaved,
 }: SaveToNotionButtonProps) {
-  const [status, setStatus] = useState<SaveStatus>("idle");
-  const [error, setError] = useState<string | null>(null);
-
-  const handleClick = useCallback(async () => {
-    if (
-      saved ||
-      status === "resolving" ||
-      status === "saving" ||
-      status === "done"
-    ) {
-      return;
-    }
-
-    setError(null);
-
-    try {
-      let targetPaper = paper;
-
-      if (!targetPaper) {
-        const trimmedDoi = doi?.trim();
-        const trimmedTitle = title?.trim();
-
-        if (!trimmedDoi && !trimmedTitle) {
-          throw new Error("保存対象の DOI またはタイトルが見つかりません");
-        }
-
-        setStatus("resolving");
-        const resolveRes = await fetch("/api/resolve", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(
-            trimmedDoi ? { doi: trimmedDoi } : { title: trimmedTitle },
-          ),
-        });
-        const resolveData = await resolveRes.json();
-        if (!resolveRes.ok) {
-          throw new Error(resolveData.error ?? "論文の解決に失敗しました");
-        }
-
-        targetPaper = resolveData.paper as S2Paper | undefined;
-        if (!targetPaper) {
-          throw new Error("保存対象の論文を取得できませんでした");
-        }
-      }
-
-      setStatus("saving");
-      const archiveRes = await fetch("/api/archive", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ paper: targetPaper }),
-      });
-      const archiveData = await archiveRes.json();
-      if (!archiveRes.ok) {
-        throw new Error(archiveData.error ?? "Notionへの保存に失敗しました");
-      }
-
-      setStatus("done");
-      onSaved?.();
-    } catch (err) {
-      setStatus("error");
-      setError(err instanceof Error ? err.message : "Unknown error");
-    }
-  }, [status, paper, doi, title, saved, onSaved]);
+  const { status, error, save } = useSaveToNotion({ paper, doi, title, saved, onSaved });
 
   const disabled =
     saved || status === "resolving" || status === "saving" || status === "done";
@@ -124,7 +60,7 @@ export default function SaveToNotionButton({
     <div className="space-y-1.5">
       <button
         type="button"
-        onClick={handleClick}
+        onClick={save}
         disabled={disabled}
         className={buttonClassName}
       >

--- a/packages/web/src/hooks/useSaveToNotion.ts
+++ b/packages/web/src/hooks/useSaveToNotion.ts
@@ -1,0 +1,86 @@
+import { useCallback, useState } from "react";
+import type { S2Paper } from "@paper-tools/core";
+
+export type SaveStatus = "idle" | "resolving" | "saving" | "done" | "error";
+
+interface UseSaveToNotionProps {
+  paper?: S2Paper;
+  doi?: string;
+  title?: string;
+  saved?: boolean;
+  onSaved?: () => void;
+}
+
+export function useSaveToNotion({
+  paper,
+  doi,
+  title,
+  saved = false,
+  onSaved,
+}: UseSaveToNotionProps) {
+  const [status, setStatus] = useState<SaveStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const save = useCallback(async () => {
+    if (
+      saved ||
+      status === "resolving" ||
+      status === "saving" ||
+      status === "done"
+    ) {
+      return;
+    }
+
+    setError(null);
+
+    try {
+      let targetPaper = paper;
+
+      if (!targetPaper) {
+        const trimmedDoi = doi?.trim();
+        const trimmedTitle = title?.trim();
+
+        if (!trimmedDoi && !trimmedTitle) {
+          throw new Error("保存対象の DOI またはタイトルが見つかりません");
+        }
+
+        setStatus("resolving");
+        const resolveRes = await fetch("/api/resolve", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            trimmedDoi ? { doi: trimmedDoi } : { title: trimmedTitle },
+          ),
+        });
+        const resolveData = await resolveRes.json();
+        if (!resolveRes.ok) {
+          throw new Error(resolveData.error ?? "論文の解決に失敗しました");
+        }
+
+        targetPaper = resolveData.paper as S2Paper | undefined;
+        if (!targetPaper) {
+          throw new Error("保存対象の論文を取得できませんでした");
+        }
+      }
+
+      setStatus("saving");
+      const archiveRes = await fetch("/api/archive", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ paper: targetPaper }),
+      });
+      const archiveData = await archiveRes.json();
+      if (!archiveRes.ok) {
+        throw new Error(archiveData.error ?? "Notionへの保存に失敗しました");
+      }
+
+      setStatus("done");
+      onSaved?.();
+    } catch (err) {
+      setStatus("error");
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }, [status, paper, doi, title, saved, onSaved]);
+
+  return { status, error, save };
+}


### PR DESCRIPTION
🎯 **What:** Extracted the state management and API logic from `SaveToNotionButton` into a new custom hook called `useSaveToNotion`.
💡 **Why:** `SaveToNotionButton` was a complex component handling both complex asynchronous business logic (resolving and archiving papers to Notion) and presentation (rendering varying icons and labels based on state). This violates separation of concerns. Extracting the logic into a hook improves readability and maintainability, leaving the component focused purely on UI rendering.
✅ **Verification:** Verified that `packages/web` builds successfully (`pnpm run build`) and all tests pass (`pnpm test`). The `SaveToNotionButton` continues to behave identically, utilizing the `status`, `error`, and `save` function from the newly created hook.
✨ **Result:** The `SaveToNotionButton` component is now much simpler and purely presentational, significantly improving code health. The business logic is isolated and easier to test independently.

---
*PR created automatically by Jules for task [4459831620767936257](https://jules.google.com/task/4459831620767936257) started by @is0692vs*