### PR TITLE
🧪 [Testing Improvement] Add boundary condition tests for aggregateCoauthorsFromPapers

### DIFF
--- a/packages/author-profiler/src/tests/coauthor-network.test.ts
+++ b/packages/author-profiler/src/tests/coauthor-network.test.ts
@@ -7,6 +7,53 @@ vi.mock("@paper-tools/core", () => ({
 }));
 
 describe("aggregateCoauthorsFromPapers", () => {
+    it("returns an empty array when given empty papers array", () => {
+        expect(aggregateCoauthorsFromPapers("self", [])).toEqual([]);
+    });
+
+    it("handles papers with undefined authors gracefully", () => {
+        const papers = [
+            { paperId: "p1", title: "Missing Authors" }
+        ];
+        expect(aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[])).toEqual([]);
+    });
+
+    it("handles authors with missing or empty IDs gracefully", () => {
+        const papers = [
+            {
+                paperId: "p1",
+                title: "A",
+                authors: [
+                    { authorId: "self", name: "Self" },
+                    { authorId: "", name: "Empty ID" },
+                    { authorId: "   ", name: "Whitespace ID" },
+                    { name: "Undefined ID" },
+                    { authorId: "a1", name: "Alice" }
+                ],
+            }
+        ];
+        expect(aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[])).toEqual([
+            { authorId: "a1", name: "Alice", paperCount: 1 }
+        ]);
+    });
+
+    it("deduplicates the same author within the same paper", () => {
+        const papers = [
+            {
+                paperId: "p1",
+                title: "A",
+                authors: [
+                    { authorId: "self", name: "Self" },
+                    { authorId: "a1", name: "Alice" },
+                    { authorId: "a1", name: "Alice Duplicate" }
+                ],
+            }
+        ];
+        expect(aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[])).toEqual([
+            { authorId: "a1", name: "Alice", paperCount: 1 }
+        ]);
+    });
+
     it("aggregates coauthor counts and excludes self", () => {
         const papers = [
             {


### PR DESCRIPTION
🎯 **What:** Added boundary condition unit tests for the `aggregateCoauthorsFromPapers` function in `@paper-tools/author-profiler` to prevent regressions in its pure-logic execution.

📊 **Coverage:** The new tests cover the following scenarios:
* Empty `papers` array.
* Papers with `undefined` authors array.
* Authors with missing or whitespace-only IDs (`authorId`).
* Deduplication of the same author appearing multiple times in the same paper.

✨ **Result:** Test coverage for `coauthor-network.ts` is improved, ensuring graceful handling of malformed input and protecting the deduplication logic from future breakage.

---
*PR created automatically by Jules for task [15096263886262272272](https://jules.google.com/task/15096263886262272272) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`aggregateCoauthorsFromPapers` の境界条件テスト4件（空配列、`undefined` authors、無効な authorId、同一ペーパー内重複）を追加する PR です。追加された各テストケースは実装（`coauthor-network.ts`）と完全に整合しており、論理的に正確です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなく、マージに問題ありません。

追加された4件のテストはすべて実装コードと整合しており、期待値も正確です。P0・P1 相当の問題は見つかりませんでした。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/author-profiler/src/tests/coauthor-network.test.ts | aggregateCoauthorsFromPapers の境界条件テストを4件追加。実装コードとの整合性は全て確認済みで、期待値はいずれも正確。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[aggregateCoauthorsFromPapers\n'selfId', papers] --> B{papers.length == 0?}
    B -- はい --> Z[return 空配列]
    B -- いいえ --> C[各 paper を処理]
    C --> D[seenInPaper = new Set]
    D --> E{paper.authors が存在する?}
    E -- いいえ / ?? [] --> F[次の paper へ]
    E -- はい --> G[各 author を処理]
    G --> H[id = authorId ?? '' .trim()]
    H --> I{id が空 OR id === selfId OR seenInPaper に存在?}
    I -- はい --> J[スキップ]
    I -- いいえ --> K[seenInPaper に追加]
    K --> L{authorMap に存在?}
    L -- はい --> M[paperCount += 1]
    L -- いいえ --> N[authorMap に新規登録]
    M & N --> G
    F --> C
    C --> O[paperCount 降順ソートで返す]
```

<sub>Reviews (1): Last reviewed commit: ["test(author-profiler): add boundary test..."](https://github.com/hiroki-org/paper-tools/commit/57e87ca5b9ae10ea0dbd9556229425ccfded3be8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739179)</sub>

<!-- /greptile_comment -->