### PR TITLE
🧪 Add edge case tests for drilldown extractKeywords

### DIFF
--- a/packages/drilldown/tests/drilldown.test.ts
+++ b/packages/drilldown/tests/drilldown.test.ts
@@ -60,6 +60,40 @@ describe("extractKeywords", () => {
         const keywords = extractKeywords([], 10);
         expect(keywords).toEqual([]);
     });
+
+    it("should extract keywords from abstract", () => {
+        const papers = [
+            {
+                title: "A Study",
+                authors: [],
+                abstract: "This abstract discusses revolutionary quantum computing architectures."
+            },
+        ];
+
+        const keywords = extractKeywords(papers, 10);
+        expect(keywords).toContain("revolutionary");
+        expect(keywords).toContain("quantum");
+        expect(keywords).toContain("computing");
+        expect(keywords).toContain("architectures");
+    });
+
+    it("should return empty array for papers with only stopwords or special chars in title and abstract", () => {
+        const papers = [
+            {
+                title: "The and of a in",
+                authors: [],
+                abstract: "!@#$%^&*()_+ is to for be"
+            },
+            {
+                title: "a to at on it",
+                authors: [],
+                abstract: "- = [] {} ; : ' \" , . / ? < > \\ | a b c 1 2"
+            }
+        ];
+
+        const keywords = extractKeywords(papers, 10);
+        expect(keywords).toEqual([]);
+    });
 });
 
 describe("drilldown", () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added missing edge case tests for the `extractKeywords` function in `packages/drilldown/src/drilldown.ts` to ensure robust handling of non-standard paper inputs.

📊 **Coverage:** What scenarios are now tested
1. Papers that only contain stopwords, special characters, and short words in both their `title` and `abstract`. This ensures the tokenizer and filtering logic function correctly and securely against edge cases, correctly returning an empty keywords array.
2. Extraction of keywords exclusively from the `abstract` field.

✨ **Result:** The improvement in test coverage
The test coverage for `packages/drilldown/src/drilldown.ts` improved from 91.37% to 95.68%. Specifically, previously uncovered lines `#148-152` concerning abstract parsing are now fully exercised by the test suite. All tests pass successfully.

---
*PR created automatically by Jules for task [15295992898376574987](https://jules.google.com/task/15295992898376574987) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`extractKeywords` のエッジケースを対象とした 2 つのテストを追加するPRです。①abstract フィールドのみからのキーワード抽出、②タイトル・アブストラクトがすべてストップワードまたは記号で構成される場合に空配列を返す、というシナリオを検証し、カバレッジを 91.37% → 95.68% に向上させています。テストロジック自体は正確で、追加されたアサーションはすべて実装コードの挙動と一致しています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更でロジックは正確。P2 スタイル指摘が 1 件あるがマージに支障はない。

P2 指摘（テストデータ内の "abstract" という単語の混入）が 1 件のみ。機能コードへの変更はなく、追加テストはいずれも正しい挙動をカバーしているため 4/5 が妥当。

特になし。変更は drilldown.test.ts のみ。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/drilldown.test.ts | 2 つのエッジケーステストを追加。ロジックは正確で意図したコードパス（lines 147-152）をカバーしているが、抽象文に "abstract" という単語が含まれ、フィールド名がキーワードとして抽出される軽微な紛らわしさがある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractKeywords 呼び出し] --> B{papers が空?}
    B -- Yes --> Z[空配列を返す]
    B -- No --> C[各 paper をループ]
    C --> D[title をトークン化 → freq に加算]
    D --> E{keywords フィールドあり?}
    E -- Yes --> F[keywords をトークン化 → freq に +2]
    E -- No --> G{abstract フィールドあり?}
    F --> G
    G -- Yes --> H[abstract をトークン化 → freq に加算]
    G -- No --> I[次の paper へ]
    H --> I
    I --> C
    C -- 全 paper 処理完了 --> J[freq を降順ソート]
    J --> K[上位 topN を返す]

    style H fill:#d4edda,stroke:#28a745
    style Z fill:#f8d7da,stroke:#dc3545
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/drilldown/tests/drilldown.test.ts
Line: 69

Comment:
**テストデータに "abstract" という単語が混入する**

アブストラクト文字列 `"This abstract discusses revolutionary quantum computing architectures."` の中の単語 `"abstract"` は `STOP_WORDS` に含まれておらず、長さも 2 文字超なので `tokenize` によってキーワードとして抽出されます。このテストの意図は「`abstract` フィールドからキーワードを取り出せること」の検証ですが、フィールド名そのものが結果に混入するためテストデータとして若干紛らわしくなっています。

別の単語（例: `"This paper presents cutting-edge..."` など）に置き換えると意図がより明確になります。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add edge case tests for drilldown ..."](https://github.com/hiroki-org/paper-tools/commit/024e4a1af4fb77cd248489ce3177e022be73f22b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739275)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->