### PR TITLE
fix(web): timing-safe cookie signature verification

### DIFF
--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes } from "crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { Client } from "@notionhq/client";
 import { NextResponse } from "next/server";
 import {
@@ -58,7 +58,15 @@ export function sealCookieValue(data: unknown) {
 export function unsealCookieValue<T>(value: string): T | null {
     const [payload, sig] = value.split(".");
     if (!payload || !sig) return null;
-    if (signPayload(payload) !== sig) return null;
+    const expectedSig = signPayload(payload);
+    const expectedSigBuffer = Buffer.from(expectedSig);
+    const actualSigRaw = Buffer.from(sig);
+    const actualSigBuffer = Buffer.alloc(expectedSigBuffer.length);
+    actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length);
+
+    const signaturesMatch = timingSafeEqual(expectedSigBuffer, actualSigBuffer)
+        && actualSigRaw.length === expectedSigBuffer.length;
+    if (!signaturesMatch) return null;
     try {
         return JSON.parse(fromBase64Url(payload)) as T;
     } catch {


### PR DESCRIPTION
Salvage replacement for closed PR #205. Implements timing-safe signature verification and keeps generated files unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

クッキー署名検証を単純な文字列比較（`!==`）からタイミングセーフ比較（`timingSafeEqual`）に置き換えています。バッファパディングによって等長バッファを作成してから比較するアプローチは正しく動作しますが、長さチェックを `timingSafeEqual` の後に `&&` で評価する実装は慣用的ではありません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

タイミングセーフ比較の実装は正しく動作するが、長さチェックの順序に改善の余地がある

P2 の指摘のみ（&&短絡評価による非標準な長さチェック順序）。機能的な正確性は問題なく、HMAC-SHA256 の出力は常に固定長（43文字）のため実用上の脆弱性はない。慣用的な実装に修正することが推奨される。

packages/web/src/lib/auth.ts の unsealCookieValue 関数（長さチェックの順序）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/lib/auth.ts | クッキー署名検証をタイミングセーフ比較（timingSafeEqual）に置き換え。ただし、長さチェックが &&（短絡評価）の後に来るため、timingSafeEqual の戻り値によって実行経路がわずかに異なる（実用上の影響は軽微） |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["unsealCookieValue(value)"] --> B["value.split('.') で payload / sig を分割"]
    B --> C{payload と sig が存在するか？}
    C -- いいえ --> D["null を返す"]
    C -- はい --> E["expectedSig = signPayload(payload)"]
    E --> F["expectedSigBuffer = Buffer.from(expectedSig)"]
    F --> G["actualSigRaw = Buffer.from(sig)"]
    G --> H["actualSigBuffer = Buffer.alloc(expectedSigBuffer.length) ←ゼロ初期化"]
    H --> I["actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length)"]
    I --> J["timingSafeEqual(expectedSigBuffer, actualSigBuffer)"]
    J -- false --> D
    J -- true --> K["actualSigRaw.length === expectedSigBuffer.length ?"]
    K -- false --> D
    K -- true --> L["JSON.parse(fromBase64Url(payload))"]
    L --> M{パース成功？}
    M -- はい --> N["型 T の値を返す"]
    M -- いいえ --> D
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web/src/lib/auth.ts
Line: 67-68

Comment:
**長さチェックの順序がタイミングリークを引き起こす可能性**

`timingSafeEqual(...)` の戻り値が `true` の場合にのみ `actualSigRaw.length === expectedSigBuffer.length` が評価されます（`&&` の短絡評価）。これにより、`timingSafeEqual` が `true` を返した場合と `false` を返した場合とで、レスポンスタイムにわずかな差が生じます。

実際には `timingSafeEqual` が `true` を返すのは正しい署名（または短縮されたバッファがたまたま一致した場合）のみであり、実用上の脆弱性はありません。ただし、タイミングセーフ比較の本来の目的（一定時間での実行）を部分的に損ないます。

より明確で慣用的な実装：

```typescript
const expectedSigBuffer = Buffer.from(signPayload(payload));
const actualSigBuffer = Buffer.from(sig);
if (
    expectedSigBuffer.length !== actualSigBuffer.length ||
    !timingSafeEqual(expectedSigBuffer, actualSigBuffer)
) {
    return null;
}
```

HMAC-SHA256 の base64url 出力は常に 43 文字固定なので、長さ事前チェックが追加のタイミング情報を漏らすリスクは実質ゼロです。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): avoid length-oracle in cookie ..."](https://github.com/hiroki-org/paper-tools/commit/536a292a9db43e582307dada3a2d21745e03c748) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30112840)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->