### PR TITLE
🔒 Fix hardcoded API key vulnerability in tests

### DIFF
--- a/packages/core/tests/semantic-scholar-client.test.ts
+++ b/packages/core/tests/semantic-scholar-client.test.ts
@@ -127,7 +127,8 @@ describe("Semantic Scholar Client", () => {
 
     it("should attach x-api-key header when S2_API_KEY is set", async () => {
         const previous = process.env["S2_API_KEY"];
-        process.env["S2_API_KEY"] = "dummy-key";
+        const testKey = `test-key-${Date.now()}`;
+        process.env["S2_API_KEY"] = testKey;
         vi.resetModules();
 
         mockFetch.mockResolvedValueOnce({
@@ -139,7 +140,7 @@ describe("Semantic Scholar Client", () => {
         const { getRecommendationsForPaper: fnWithKey } = await import("../src/semantic-scholar-client.js");
         await fnWithKey("paper-key-test");
         const [, requestInit] = mockFetch.mock.calls[0] as [string, RequestInit];
-        expect((requestInit.headers as Record<string, string>)["x-api-key"]).toBe("dummy-key");
+        expect((requestInit.headers as Record<string, string>)["x-api-key"]).toBe(testKey);
 
         if (previous === undefined) {
             delete process.env["S2_API_KEY"];


### PR DESCRIPTION
🎯 **What:** Removed hardcoded S2_API_KEY value 'dummy-key' from tests.
⚠️ **Risk:** Hardcoded strings that look like secrets can trigger static application security testing (SAST) tools or accidental commits of real keys.
🛡️ **Solution:** Replaced the hardcoded string with a dynamically generated string using `Date.now()`.

---
*PR created automatically by Jules for task [1627377501079599322](https://jules.google.com/task/1627377501079599322) started by @is0692vs*