### PR TITLE
test(drilldown): add extractKeywords edge-case coverage

### DIFF
--- a/packages/drilldown/tests/drilldown.test.ts
+++ b/packages/drilldown/tests/drilldown.test.ts
@@ -80,7 +80,7 @@ describe("extractKeywords", () => {
     it("should return empty array for titles/abstracts with stopwords and symbols only", () => {
         const papers = [
             { title: "The and of a in", authors: [], abstract: "!@#$%^&*() is to for be" },
-            { title: "a to at on it", authors: [], abstract: "- = [] {} ; : ' " , . / ? < > \ |" },
+            { title: "a to at on it", authors: [], abstract: "symbols only punctuation marks" },
         ];
 
         const keywords = extractKeywords(papers, 10);

--- a/packages/drilldown/tests/drilldown.test.ts
+++ b/packages/drilldown/tests/drilldown.test.ts
@@ -60,6 +60,32 @@ describe("extractKeywords", () => {
         const keywords = extractKeywords([], 10);
         expect(keywords).toEqual([]);
     });
+
+    it("should extract keywords from abstract field content", () => {
+        const papers = [
+            {
+                title: "A Study",
+                authors: [],
+                abstract: "This paper discusses revolutionary quantum computing architectures.",
+            },
+        ];
+
+        const keywords = extractKeywords(papers, 10);
+        expect(keywords).toContain("revolutionary");
+        expect(keywords).toContain("quantum");
+        expect(keywords).toContain("computing");
+        expect(keywords).toContain("architectures");
+    });
+
+    it("should return empty array for titles/abstracts with stopwords and symbols only", () => {
+        const papers = [
+            { title: "The and of a in", authors: [], abstract: "!@#$%^&*() is to for be" },
+            { title: "a to at on it", authors: [], abstract: "- = [] {} ; : ' " , . / ? < > \ |" },
+        ];
+
+        const keywords = extractKeywords(papers, 10);
+        expect(keywords).toEqual([]);
+    });
 });
 
 describe("drilldown", () => {

--- a/packages/drilldown/tests/drilldown.test.ts
+++ b/packages/drilldown/tests/drilldown.test.ts
@@ -80,7 +80,7 @@ describe("extractKeywords", () => {
     it("should return empty array for titles/abstracts with stopwords and symbols only", () => {
         const papers = [
             { title: "The and of a in", authors: [], abstract: "!@#$%^&*() is to for be" },
-            { title: "a to at on it", authors: [], abstract: "symbols only punctuation marks" },
+            { title: "a to at on it", authors: [], abstract: "!!! ??? ###" },
         ];
 
         const keywords = extractKeywords(papers, 10);


### PR DESCRIPTION
Salvage replacement for closed PR #208.\n\nAdds edge-case tests for extractKeywords (abstract keyword extraction + stopword/symbol-only input).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

閉じられた PR #208 の代替として、`extractKeywords` 関数に 2 件のエッジケーステストを追加する PR です。①`abstract` フィールドからのキーワード抽出、②ストップワード・記号のみで構成される入力に対して空配列を返すことを検証します。実装（`drilldown.ts`）と照合した結果、両テストのアサーションは正しく、スコープも適切です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、安全にマージ可能です。

実装の tokenize ロジックおよびストップワードリストと照合した結果、追加された 2 件のテストはいずれも正確にパスし、論理的な誤りは見当たりませんでした。プロダクションコードへの影響はありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/drilldown.test.ts | abstractフィールドからのキーワード抽出テストと、ストップワード・記号のみ入力に対する空配列返却テストを追加。実装との整合性を確認済みで、どちらも正確にパスする。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["extractKeywords(papers, topN)"] --> B["paper.title を tokenize"]
    A --> C{"paper.keywords あり?"}
    A --> D{"paper.abstract あり?"}
    C -- Yes --> E["keywords を tokenize\n(重み +2)"]
    D -- Yes --> F["abstract を tokenize\n(重み +1)"]
    B --> G["freq Map に +1"]
    E --> G
    F --> G
    G --> H["頻度順ソート → topN を返す"]
```

<sub>Reviews (1): Last reviewed commit: ["test: use symbol-only abstract fixture f..."](https://github.com/hiroki-org/paper-tools/commit/a179836e3cc0f5f3e011d716de918b6b1aaa5293) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30112930)</sub>

<!-- /greptile_comment -->