### PR TITLE
🧹 Remove unused Sparkles import in search page

### DIFF
--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import { Sparkles } from "lucide-react";
 import type { Paper } from "@paper-tools/core";
 import type { DrilldownResult } from "@paper-tools/drilldown";
 import SearchForm from "@/components/SearchForm";


### PR DESCRIPTION
🎯 **What:** Removed unused `Sparkles` import from `packages/web/src/app/search/page.tsx`
💡 **Why:** Improves code maintainability and readability by eliminating dead code.
✅ **Verification:** Verified `pnpm --filter @paper-tools/web test` and `pnpm --filter @paper-tools/web build` pass successfully.
✨ **Result:** Cleaner codebase without unused dependencies.

---
*PR created automatically by Jules for task [12948871330106640291](https://jules.google.com/task/12948871330106640291) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `packages/web/src/app/search/page.tsx` から未使用の `Sparkles` インポートを削除するクリーンアップです。コードへの機能的な影響はありません。なお、PR の主目的と無関係な `next-env.d.ts` の自動生成パス変更（`.next/dev/types/` → `.next/types/`）も含まれており、意図的かどうか確認を推奨します。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2 の指摘のみ。機能への影響はなく、マージ自体は安全です。

変更は非常に小さく、未使用インポートの削除のみでロジックへの影響はありません。`next-env.d.ts` の変更は自動生成ファイルの更新と思われ、P2 レベルの確認事項に留まります。

`packages/web/next-env.d.ts` の変更が PR の意図と一致しているか確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/search/page.tsx | 未使用の `Sparkles` インポートを削除。コードロジックへの影響なし。 |
| packages/web/next-env.d.ts | 型参照パスを `.next/dev/types/routes.d.ts` から `.next/types/routes.d.ts` に変更。Next.js 自動生成ファイルの更新と思われるが、PR の主目的と無関係な変更が含まれている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["packages/web/src/app/search/page.tsx"] -->|"Sparkles import 削除（未使用）"| B["lucide-react\nSparkles ❌ 削除"]
    C["packages/web/next-env.d.ts\n（自動生成）"] -->|"パス変更"| D[".next/dev/types/routes.d.ts\n→ .next/types/routes.d.ts"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web/next-env.d.ts
Line: 3

Comment:
**PR タイトルと無関係な変更が含まれています**

このファイルは Next.js が自動生成するものであり、ファイル内コメントにも "This file should not be edited" と明記されています。パスが `.next/dev/types/routes.d.ts` から `.next/types/routes.d.ts` へ変わっており、`next dev` 実行時と `next build` 実行時で出力先が異なるため、ビルド環境が切り替わった際に自動更新された可能性があります。意図的な変更であれば問題ありませんが、PR の目的（未使用 import の削除）と無関係なため、別途確認・コミットとして分離することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove unused Sparkles import fro..."](https://github.com/hiroki-org/paper-tools/commit/c29ea145fbbdfb4ca3bea63fb451b68e01432cbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739207)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->