### PR TITLE
🧪 Add test coverage for Recommender CLI logic

### DIFF
--- a/packages/recommender/src/cli.ts
+++ b/packages/recommender/src/cli.ts
@@ -20,7 +20,7 @@ import { parsePositiveInt } from "@paper-tools/core";
 const program = new Command();
 
 
-async function syncPapers(
+export async function syncPapers(
     databaseId: string,
     papers: S2Paper[],
     duplicates: DuplicateResult,
@@ -69,7 +69,7 @@ async function syncPapers(
     return { added, skipped, errors };
 }
 
-async function outputJson(data: unknown, output?: string): Promise<void> {
+export async function outputJson(data: unknown, output?: string): Promise<void> {
     const json = JSON.stringify(data, null, 2);
     if (output) {
         const { writeFile } = await import("node:fs/promises");
@@ -80,7 +80,7 @@ async function outputJson(data: unknown, output?: string): Promise<void> {
     console.log(json);
 }
 
-function requireDatabaseId(): string {
+export function requireDatabaseId(): string {
     const databaseId = process.env["NOTION_DATABASE_ID"];
     if (!databaseId) {
         throw new Error("NOTION_DATABASE_ID が未設定です");
@@ -181,4 +181,4 @@ program
         }
     });
 
-program.parse();
+if (process.env["VITEST"] !== "true") { program.parse(); }

--- a/packages/recommender/tests/cli.test.ts
+++ b/packages/recommender/tests/cli.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { syncPapers, outputJson, requireDatabaseId } from "../src/cli.js";
+import { createPaperPage } from "../src/notion-client.js";
+
+// Mock the notion-client and node:fs/promises
+vi.mock("../src/notion-client.js", async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual as any,
+        createPaperPage: vi.fn(),
+    };
+});
+
+vi.mock("node:fs/promises", () => ({
+    writeFile: vi.fn(),
+}));
+
+describe("CLI module tests", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env["NOTION_DATABASE_ID"];
+    });
+
+    describe("requireDatabaseId", () => {
+        it("should return database id when set", () => {
+            process.env["NOTION_DATABASE_ID"] = "test-db-id";
+            expect(requireDatabaseId()).toBe("test-db-id");
+        });
+
+        it("should throw error when database id is missing", () => {
+            expect(() => requireDatabaseId()).toThrow("NOTION_DATABASE_ID が未設定です");
+        });
+    });
+
+    describe("outputJson", () => {
+        let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+        let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+        beforeEach(() => {
+            consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+            consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            consoleLogSpy.mockRestore();
+            consoleErrorSpy.mockRestore();
+        });
+
+        it("should output json to console when no output file is provided", async () => {
+            const data = { foo: "bar" };
+            await outputJson(data);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it("should write json to file when output file is provided", async () => {
+            const data = { foo: "bar" };
+            const outputFile = "out.json";
+
+            const fsPromises = await import("node:fs/promises");
+
+            await outputJson(data, outputFile);
+
+            expect(fsPromises.writeFile).toHaveBeenCalledWith(outputFile, JSON.stringify(data, null, 2), "utf-8");
+            expect(consoleErrorSpy).toHaveBeenCalledWith(`Output written to: ${outputFile}`);
+            expect(consoleLogSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("syncPapers", () => {
+        let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+        beforeEach(() => {
+            consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            consoleErrorSpy.mockRestore();
+        });
+
+        const mockValidation = { missingOptional: [] };
+
+        it("should return correct counts when dryRun is true", async () => {
+            const papers = [
+                { paperId: "1", title: "Paper 1", externalIds: { DOI: "10.123/1" }, authors: [] },
+                { paperId: "2", title: "Paper 2", externalIds: { DOI: "10.123/2" }, authors: [] },
+            ];
+
+            const duplicates = {
+                duplicateDois: new Set<string>(),
+                duplicateTitles: new Set<string>(),
+            };
+
+            const result = await syncPapers("db", papers as any, duplicates, true, mockValidation);
+
+            expect(result).toEqual({ added: 2, skipped: 0, errors: 0 });
+            expect(createPaperPage).not.toHaveBeenCalled();
+        });
+
+        it("should skip duplicate papers based on DOI and Title", async () => {
+            const papers = [
+                { paperId: "1", title: "Paper 1", externalIds: { DOI: "10.123/1" }, authors: [] }, // New
+                { paperId: "2", title: "Paper 2", externalIds: { DOI: "10.123/dup" }, authors: [] }, // Duplicate DOI
+                { paperId: "3", title: "duplicate title", externalIds: { DOI: "10.123/3" }, authors: [] }, // Duplicate Title
+            ];
+
+            const duplicates = {
+                duplicateDois: new Set(["10.123/dup"]),
+                duplicateTitles: new Set(["duplicate title"]),
+            };
+
+            const result = await syncPapers("db", papers as any, duplicates, true, mockValidation);
+
+            expect(result).toEqual({ added: 1, skipped: 2, errors: 0 });
+            expect(createPaperPage).not.toHaveBeenCalled();
+        });
+
+        it("should add papers and handle API errors during sync", async () => {
+            const papers = [
+                { paperId: "1", title: "Paper 1", externalIds: { DOI: "10.123/1" }, authors: [] }, // Success
+                { paperId: "2", title: "Paper 2", externalIds: { DOI: "10.123/error" }, authors: [] }, // Error
+                { paperId: "3", title: "Paper 3", externalIds: { DOI: "10.123/3" }, authors: [] }, // Success
+            ];
+
+            const duplicates = {
+                duplicateDois: new Set<string>(),
+                duplicateTitles: new Set<string>(),
+            };
+
+            vi.mocked(createPaperPage).mockImplementation(async (_, paper) => {
+                if (paper.externalIds?.DOI === "10.123/error") {
+                    throw new Error("API Error");
+                }
+                return { url: "test-url" } as any;
+            });
+
+            const result = await syncPapers("db", papers as any, duplicates, false, mockValidation);
+
+            expect(result).toEqual({ added: 2, skipped: 0, errors: 1 });
+            expect(createPaperPage).toHaveBeenCalledTimes(3);
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to add paper 10.123/error:", "API Error");
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The `packages/recommender/src/cli.ts` file lacked tests due to the difficulty of testing the CLI directly without modifying global process properties. I've refactored `cli.ts` to export its core logic functions (`syncPapers`, `outputJson`, `requireDatabaseId`) and wrap the CLI execution so it doesn't run during testing.

📊 **Coverage:** A new test file `packages/recommender/tests/cli.test.ts` was added to thoroughly cover:
- Dry run checks
- Skipping existing papers based on DOI and Title
- Error handling
- Basic json output via console vs file output
- Requirement check for notion database ID

✨ **Result:** Test coverage for `packages/recommender` has been significantly improved, increasing resilience against regressions.

---
*PR created automatically by Jules for task [3962219219985924331](https://jules.google.com/task/3962219219985924331) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

テストカバレッジ向上のため `cli.ts` の主要関数を `export` に変更し、新規テストファイル `cli.test.ts` を追加した PR です。`program.parse()` の実行を `VITEST` 環境変数で制御する形にリファクタリングしています。

- `process.env[\"VITEST\"] !== \"true\"` という条件は本番コードにテストフレームワーク名を埋め込む形になっており、`import.meta.url` を使ったフレームワーク非依存なパターンへの変更を推奨します。
- タイトル重複チェックのテストが小文字同士の比較のみのため `toLowerCase()` の正規化が実際に検証されておらず、また `dryRun: false` + 重複あり のシナリオのカバレッジが欠けています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2 のスタイル・テストカバレッジの指摘のみで、機能的な破壊変更はないためマージ可能です。

変更は関数の export 化と条件付き program.parse() のみで、既存の本番ロジックは変更されていません。P0/P1 の問題は見当たらず、P2 のみです。

特に注意が必要なファイルはありませんが、cli.ts の VITEST ガード条件と cli.test.ts のテストカバレッジギャップを確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/recommender/src/cli.ts | `syncPapers`・`outputJson`・`requireDatabaseId` を `export` に変更し、`program.parse()` を `VITEST` 環境変数で条件分岐。テスト可能化のための最小限のリファクタリング。`VITEST` への直接依存はスタイル上の懸念あり。 |
| packages/recommender/tests/cli.test.ts | 新規テストファイル。`requireDatabaseId`・`outputJson`・`syncPapers` の主要パスをカバー。タイトルの大文字小文字正規化と `dryRun: false` + 重複あり のシナリオが未テスト。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[syncPapers 呼び出し] --> B{各論文をループ}
    B --> C{DOI または タイトルが重複?}
    C -- Yes --> D[skipped++]
    C -- No --> E[toProcess に追加]
    D --> B
    E --> B
    B -- 終了 --> F{dryRun?}
    F -- true --> G[added = toProcess.length\n早期リターン]
    F -- false --> H[BATCH_SIZE=5 でバッチ処理]
    H --> I[createPaperPage 呼び出し]
    I -- 成功 --> J[added++]
    I -- 失敗 --> K[errors++\nconsole.error]
    J --> L{次のバッチ?}
    K --> L
    L -- あり --> H
    L -- なし --> M[結果を返す\nadded / skipped / errors]
    G --> M
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/recommender/src/cli.ts
Line: 184

Comment:
**テストフレームワーク名を本番コードに埋め込んでいる**

`process.env["VITEST"] !== "true"` という条件でテスト実行を制御しているため、本番コードがテストフレームワーク名に依存してしまっています。将来 Vitest 以外のランナーを使う場合や、ローカルで直接 `ts-node` 等で実行した際は環境変数がセットされず `program.parse()` が走る場合があります。

ES モジュールで一般的な `import.meta.url` を使ったパターンの方がフレームワーク非依存です。

```suggestion
if (import.meta.url === new URL(process.argv[1], import.meta.url).href) { program.parse(); }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/recommender/tests/cli.test.ts
Line: 101-117

Comment:
**タイトル重複チェックの大文字小文字変換が実際にはテストされていない**

`cli.ts` の `syncPapers` では `paper.title.trim().toLowerCase()` した値で `duplicateTitles` を照合しますが、このテストではペーパーのタイトル (`"duplicate title"`) と Set の値 (`"duplicate title"`) がどちらも最初から小文字なため、`toLowerCase()` の正規化が実際に機能しているかを確認できていません。例えば `"Duplicate Title"` vs `"duplicate title"` のようなケースを追加すると、ケースインセンシティブな照合ロジックをより確実に検証できます。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/recommender/tests/cli.test.ts
Line: 101-117

Comment:
**`dryRun: false` かつ重複あり のシナリオがテストされていない**

重複スキップのテストはすべて `dryRun: true` で実行されています。`dryRun: false` かつ `duplicates` に重複が含まれる場合、`createPaperPage` が重複を除いた論文のみで呼ばれるかどうかを確認するテストがなく、実際の同期パスにおける重複排除ロジックのカバレッジが欠けています。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Refactor cli.ts and add test coverage"](https://github.com/hiroki-org/paper-tools/commit/7290741251c50621b436da0e7b177d184f7377cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739332)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->