### PR TITLE
🧹 [code health improvement] Resolve DOI parameter robustly

### DIFF
--- a/packages/web/src/app/graph/page.tsx
+++ b/packages/web/src/app/graph/page.tsx
@@ -110,7 +110,7 @@ function useGraphData() {
       }
 
       if (nextMode === "doi") {
-        return trimmed;
+        return trimmed.replace(/^(?:https?:\/\/(?:dx\.)?doi\.org\/|doi:)/i, "");
       }
 
       const body =


### PR DESCRIPTION
🎯 **What:** Improved the `resolveToDoi` function in `packages/web/src/app/graph/page.tsx` to handle URL and prefixed DOI formats more robustly.

💡 **Why:** The previous implementation naïvely returned the raw input when `mode === "doi"`, which would fail if the user pasted a full URL (e.g., `https://doi.org/10.1145/123456`) or a `doi:` prefixed string. By using a regular expression to strip common prefixes (`https://doi.org/`, `http://doi.org/`, `dx.doi.org/`, and `doi:`), the application can correctly extract and use the base DOI, leading to a more resilient user experience and cleaner data handling. This also resolves the spirit of the previous `TODO` comment regarding DOI resolution robustness.

✅ **Verification:**
- Ran `pnpm test -- --coverage` across the workspace to ensure tests continue to pass.
- Used `pnpm run build` to verify the application builds without errors.

✨ **Result:** The graph generation form can now seamlessly accept various common DOI formats (URLs, prefixed strings) without throwing resolution errors downstream.

---
*PR created automatically by Jules for task [3851569422526946472](https://jules.google.com/task/3851569422526946472) started by @is0692vs*