### PR TITLE
🧪 Add missing error path tests in useSaveToNotion.ts

### DIFF
--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/hooks/useSaveToNotion.test.ts
+++ b/packages/web/src/hooks/useSaveToNotion.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSaveToNotion } from "./useSaveToNotion";
+import type { S2Paper } from "@paper-tools/core";
+
+describe("useSaveToNotion", () => {
+  const mockPaper: S2Paper = {
+    paperId: "test-paper-123",
+    title: "Test Paper Title",
+    abstract: "Test abstract",
+    authors: [],
+    year: 2024,
+    venue: "Test",
+    citationCount: 0,
+    influentialCitationCount: 0,
+    referenceCount: 0,
+    externalIds: { DOI: "10.1234/test" },
+    url: "http://example.com",
+    tldr: null,
+    fieldsOfStudy: null,
+    publicationDate: null,
+    journal: null,
+  };
+
+  const mockOnSaved = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    mockOnSaved.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should do nothing if already saved", async () => {
+    const { result } = renderHook(() =>
+      useSaveToNotion({ paper: mockPaper, saved: true, onSaved: mockOnSaved })
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("should successfully save when paper is provided (skips resolve)", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useSaveToNotion({ paper: mockPaper, onSaved: mockOnSaved })
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith("/api/archive", expect.any(Object));
+    expect(result.current.status).toBe("done");
+    expect(mockOnSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("should resolve by DOI and then save", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ paper: mockPaper }),
+      } as Response) // /api/resolve
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response); // /api/archive
+
+    const { result } = renderHook(() =>
+      useSaveToNotion({ doi: "10.1234/test", onSaved: mockOnSaved })
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/resolve",
+      expect.objectContaining({
+        body: JSON.stringify({ doi: "10.1234/test" }),
+      })
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/archive",
+      expect.objectContaining({
+        body: JSON.stringify({ paper: mockPaper }),
+      })
+    );
+    expect(result.current.status).toBe("done");
+    expect(mockOnSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("should resolve by title and then save", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ paper: mockPaper }),
+      } as Response) // /api/resolve
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response); // /api/archive
+
+    const { result } = renderHook(() =>
+      useSaveToNotion({ title: "Test Paper Title", onSaved: mockOnSaved })
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/resolve",
+      expect.objectContaining({
+        body: JSON.stringify({ title: "Test Paper Title" }),
+      })
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/archive",
+      expect.objectContaining({
+        body: JSON.stringify({ paper: mockPaper }),
+      })
+    );
+    expect(result.current.status).toBe("done");
+    expect(mockOnSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("should set error when no paper, doi, or title provided", async () => {
+    const { result } = renderHook(() => useSaveToNotion({}));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("保存対象の DOI またはタイトルが見つかりません");
+  });
+
+  it("should set error when resolve API fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Custom resolve error" }),
+    } as Response);
+
+    const { result } = renderHook(() => useSaveToNotion({ doi: "10.1234/test" }));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("Custom resolve error");
+  });
+
+  it("should set default error when resolve API fails without error message", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}), // missing error
+    } as Response);
+
+    const { result } = renderHook(() => useSaveToNotion({ doi: "10.1234/test" }));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("論文の解決に失敗しました");
+  });
+
+  it("should set error when resolve API returns ok but no paper", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}), // no paper
+    } as Response);
+
+    const { result } = renderHook(() => useSaveToNotion({ doi: "10.1234/test" }));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("保存対象の論文を取得できませんでした");
+  });
+
+  it("should set error when archive API fails", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ paper: mockPaper }),
+      } as Response) // /api/resolve
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Custom archive error" }),
+      } as Response); // /api/archive
+
+    const { result } = renderHook(() => useSaveToNotion({ doi: "10.1234/test" }));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("Custom archive error");
+  });
+
+  it("should set default error when archive API fails without error message", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ paper: mockPaper }),
+      } as Response) // /api/resolve
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}), // no error message
+      } as Response); // /api/archive
+
+    const { result } = renderHook(() => useSaveToNotion({ doi: "10.1234/test" }));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("Notionへの保存に失敗しました");
+  });
+
+  it("should handle general network error", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network Error"));
+
+    const { result } = renderHook(() => useSaveToNotion({ paper: mockPaper }));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("Network Error");
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `useSaveToNotion` React hook lacked tests, particularly for the multiple specific error paths encountered when attempting to resolve and archive a paper via Notion.

📊 **Coverage:** What scenarios are now tested
- Happy paths for saving a paper directly or resolving by DOI/title first.
- Missing paper, DOI, or title error condition.
- `/api/resolve` fetch failures (both explicit error messages and generic defaults).
- `/api/resolve` returning a success status but no valid paper.
- `/api/archive` fetch failures (both explicit error messages and generic defaults).
- General network/unexpected error catching via the hook's try/catch block.

✨ **Result:** The improvement in test coverage
The hook is now fully covered by 11 discrete test cases verifying both expected successes and every described failure state, ensuring confident future refactoring.

---
*PR created automatically by Jules for task [923378912702042689](https://jules.google.com/task/923378912702042689) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`useSaveToNotion` フックに対して、ハッピーパスとすべてのエラーパスを網羅する 11 件のテストケースが追加されました。実装との整合性は確認済みで、テストロジック自体に誤りはありません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2 のみで実質的なバグはなく、マージ自体は安全です

テストロジックは実装と一致しており、論理的な誤りはありません。`vi.unstubAllGlobals()` の欠如と `next-env.d.ts` の混入はいずれも P2 レベルのベストプラクティス上の懸念にとどまります。

`next-env.d.ts` の変更が意図的かどうかを確認してください
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/hooks/useSaveToNotion.test.ts | 11件のテストケースを新規追加。ハッピーパス・各エラーパスをほぼ網羅しているが、`afterEach` のグローバルスタブ解除が不完全（`vi.unstubAllGlobals()` 不足） |
| packages/web/next-env.d.ts | Next.js 自動生成ファイルのルート型パスが dev → 本番パスへ変更。テスト追加 PR への意図しない混入の可能性あり |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[save called] --> B{saved or in-progress?}
    B -- Yes --> C[Early return]
    B -- No --> D{paper provided?}
    D -- Yes --> G[POST /api/archive]
    D -- No --> E{doi or title?}
    E -- No --> ERR1[throw: no DOI or title]
    E -- Yes --> F[POST /api/resolve]
    F --> F1{res.ok?}
    F1 -- No --> ERR2[throw: resolveData.error]
    F1 -- Yes --> F2{paper in data?}
    F2 -- No --> ERR3[throw: paper not found]
    F2 -- Yes --> G
    G --> G1{res.ok?}
    G1 -- No --> ERR4[throw: archiveData.error]
    G1 -- Yes --> H[status=done, onSaved]
    ERR1 & ERR2 & ERR3 & ERR4 --> Z[catch: status=error, setError]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web/src/hooks/useSaveToNotion.test.ts
Line: 35-39

Comment:
**`vi.restoreAllMocks()` はグローバルスタブを解放しない**

`vi.stubGlobal()` で設定したスタブは `vi.restoreAllMocks()` では解除されません。`vi.unstubAllGlobals()` を使う必要があります。`beforeEach` で毎回 `vi.stubGlobal` を呼び直しているため、このファイル内では問題になりませんが、Vitest の pool 設定によっては `fetch` スタブが他のテストファイルへ漏れる可能性があります。`afterEach` に `vi.unstubAllGlobals()` を追加することを推奨します。

```suggestion
  afterEach(() => {
    vi.restoreAllMocks();
    vi.unstubAllGlobals();
  });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web/next-env.d.ts
Line: 3

Comment:
**自動生成ファイルの変更がこの PR に混入している**

このファイルには「This file should not be edited」とコメントされており、Next.js が自動生成します。`.next/dev/types/routes.d.ts` から `.next/types/routes.d.ts` へのパス変更は、Next.js のバージョンアップや開発環境のビルド実行によるものと思われますが、テスト追加のみを目的としたこの PR には本来含まれないはずの変更です。意図的な変更かどうかをご確認ください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add test coverage for useSaveToNot..."](https://github.com/hiroki-org/paper-tools/commit/f83abfe92a43c026bbc03084b5d387da2f3c52b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739210)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->