### PR TITLE
test(ci): fix stale tests blocking main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     permissions:
       contents: read
     env:
-      BASE_URL: http://127.0.0.1:3000
+      BASE_URL: http://localhost:3000
       CI: "true"
     steps:
       - name: Checkout

--- a/packages/core/tests/semantic-scholar-client.test.ts
+++ b/packages/core/tests/semantic-scholar-client.test.ts
@@ -9,6 +9,7 @@ const {
     getRecommendations,
     getPaper,
     getAuthor,
+    getAuthorPapers,
     searchAuthors,
     searchPapers,
 } = await import("../src/semantic-scholar-client.js");

--- a/packages/web/src/app/api/graph/export/route.test.ts
+++ b/packages/web/src/app/api/graph/export/route.test.ts
@@ -3,9 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@paper-tools/visualizer", () => ({
-  toJson: vi.fn(),
-  toDot: vi.fn(),
-  toMermaid: vi.fn(),
+  formatGraph: vi.fn(),
+  SUPPORTED_FORMATS: ["json", "dot", "mermaid"],
 }));
 
 const visualizer = await import("@paper-tools/visualizer");
@@ -61,7 +60,7 @@ describe("/api/graph/export POST", () => {
 
   it("formatがjsonのとき、toJsonの結果を返す", async () => {
     const mockOutput = '{"mocked": "json"}';
-    vi.mocked(visualizer.toJson).mockReturnValueOnce(mockOutput);
+    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
 
     const req = createRequest({ graph: mockGraph, format: "json" });
     const res = await POST(req);
@@ -70,12 +69,12 @@ describe("/api/graph/export POST", () => {
     expect(res.status).toBe(200);
     expect(data.output).toBe(mockOutput);
     expect(data.format).toBe("json");
-    expect(visualizer.toJson).toHaveBeenCalledWith(mockGraph);
+    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "json");
   });
 
   it("formatがdotのとき、toDotの結果を返す", async () => {
     const mockOutput = "digraph { mock }";
-    vi.mocked(visualizer.toDot).mockReturnValueOnce(mockOutput);
+    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
 
     const req = createRequest({ graph: mockGraph, format: "dot" });
     const res = await POST(req);
@@ -84,12 +83,12 @@ describe("/api/graph/export POST", () => {
     expect(res.status).toBe(200);
     expect(data.output).toBe(mockOutput);
     expect(data.format).toBe("dot");
-    expect(visualizer.toDot).toHaveBeenCalledWith(mockGraph);
+    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "dot");
   });
 
   it("formatがmermaidのとき、toMermaidの結果を返す", async () => {
     const mockOutput = "graph TD; mock;";
-    vi.mocked(visualizer.toMermaid).mockReturnValueOnce(mockOutput);
+    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
 
     const req = createRequest({ graph: mockGraph, format: "mermaid" });
     const res = await POST(req);
@@ -98,7 +97,7 @@ describe("/api/graph/export POST", () => {
     expect(res.status).toBe(200);
     expect(data.output).toBe(mockOutput);
     expect(data.format).toBe("mermaid");
-    expect(visualizer.toMermaid).toHaveBeenCalledWith(mockGraph);
+    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "mermaid");
   });
 
   it("予期せぬエラー発生時に500を返す", async () => {

--- a/verification/verify_confirm.py
+++ b/verification/verify_confirm.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from playwright.sync_api import Page, Route, expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:3000").rstrip("/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:3000").rstrip("/")
 
 
 def _json_response(route: Route, status: int, payload: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- import `getAuthorPapers` in the Semantic Scholar client test so the core package test matches the current API surface
- update the graph export route test to mock `formatGraph` and `SUPPORTED_FORMATS`, matching the current visualizer exports
- restore the main CI failure path without changing runtime code

## Investigation
- `main` had multiple CI runs queued for about 30 minutes because Actions jobs were backed up
- the first actionable failure was on main run `24295150096` (`Package tests (core)` and `Web unit tests`)
- the same failures were already present on PR `#183`, so this was not a main-only regression
- newer PRs such as `#195` and `#192` were still pending when inspected, so recent main instability was a mix of queue backlog and pre-existing test failures

## Verification
- `pnpm --filter @paper-tools/core test`
- `pnpm --filter @paper-tools/web test`