### PR TITLE
🧪 Add edge case tests for drilldown extractKeywords

### DIFF
--- a/packages/drilldown/tests/drilldown.test.ts
+++ b/packages/drilldown/tests/drilldown.test.ts
@@ -60,6 +60,16 @@ describe("extractKeywords", () => {
         const keywords = extractKeywords([], 10);
         expect(keywords).toEqual([]);
     });
+
+    it("should return empty array for inputs containing only stopwords or special chars", () => {
+        const papers = [
+            { title: "The a an to for of", authors: [] },
+            { title: "!!! ??? &&&", authors: [] },
+            { title: "The of", abstract: "And but or in on at", authors: [] }
+        ];
+        const keywords = extractKeywords(papers, 10);
+        expect(keywords).toEqual([]);
+    });
 });
 
 describe("drilldown", () => {


### PR DESCRIPTION
🎯 **What:** Added tests for extractKeywords edge cases where titles or abstracts contain only stopwords or special characters.
📊 **Coverage:** Added tests for pure function edge cases to verify that an empty array is correctly returned.
✨ **Result:** Improved testing robustness and coverage for the drilldown package.

---
*PR created automatically by Jules for task [5435956215399852018](https://jules.google.com/task/5435956215399852018) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ストップワードのみ、または特殊文字のみを含む論文データを渡した場合に `extractKeywords` が空配列を返すことを確認するエッジケーステストを1件追加しています。実装ロジックとの整合性は取れており、テストの期待値は正しいです。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト追加のみのPRであり、プロダクションコードへの変更はなく安全にマージ可能です。

変更はテストファイル1件のみで、追加されたアサーションの期待値も実装と一致しています。P2の指摘（テスト分割）は機能的な問題ではないためスコアに影響しません。

特になし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/drilldown.test.ts | extractKeywords のエッジケーステストを追加。ロジックは正確だが3つのシナリオが1テストに混在しており、デバッグ時の識別が難しい。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["extractKeywords(papers, topN)"] --> B["各 paper を走査"]
    B --> C["tokenize(paper.title)"]
    B --> D{"paper.keywords あり?"}
    B --> E{"paper.abstract あり?"}
    D -- Yes --> F["tokenize(kw) × 各キーワード\n頻度 +2"]
    E -- Yes --> G["tokenize(paper.abstract)\n頻度 +1"]
    C --> H["頻度 +1"]
    F --> I["freq Map に集計"]
    G --> I
    H --> I
    I --> J["freq.entries() を頻度降順ソート"]
    J --> K["上位 topN を返す"]
    K --> L{"結果が空?"}
    L -- Yes --> M["[] を返す ✅ (エッジケーステスト対象)"]
    L -- No --> N["キーワード配列を返す"]

    subgraph tokenize
        T1["text.toLowerCase()"] --> T2["非英数字・スペース・ハイフンを除去"]
        T2 --> T3["空白で分割"]
        T3 --> T4["長さ ≤ 2 または STOP_WORDS に含まれるトークンを除外"]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/drilldown/tests/drilldown.test.ts
Line: 64-72

Comment:
**3つのエッジケースを1つのテストに集約している点について**

「ストップワードのみ」「特殊文字のみ」「タイトル＋abstractがストップワードのみ」という異なる3つのシナリオが1つの `it` ブロックにまとめられています。どれか1ケースが失敗したとき、どのシナリオが原因かテスト名だけでは特定しにくくなります。各ケースを独立した `it` に分けることを検討してください。

```suggestion
    it("should return empty array when title contains only stopwords", () => {
        const papers = [
            { title: "The a an to for of", authors: [] },
        ];
        expect(extractKeywords(papers, 10)).toEqual([]);
    });

    it("should return empty array when title contains only special characters", () => {
        const papers = [
            { title: "!!! ??? &&&", authors: [] },
        ];
        expect(extractKeywords(papers, 10)).toEqual([]);
    });

    it("should return empty array when title and abstract contain only stopwords", () => {
        const papers = [
            { title: "The of", abstract: "And but or in on at", authors: [] },
        ];
        expect(extractKeywords(papers, 10)).toEqual([]);
    });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(drilldown): add edge case tests for..."](https://github.com/hiroki-org/paper-tools/commit/5d932a2ccd8d109781215a06e2c7fd5b2f48159a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739239)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->