### PR TITLE
🧪 add missing error path test for getDatabaseInfo in notion-client

### DIFF
--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -136,10 +136,19 @@ describe("additional coverage", () => {
             }
         };
 
-        const info = await getDatabaseInfo("db-1", clientWithFailingUsers as any);
+        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const info = await getDatabaseInfo("db-1", clientWithFailingUsers as unknown as Parameters<typeof getDatabaseInfo>[1]);
 
-        expect(info.databaseName).toBe("Test DB");
-        expect(info.workspaceName).toBe("Notion Workspace");
+            expect(info.databaseName).toBe("Test DB");
+            expect(info.workspaceName).toBe("Notion Workspace");
+            expect(consoleSpy).toHaveBeenCalledWith(
+                "Failed to retrieve Notion workspace name, falling back to default:",
+                expect.any(Error),
+            );
+        } finally {
+            consoleSpy.mockRestore();
+        }
     });
 
     it("readTitle and readRichText should handle NotionRichTextItem mapping", async () => {

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -124,6 +124,24 @@ describe("additional coverage", () => {
         expect(info.workspaceName).toBe("Test User");
     });
 
+    it("getDatabaseInfo should fallback to 'Notion Workspace' if users.me fails", async () => {
+        const { getDatabaseInfo } = await import("../src/notion-client.js");
+        mockClient.databases.retrieve.mockResolvedValueOnce({
+            title: [{ plain_text: "Test DB" }],
+        });
+        const clientWithFailingUsers = {
+            ...mockClient,
+            users: {
+                me: vi.fn().mockRejectedValueOnce(new Error("API Error")),
+            }
+        };
+
+        const info = await getDatabaseInfo("db-1", clientWithFailingUsers as any);
+
+        expect(info.databaseName).toBe("Test DB");
+        expect(info.workspaceName).toBe("Notion Workspace");
+    });
+
     it("readTitle and readRichText should handle NotionRichTextItem mapping", async () => {
         const { queryPapers } = await import("../src/notion-client.js");
         mockClient.databases.query.mockResolvedValueOnce({


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `getDatabaseInfo` in `packages/recommender/src/notion-client.ts`. The test verifies that if `client.users.me({})` throws an error, the `workspaceName` correctly falls back to `"Notion Workspace"`.

📊 **Coverage:** The new test covers the specific `catch` block inside `getDatabaseInfo`, simulating a failure via `client.users.me()`.

✨ **Result:** Improved overall test coverage and guarantees that external API failures regarding workspace fetching do not cause cascading failures.

---
*PR created automatically by Jules for task [4141904360894031979](https://jules.google.com/task/4141904360894031979) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`getDatabaseInfo` 内の `client.users.me()` 失敗時の `catch` ブロックをカバーするテストを 1 件追加した PR です。テストのセットアップ・アサーションともに正確で、ソースコードの実装と一致しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、マージしても問題ありません。

追加されたテストはソースコードの catch ブロックを正確にカバーしており、モックのセットアップ・アサーションも正しい。製品コードへの変更はなく、リグレッションリスクはありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/recommender/tests/notion-client.test.ts | getDatabaseInfo の users.me 失敗時のフォールバック動作をカバーするテストを 1 件追加。ロジックは正確で、ソースコードの catch ブロックに対応している。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テスト (新規)
    participant GDI as getDatabaseInfo()
    participant DB as client.databases.retrieve
    participant Users as client.users.me

    Test->>GDI: getDatabaseInfo("db-1", clientWithFailingUsers)
    GDI->>DB: retrieve({ database_id: "db-1" })
    DB-->>GDI: { title: [{ plain_text: "Test DB" }] }
    GDI->>GDI: databaseName = "Test DB"
    GDI->>Users: me({})
    Users-->>GDI: throw Error("API Error")
    GDI->>GDI: catch(e) → workspaceName = "Notion Workspace" (デフォルト維持)
    GDI-->>Test: { databaseName: "Test DB", workspaceName: "Notion Workspace" }
    Test->>Test: expect(info.databaseName).toBe("Test DB") ✓
    Test->>Test: expect(info.workspaceName).toBe("Notion Workspace") ✓
```

<sub>Reviews (1): Last reviewed commit: ["test: add missing error path test for ge..."](https://github.com/hiroki-org/paper-tools/commit/e8893e2885a469fad1433d3fba6b03eddff29e62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30577109)</sub>

<!-- /greptile_comment -->