### PR TITLE
🔒 Fix insecure storage of secrets in Next.js app by enforcing server-only context

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "lucide-react": "^0.564.0"
+    "lucide-react": "^0.564.0",
+    "server-only": "^0.0.1"
   },
   "type": "module",
   "pnpm": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,6 +26,7 @@
     "next": "^16.1.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^3.4.1"
   },
   "devDependencies": {

--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { Client } from "@notionhq/client";
 import { NextRequest, NextResponse } from "next/server";
 import {

--- a/packages/web/src/app/api/auth/notion/route.ts
+++ b/packages/web/src/app/api/auth/notion/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { NextRequest, NextResponse } from "next/server";
 import { buildNotionRedirectUri, createStateToken, setOauthStateCookie } from "@/lib/auth";
 

--- a/packages/web/src/app/api/auth/refresh/route.ts
+++ b/packages/web/src/app/api/auth/refresh/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { NextRequest, NextResponse } from "next/server";
 import { getRefreshToken, getUserInfo, setAuthCookies } from "@/lib/auth";
 

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+// @vitest-environment node
+import { vi } from "vitest";
+
+// IMPORTANT: Mock "server-only" BEFORE importing anything that imports it
+vi.mock("server-only", () => ({}));
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { sealCookieValue, unsealCookieValue, clearAuthCookies, getAccessToken } from "./auth";
 import {
     ACCESS_TOKEN_COOKIE,

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createHmac, randomBytes } from "crypto";
 import { Client } from "@notionhq/client";
 import { NextResponse } from "next/server";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,17 +18,20 @@ importers:
     dependencies:
       lucide-react:
         specifier: ^0.564.0
-        version: 0.564.0(react@19.2.4)
+        version: 0.564.0
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)
       '@testing-library/react-hooks':
         specifier: ^8.0.1
-        version: 8.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 8.0.1(@types/react@19.2.14)
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -279,6 +282,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       tailwind-merge:
         specifier: ^3.4.1
         version: 3.4.1
@@ -1839,6 +1845,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2649,6 +2658,13 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/react-hooks@8.0.1(@types/react@19.2.14)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      react-error-boundary: 3.1.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@testing-library/react-hooks@8.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -2657,6 +2673,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       react-dom: 19.2.4(react@19.2.4)
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3287,6 +3311,8 @@ snapshots:
 
   lru-cache@11.2.7: {}
 
+  lucide-react@0.564.0: {}
+
   lucide-react@0.564.0(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -3434,6 +3460,10 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-error-boundary@3.1.4:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
   react-error-boundary@3.1.4(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -3490,6 +3520,8 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@7.7.4: {}
+
+  server-only@0.0.1: {}
 
   sharp@0.34.5:
     dependencies:


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Added `server-only` package imports to the core authentication logic (`packages/web/src/lib/auth.ts`) and the Next.js API route handlers managing Notion OAuth secrets (`packages/web/src/app/api/auth/callback/notion/route.ts`, `packages/web/src/app/api/auth/notion/route.ts`, and `packages/web/src/app/api/auth/refresh/route.ts`). 

⚠️ **Risk:** The potential impact if left unfixed
While reading secrets from `process.env` is standard practice, without strict enforcement, Next.js applications run the risk of inadvertently importing utility functions or files that contain these environment variable accessors into a Client Component. If this happens, Next.js might bundle the file into the client-side JavaScript, potentially exposing the `NOTION_OAUTH_CLIENT_SECRET`, `COOKIE_SECRET`, or `NEXTAUTH_SECRET` to end users. If exploited, an attacker could use these secrets to forge authentication tokens or impersonate the application in Notion API requests, leading to data breaches or unauthorized modifications.

🛡️ **Solution:** How the fix addresses the vulnerability
By adding `import "server-only";` at the top of these sensitive files, we utilize Next.js's officially recommended mechanism for securing server-side code. If any developer accidentally imports these files into a Client Component, the build will explicitly fail with an error (`This module cannot be imported from a Client Component module`). This acts as a robust safeguard, guaranteeing that the code accessing `process.env` secrets remains strictly on the server and is never shipped to the client browser. Tests were updated using `vi.mock` to ensure they continue to pass in the test environment without issues.

---
*PR created automatically by Jules for task [5933325552558277710](https://jules.google.com/task/5933325552558277710) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `packages/web/src/lib/auth.ts` および各認証APIルートに `import "server-only"` を追加することで、秘密情報を含むファイルがNext.jsのクライアントバンドルに誤って含まれるリスクを排除しようとしています。`auth.ts` への追加は本質的なセキュリティ改善ですが、2点の問題が見られます。

- `server-only` がモノレポルートの `package.json` にも誤って追加されており、これにより `pnpm-lock.yaml` でルートワークスペースの `@testing-library/react` / `@testing-library/react-hooks` / `lucide-react` から `react`/`react-dom` ピア依存解決が消え、ルートのReactテストが壊れる可能性があります。
- `auth.ts` のHMAC署名検証で `!==` 文字列比較が使われており、タイミング攻撃に脆弱です（`crypto.timingSafeEqual()` による定数時間比較が必要です）。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

P1が2件（タイミング攻撃脆弱性、ルートpackage.jsonへの誤追加によるロックファイル破壊）があるためマージ前に修正が必要です。

セキュリティ上の本命である `auth.ts` への `server-only` 追加は正しいが、タイミング攻撃に脆弱なHMAC比較が残存している（P1セキュリティ）。またルートワークスペースへの `server-only` 誤追加によってpnpmロックファイルのピア依存解決が変化し、ルートのReactテストが壊れるリスクがある（P1ロジック）。複数のP1が存在するため3/5とする。

`packages/web/src/lib/auth.ts`（タイミング攻撃）と `package.json` / `pnpm-lock.yaml`（誤追加によるピア依存の変化）に注意が必要です。
</details>


<details open><summary><h3>Security Review</h3></summary>

- **タイミング攻撃 (`packages/web/src/lib/auth.ts:62`)**: `signPayload(payload) !== sig` による文字列比較は短絡評価であり、Cookieの署名を1バイトずつ推測するタイミング攻撃に対して脆弱です。`crypto.timingSafeEqual()` への置き換えが必要です。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web/src/lib/auth.ts | `import "server-only"` の追加は適切だが、HMAC検証に `!==` 文字列比較を使っており、タイミング攻撃に脆弱（P1セキュリティ問題） |
| package.json | モノレポルートに `server-only` が誤って追加され、pnpm-lock.yaml でルートワークスペースのreact/react-domピア依存解決が変化（P1） |
| pnpm-lock.yaml | ルートワークスペースで `@testing-library/react` / `@testing-library/react-hooks` / `lucide-react` からreact/react-domピアが消え、ルートのReactテストが壊れるリスクあり |
| packages/web/src/lib/auth.test.ts | `vi.mock("server-only")` を静的インポート前に置くことでテスト環境での `server-only` をモック、概ね適切な対応 |
| packages/web/src/app/api/auth/callback/notion/route.ts | `import "server-only"` 追加は冗長（APIルートはもともとサーバーサイドのみ）だが実害はない |
| packages/web/package.json | `server-only` を `packages/web` の依存に正しく追加（Next.jsアプリの適切な場所） |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser] -->|GET /api/auth/notion| B[notion/route.ts]
    B -->|createStateToken, buildRedirectUri| C[auth.ts]
    B -->|Notionへリダイレクト| A

    A -->|OAuth認可後コールバック| D[callback/notion/route.ts]
    D -->|sealCookieValue, setAuthCookies| C
    D -->|認証クッキー設定| A

    A -->|POST /api/auth/refresh| E[refresh/route.ts]
    E -->|getRefreshToken, setAuthCookies| C
    E -->|トークン更新API呼び出し| F[Notion API]
    F -->|新しいトークン| E
    E -->|クッキー更新| A

    subgraph server_guard [server-only ガード適用済み]
        B
        C
        D
        E
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/web/src/lib/auth.ts`, line 62 ([link](https://github.com/hiroki-org/paper-tools/blob/75d17c29c6237c7d150c6dd612eee77e41d66fbd/packages/web/src/lib/auth.ts#L62)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **タイミング攻撃に脆弱なHMAC検証**

   `!==` による文字列比較は短絡評価を行うため、攻撃者がレスポンス時間を計測することで正しい署名を1バイトずつ推測できるタイミング攻撃に対して脆弱です。Cookieの署名検証にはこの比較が使われているため、セッションの偽造リスクがあります。`crypto.timingSafeEqual()` を使った定数時間比較に置き換えてください。

   ```typescript
   import { createHmac, randomBytes, timingSafeEqual } from "crypto";

   function safeCompare(a: string, b: string): boolean {
       const bufA = Buffer.from(a);
       const bufB = Buffer.from(b);
       if (bufA.length !== bufB.length) return false;
       return timingSafeEqual(bufA, bufB);
   }

   // unsealCookieValue 内:
   if (!safeCompare(signPayload(payload), sig)) return null;
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web/src/lib/auth.ts
   Line: 62

   Comment:
   **タイミング攻撃に脆弱なHMAC検証**

   `!==` による文字列比較は短絡評価を行うため、攻撃者がレスポンス時間を計測することで正しい署名を1バイトずつ推測できるタイミング攻撃に対して脆弱です。Cookieの署名検証にはこの比較が使われているため、セッションの偽造リスクがあります。`crypto.timingSafeEqual()` を使った定数時間比較に置き換えてください。

   ```typescript
   import { createHmac, randomBytes, timingSafeEqual } from "crypto";

   function safeCompare(a: string, b: string): boolean {
       const bufA = Buffer.from(a);
       const bufB = Buffer.from(b);
       if (bufA.length !== bufB.length) return false;
       return timingSafeEqual(bufA, bufB);
   }

   // unsealCookieValue 内:
   if (!safeCompare(signPayload(payload), sig)) return null;
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web/src/lib/auth.ts
Line: 62

Comment:
**タイミング攻撃に脆弱なHMAC検証**

`!==` による文字列比較は短絡評価を行うため、攻撃者がレスポンス時間を計測することで正しい署名を1バイトずつ推測できるタイミング攻撃に対して脆弱です。Cookieの署名検証にはこの比較が使われているため、セッションの偽造リスクがあります。`crypto.timingSafeEqual()` を使った定数時間比較に置き換えてください。

```typescript
import { createHmac, randomBytes, timingSafeEqual } from "crypto";

function safeCompare(a: string, b: string): boolean {
    const bufA = Buffer.from(a);
    const bufB = Buffer.from(b);
    if (bufA.length !== bufB.length) return false;
    return timingSafeEqual(bufA, bufB);
}

// unsealCookieValue 内:
if (!safeCompare(signPayload(payload), sig)) return null;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: package.json
Line: 25

Comment:
**`server-only` をモノレポルートに追加するのは誤り**

ルートの `package.json` は Next.js アプリではなくモノレポのオーケストレーションパッケージです。`server-only` は Next.js のビルドシステムに依存したガードであり、ここに追加しても機能しません。さらに、このPRの `pnpm-lock.yaml` の変更で、ルートワークスペースの `@testing-library/react` および `@testing-library/react-hooks` が `react`/`react-dom` ピア依存なしで解決されるようになっており、ルートワークスペースのReactコンポーネントテストが壊れる可能性があります。`server-only` はすでに `packages/web/package.json` に正しく追加されているため、ルートの `package.json` からは削除してください。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web/src/app/api/auth/callback/notion/route.ts
Line: 1

Comment:
**Next.js APIルートへの `server-only` 追加は冗長**

`app/api/` 配下のルートハンドラはNext.jsの仕様上、クライアントバンドルには決して含まれません。`import "server-only"` は Client Component からインポートされるユーティリティファイルを保護するためのものであり、APIルートへの追加はビルド安全性への実質的な貢献がありません。実際にリスクがあったのは `auth.ts` であり、そこへの追加は適切です。同様に `packages/web/src/app/api/auth/notion/route.ts` および `packages/web/src/app/api/auth/refresh/route.ts` の `import "server-only"` も冗長です。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Add server-only imports to prevent se..."](https://github.com/hiroki-org/paper-tools/commit/75d17c29c6237c7d150c6dd612eee77e41d66fbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29739930)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->