### PR TITLE
🧹 Refactor PaperDetailView to improve code health

### DIFF
--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/components/paper/PaperDetailView.tsx
+++ b/packages/web/src/components/paper/PaperDetailView.tsx
@@ -1,10 +1,12 @@
-import { ArrowLeft, BookOpen, Calendar, Info, MapPin, Quote } from "lucide-react";
+import { ArrowLeft, Quote } from "lucide-react";
 import { useState } from "react";
 import type { S2Paper } from "@paper-tools/core";
 import { BibtexButton } from "@/components/bibtex/BibtexButton";
 import SaveToNotionButton from "@/components/SaveToNotionButton";
 import TagInput from "@/components/TagInput";
 import { ExternalLinkButtons } from "@/components/paper/ExternalLinkButtons";
+import { PaperHeader } from "@/components/paper/PaperHeader";
+import { PaperDetails } from "@/components/paper/PaperDetails";
 import type { PaperDetail } from "@/types/paper";
 
 type Props = {
@@ -53,41 +55,7 @@ export function PaperDetailView({ paper, onBack }: Props) {
         <ExternalLinkButtons paper={paper} />
       </div>
 
-      <header className="space-y-6">
-        <h1 className="text-3xl font-bold tracking-tight text-slate-900 md:text-4xl">
-          {paper.title}
-        </h1>
-
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm font-medium text-slate-500">
-          <div className="flex items-center gap-2">
-            <BookOpen size={16} className="text-slate-400" />
-            <span className="text-slate-700">
-              {paper.authors.length > 5
-                ? `${paper.authors.slice(0, 5).map((a) => a.name).join(", ")} et al.`
-                : paper.authors.map((a) => a.name).join(", ")}
-            </span>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <MapPin size={16} className="text-slate-400" />
-            <span>{paper.venue || "Venue unknown"}</span>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Calendar size={16} className="text-slate-400" />
-            <span>{paper.year || "Year unknown"}</span>
-          </div>
-
-          <div className="flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-emerald-700 ring-1 ring-emerald-200">
-            <Quote size={14} />
-            <span>
-              {paper.citationCount} citations
-              {paper.influentialCitationCount > 0 &&
-                ` (${paper.influentialCitationCount} influential)`}
-            </span>
-          </div>
-        </div>
-      </header>
+      <PaperHeader paper={paper} />
 
       {paper.tldr?.text && (
         <section className="rounded-2xl border border-blue-100 bg-blue-50/50 p-6 shadow-sm backdrop-blur-sm">
@@ -118,72 +86,7 @@ export function PaperDetailView({ paper, onBack }: Props) {
         </section>
 
         <section className="space-y-6">
-          <div>
-            <h2 className="mb-4 flex items-center gap-2 text-xl font-bold text-slate-900">
-              <Info size={20} className="text-slate-400" />
-              Details
-            </h2>
-            <div className="divide-y divide-slate-100 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-              <div className="px-5 py-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  Fields of Study
-                </p>
-                <div className="mt-2 flex flex-wrap gap-1.5">
-                  {fields.length > 0 ? (
-                    fields.map((f, i) => (
-                      <span
-                        key={i}
-                        className="rounded-lg bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700"
-                      >
-                        {f.category}
-                      </span>
-                    ))
-                  ) : (
-                    <span className="text-sm text-slate-500">N/A</span>
-                  )}
-                </div>
-              </div>
-              <div className="px-5 py-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  DOI
-                </p>
-                <p className="mt-1 text-sm font-medium text-slate-700">
-                  {doi ?? "N/A"}
-                </p>
-              </div>
-              <div className="px-5 py-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  Published
-                </p>
-                <p className="mt-1 text-sm font-medium text-slate-700">
-                  {paper.publicationDate ?? paper.year ?? "N/A"}
-                </p>
-              </div>
-              <div className="px-5 py-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  Stats
-                </p>
-                <div className="mt-2 grid grid-cols-2 gap-4">
-                  <div>
-                    <p className="text-xl font-bold text-slate-900">
-                      {paper.citationCount}
-                    </p>
-                    <p className="text-[10px] uppercase text-slate-500">
-                      Citations
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xl font-bold text-slate-900">
-                      {paper.referenceCount}
-                    </p>
-                    <p className="text-[10px] uppercase text-slate-500">
-                      References
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <PaperDetails paper={paper} fields={fields} doi={doi} />
 
           <div className="flex flex-col gap-3">
             <div>

--- a/packages/web/src/components/paper/PaperDetails.tsx
+++ b/packages/web/src/components/paper/PaperDetails.tsx
@@ -1,0 +1,79 @@
+import { Info } from "lucide-react";
+import type { PaperDetail } from "@/types/paper";
+
+type PaperDetailsProps = {
+  paper: PaperDetail;
+  fields: { category: string }[];
+  doi: string | undefined;
+};
+
+export function PaperDetails({ paper, fields, doi }: PaperDetailsProps) {
+  return (
+    <div>
+      <h2 className="mb-4 flex items-center gap-2 text-xl font-bold text-slate-900">
+        <Info size={20} className="text-slate-400" />
+        Details
+      </h2>
+      <div className="divide-y divide-slate-100 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="px-5 py-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Fields of Study
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {fields.length > 0 ? (
+              fields.map((f, i) => (
+                <span
+                  key={i}
+                  className="rounded-lg bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700"
+                >
+                  {f.category}
+                </span>
+              ))
+            ) : (
+              <span className="text-sm text-slate-500">N/A</span>
+            )}
+          </div>
+        </div>
+        <div className="px-5 py-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            DOI
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-700">
+            {doi ?? "N/A"}
+          </p>
+        </div>
+        <div className="px-5 py-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Published
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-700">
+            {paper.publicationDate ?? paper.year ?? "N/A"}
+          </p>
+        </div>
+        <div className="px-5 py-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Stats
+          </p>
+          <div className="mt-2 grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-xl font-bold text-slate-900">
+                {paper.citationCount}
+              </p>
+              <p className="text-[10px] uppercase text-slate-500">
+                Citations
+              </p>
+            </div>
+            <div>
+              <p className="text-xl font-bold text-slate-900">
+                {paper.referenceCount}
+              </p>
+              <p className="text-[10px] uppercase text-slate-500">
+                References
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/paper/PaperHeader.tsx
+++ b/packages/web/src/components/paper/PaperHeader.tsx
@@ -1,0 +1,46 @@
+import { BookOpen, Calendar, MapPin, Quote } from "lucide-react";
+import type { PaperDetail } from "@/types/paper";
+
+type PaperHeaderProps = {
+  paper: PaperDetail;
+};
+
+export function PaperHeader({ paper }: PaperHeaderProps) {
+  return (
+    <header className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight text-slate-900 md:text-4xl">
+        {paper.title}
+      </h1>
+
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm font-medium text-slate-500">
+        <div className="flex items-center gap-2">
+          <BookOpen size={16} className="text-slate-400" />
+          <span className="text-slate-700">
+            {paper.authors.length > 5
+              ? `${paper.authors.slice(0, 5).map((a) => a.name).join(", ")} et al.`
+              : paper.authors.map((a) => a.name).join(", ")}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <MapPin size={16} className="text-slate-400" />
+          <span>{paper.venue || "Venue unknown"}</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Calendar size={16} className="text-slate-400" />
+          <span>{paper.year || "Year unknown"}</span>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-emerald-700 ring-1 ring-emerald-200">
+          <Quote size={14} />
+          <span>
+            {paper.citationCount} citations
+            {paper.influentialCitationCount > 0 &&
+              ` (${paper.influentialCitationCount} influential)`}
+          </span>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
🎯 **What:**
Refactored the `PaperDetailView` component by extracting its large sections into smaller, dedicated sub-components. Specifically:
- Extracted the `<header>` section into a new `PaperHeader` component.
- Extracted the `Details` section into a new `PaperDetails` component.
- Used these newly created components within `PaperDetailView`, passing down the necessary props.

💡 **Why:**
The `PaperDetailView` component had grown quite large, dealing with both the page's overall layout structure and detailed granular displays. This refactor makes the code much easier to read and maintain, separating concerns more cleanly into distinct smaller parts, addressing the "Long function" code health issue.

✅ **Verification:**
- Verified the code visually by ensuring props were accurately passed down.
- Ensured tests run successfully and successfully built the web package (`pnpm test`, `pnpm run build`).

✨ **Result:**
The main `PaperDetailView` component is now noticeably shorter and simpler, making future layout changes or additions easier to manage without sorting through hundreds of lines of code.

---
*PR created automatically by Jules for task [14983816967411214205](https://jules.google.com/task/14983816967411214205) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`PaperDetailView` の `<header>` セクションを `PaperHeader`、Details セクションを `PaperDetails` としてそれぞれ独立したコンポーネントに切り出したリファクタリングです。ロジックの変更はなく、props の受け渡しも元の実装を正確に踏襲しています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

純粋なリファクタリングであり、ロジックの変更はないためマージは安全です。

P0・P1 の問題は見当たりません。`next-env.d.ts` への変更と `fields` の型定義に関する P2 の軽微な指摘があるため 4/5 とします。

`packages/web/next-env.d.ts` — 自動生成ファイルへの変更が意図的かどうかを確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/next-env.d.ts | インポートパスが `.next/dev/types/routes.d.ts` から `.next/types/routes.d.ts` に変更。自動生成ファイルへの手動変更の可能性あり。 |
| packages/web/src/components/paper/PaperDetailView.tsx | `PaperHeader` と `PaperDetails` を使う形にリファクタリング。ロジックの変更はなく、props の受け渡しも正確。 |
| packages/web/src/components/paper/PaperHeader.tsx | 新規コンポーネント。元のコードから `<header>` セクションを忠実に抽出しており、問題なし。 |
| packages/web/src/components/paper/PaperDetails.tsx | 新規コンポーネント。`fields` の型定義が元の `PaperDetail['fieldsOfStudy']` より狭い点が軽微な改善余地あり。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PDV["PaperDetailView"]
    PH["PaperHeader\n(新規)"]
    PD["PaperDetails\n(新規)"]
    ELB["ExternalLinkButtons"]
    TI["TagInput"]
    STN["SaveToNotionButton"]
    BB["BibtexButton"]

    PDV -->|"paper"| PH
    PDV -->|"paper, fields, doi"| PD
    PDV --> ELB
    PDV --> TI
    PDV --> STN
    PDV --> BB
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web/next-env.d.ts
Line: 3

Comment:
**「編集しないでください」ファイルの変更**

このファイルには `// NOTE: This file should not be edited` というコメントが記載されていますが、インポートパスが `./.next/dev/types/routes.d.ts` から `./.next/types/routes.d.ts` に変更されています。このファイルは Next.js が自動生成するものであり、手動で変更すべきではありません。Next.js のバージョンアップに伴い自動生成された変更であれば問題ありませんが、意図的な手動編集の場合は次回の `next dev` / `next build` 実行時に上書きされる可能性があります。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web/src/components/paper/PaperDetails.tsx
Line: 5-7

Comment:
**`fields` の型がやや曖昧**

`fields` プロップの型が `{ category: string }[]` とシンプルに定義されていますが、`PaperDetail.fieldsOfStudy` は `Array<{ category: string; source: string }> | null` と定義されています。既存の型を再利用することで型の整合性が高まり、将来 `source` フィールドを使いたくなった際に型変更が不要になります。

```suggestion
type PaperDetailsProps = {
  paper: PaperDetail;
  fields: NonNullable<PaperDetail["fieldsOfStudy"]>;
  doi: string | undefined;
};
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: extract subcomponents from PaperD..."](https://github.com/hiroki-org/paper-tools/commit/0df4804431c44e0535db2a4c5414cbe6acbc566f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739451)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->