### PR TITLE
chore(web): remove unused Sparkles import in search page

### DIFF
--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import { Sparkles } from "lucide-react";
 import type { Paper } from "@paper-tools/core";
 import type { DrilldownResult } from "@paper-tools/drilldown";
 import SearchForm from "@/components/SearchForm";


### PR DESCRIPTION
Salvage replacement for closed PR #203. Removes only the unused Sparkles import and leaves generated next-env unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`packages/web/src/app/search/page.tsx` から未使用の `Sparkles`（lucide-react）インポートを削除するクリーンアップPRです。クローズされたPR #203のサルベージとして提出されており、変更はインポート1行の削除のみで、ロジックや動作への影響はありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできます。未使用インポートの削除のみで、動作への影響はありません。

変更は1行のインポート削除のみ。コードロジック、型安全性、ランタイム動作への影響は一切なく、問題は見当たりません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/search/page.tsx | 未使用の `Sparkles`（lucide-react）インポートを1行削除する最小限の変更。ロジックへの影響なし。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: drop unrelated next-env generated..."](https://github.com/hiroki-org/paper-tools/commit/43fecd6925f23f00d456954bf85dceaf89ae4b44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30112591)</sub>

<!-- /greptile_comment -->