### PR TITLE
🔒 Fix timing attack vulnerability in signature verification

### DIFF
--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes } from "crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { Client } from "@notionhq/client";
 import { NextResponse } from "next/server";
 import {
@@ -58,7 +58,15 @@ export function sealCookieValue(data: unknown) {
 export function unsealCookieValue<T>(value: string): T | null {
     const [payload, sig] = value.split(".");
     if (!payload || !sig) return null;
-    if (signPayload(payload) !== sig) return null;
+
+    const expectedSig = signPayload(payload);
+    const expectedSigBuffer = Buffer.from(expectedSig);
+    const actualSigBuffer = Buffer.from(sig);
+
+    if (expectedSigBuffer.length !== actualSigBuffer.length || !timingSafeEqual(expectedSigBuffer, actualSigBuffer)) {
+        return null;
+    }
+
     try {
         return JSON.parse(fromBase64Url(payload)) as T;
     } catch {


### PR DESCRIPTION
🎯 **What:** Fixed a timing attack vulnerability in `unsealCookieValue` where the signature comparison was performed using standard string equality (`!==`), allowing potential attackers to guess the signature via timing discrepancies.

⚠️ **Risk:** An attacker could potentially bypass authentication or tamper with cookie payloads by measuring the time taken for the signature comparison to fail, incrementally forging a valid HMAC signature.

🛡️ **Solution:** Implemented Node's `crypto.timingSafeEqual` to ensure constant-time comparison of the expected and actual signatures. To safely use this function and prevent `RangeError` exceptions (which occur when comparing buffers of unequal length), an explicit length check was added before comparison. Buffer conversion was also implemented.

---
*PR created automatically by Jules for task [17525162642640254974](https://jules.google.com/task/17525162642640254974) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`unsealCookieValue` における署名比較を標準の文字列等値演算子から `crypto.timingSafeEqual` に置き換えることで、HMAC シグネチャをタイミング差分から推測されるリスクを排除します。`next-env.d.ts` の変更は本 PR の目的と無関係です。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージ可能。タイミング攻撃対策の本質は正しく実装されており、P2 レベルの軽微な指摘のみ。

P2 のみの指摘（長さチェックによる理論上のタイミングオラクルと無関係ファイルの変更）。セキュリティ修正の核心である `timingSafeEqual` の導入は正しく、実用上の脆弱性は残っていない。

特になし。`next-env.d.ts` の変更が意図的かどうかを確認する程度。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/lib/auth.ts | `unsealCookieValue` にて `!==` による文字列比較を `timingSafeEqual` に置き換えるタイミング攻撃対策。長さチェックが軽微なタイミングオラクルを残す可能性があるが、実用上のリスクは低い。 |
| packages/web/next-env.d.ts | 型定義パスを `.next/dev/types/routes.d.ts` → `.next/types/routes.d.ts` に変更。自動生成ファイルへの意図不明な変更でセキュリティ修正とは無関係。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant unsealCookieValue
    participant signPayload
    participant timingSafeEqual

    Client->>unsealCookieValue: cookie value (payload.sig)
    unsealCookieValue->>unsealCookieValue: split(".") → payload, sig
    unsealCookieValue->>signPayload: payload
    signPayload-->>unsealCookieValue: expectedSig (HMAC-SHA256 base64url, 43 chars)
    unsealCookieValue->>unsealCookieValue: Buffer.from(expectedSig) / Buffer.from(sig)
    alt 長さ不一致 (length check)
        unsealCookieValue-->>Client: null（早期リターン）
    else 長さ一致
        unsealCookieValue->>timingSafeEqual: expectedSigBuffer, actualSigBuffer
        timingSafeEqual-->>unsealCookieValue: true / false（定数時間比較）
        alt 検証失敗
            unsealCookieValue-->>Client: null
        else 検証成功
            unsealCookieValue-->>Client: JSON.parse(fromBase64Url(payload))
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web/src/lib/auth.ts
Line: 66-68

Comment:
**長さチェックが残存するタイミングオラクルを生成している**

`expectedSigBuffer.length !== actualSigBuffer.length` による早期リターンは、「長さが異なる署名（即座に失敗）」と「長さが正しい署名（`timingSafeEqual` を経由）」の間にタイミング差を生じさせます。`signPayload` は常に HMAC-SHA256 を base64url エンコードするため出力は常に 43 文字ですが、厳密な定数時間比較を保証するなら長さに依存せず比較できる実装が望ましいです。ただし HMAC-SHA256 の出力長は仕様上固定であり、実際の攻撃リスクは極めて低いです。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web/next-env.d.ts
Line: 3

Comment:
**PR の目的と無関係な変更が含まれている**

このファイルには `// NOTE: This file should not be edited` というコメントが書かれています。`.next/dev/types/routes.d.ts` から `.next/types/routes.d.ts` へのパス変更は Next.js のツールチェーンが自動生成した可能性が高く、今回のセキュリティ修正とは無関係です。意図的な変更であれば説明をお願いします。そうでなければ、このファイルをコミットから除外することを検討してください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix timing attack vulnerability in signa..."](https://github.com/hiroki-org/paper-tools/commit/31e479f31d7691cbc81b50272038e713380e4ed8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739213)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->