### PR TITLE
🧹 [Remove unused Network import from search page]

### DIFF
--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import { Network, Sparkles } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import type { Paper } from "@paper-tools/core";
 import type { DrilldownResult } from "@paper-tools/drilldown";
 import SearchForm from "@/components/SearchForm";


### PR DESCRIPTION
🎯 **What:** Removed unused `Network` import from `lucide-react` in `packages/web/src/app/search/page.tsx` while preserving the actively used `Sparkles` import.
💡 **Why:** To improve code cleanliness and maintainability by removing unused code.
✅ **Verification:** Verified via `grep` that the file no longer contains the `Network` import but still imports `Sparkles`. Ran the full test suite (`pnpm test`) and built the workspace (`pnpm run build`) in `packages/web` to ensure no regressions were introduced.
✨ **Result:** A cleaner import statement with no functional changes.

---
*PR created automatically by Jules for task [4416490215057684603](https://jules.google.com/task/4416490215057684603) started by @is0692vs*