### PR TITLE
🧹 Remove unused BibtexSingleResult export

### DIFF
--- a/packages/web/src/components/bibtex/useBibtex.ts
+++ b/packages/web/src/components/bibtex/useBibtex.ts
@@ -5,21 +5,21 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 export type BibtexFormat = "bibtex" | "biblatex";
 export type BibtexKeyFormat = "default" | "short" | "venue";
 
-export type BibtexSingleResult = {
-    bibtex: string;
-    source: string;
-    warnings: string[];
+type BibtexSingleResult = {
+	bibtex: string;
+	source: string;
+	warnings: string[];
 };
 
 export type BibtexPaperInput = {
-    doi?: string;
-    title: string;
+	doi?: string;
+	title: string;
 };
 
 type BibtexBulkResult = {
-    bibtex: string;
-    count: number;
-    errors: Array<{ title?: string; doi?: string; message: string }>;
+	bibtex: string;
+	count: number;
+	errors: Array<{ title?: string; doi?: string; message: string }>;
 };
 
 const SETTINGS_STORAGE_KEY = "paper-tools:bibtex-settings";
@@ -27,132 +27,169 @@ const sharedCache = new Map<string, BibtexSingleResult>();
 const MAX_CACHE_ENTRIES = 200;
 
 function setCacheWithEviction(key: string, value: BibtexSingleResult): void {
-    if (!sharedCache.has(key) && sharedCache.size >= MAX_CACHE_ENTRIES) {
-        const oldestKey = sharedCache.keys().next().value as string | undefined;
-        if (oldestKey) {
-            sharedCache.delete(oldestKey);
-        }
-    }
-    sharedCache.set(key, value);
+	if (!sharedCache.has(key) && sharedCache.size >= MAX_CACHE_ENTRIES) {
+		const oldestKey = sharedCache.keys().next().value as string | undefined;
+		if (oldestKey) {
+			sharedCache.delete(oldestKey);
+		}
+	}
+	sharedCache.set(key, value);
 }
 
 function normalizeDoi(value?: string): string {
-    if (!value) return "";
-    return value.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	if (!value) return "";
+	return value
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
-function cacheKey(input: { doi?: string; title?: string; format: BibtexFormat; keyFormat: BibtexKeyFormat }): string {
-    return [normalizeDoi(input.doi), (input.title ?? "").trim().toLowerCase(), input.format, input.keyFormat].join("|");
+function cacheKey(input: {
+	doi?: string;
+	title?: string;
+	format: BibtexFormat;
+	keyFormat: BibtexKeyFormat;
+}): string {
+	return [
+		normalizeDoi(input.doi),
+		(input.title ?? "").trim().toLowerCase(),
+		input.format,
+		input.keyFormat,
+	].join("|");
 }
 
 export function useBibtex() {
-    const [format, setFormat] = useState<BibtexFormat>("bibtex");
-    const [keyFormat, setKeyFormat] = useState<BibtexKeyFormat>("default");
-    const didLoadSettings = useRef(false);
+	const [format, setFormat] = useState<BibtexFormat>("bibtex");
+	const [keyFormat, setKeyFormat] = useState<BibtexKeyFormat>("default");
+	const didLoadSettings = useRef(false);
 
-    useEffect(() => {
-        try {
-            const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
-            if (!raw) return;
-            const parsed = JSON.parse(raw) as { format?: BibtexFormat; keyFormat?: BibtexKeyFormat };
-            if (parsed.format === "bibtex" || parsed.format === "biblatex") {
-                setFormat(parsed.format);
-            }
-            if (parsed.keyFormat === "default" || parsed.keyFormat === "short" || parsed.keyFormat === "venue") {
-                setKeyFormat(parsed.keyFormat);
-            }
-        } catch {
-            // ignore storage parse errors
-        } finally {
-            didLoadSettings.current = true;
-        }
-    }, []);
+	useEffect(() => {
+		try {
+			const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+			if (!raw) return;
+			const parsed = JSON.parse(raw) as {
+				format?: BibtexFormat;
+				keyFormat?: BibtexKeyFormat;
+			};
+			if (parsed.format === "bibtex" || parsed.format === "biblatex") {
+				setFormat(parsed.format);
+			}
+			if (
+				parsed.keyFormat === "default" ||
+				parsed.keyFormat === "short" ||
+				parsed.keyFormat === "venue"
+			) {
+				setKeyFormat(parsed.keyFormat);
+			}
+		} catch {
+			// ignore storage parse errors
+		} finally {
+			didLoadSettings.current = true;
+		}
+	}, []);
 
-    useEffect(() => {
-        if (!didLoadSettings.current) {
-            return;
-        }
-        localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ format, keyFormat }));
-    }, [format, keyFormat]);
+	useEffect(() => {
+		if (!didLoadSettings.current) {
+			return;
+		}
+		localStorage.setItem(
+			SETTINGS_STORAGE_KEY,
+			JSON.stringify({ format, keyFormat }),
+		);
+	}, [format, keyFormat]);
 
-    const getSingleBibtex = useCallback(async (
-        input: { doi?: string; title?: string },
-        overrides?: { format?: BibtexFormat; keyFormat?: BibtexKeyFormat; force?: boolean },
-    ): Promise<BibtexSingleResult> => {
-        const currentFormat = overrides?.format ?? format;
-        const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
-        const key = cacheKey({
-            doi: input.doi,
-            title: input.title,
-            format: currentFormat,
-            keyFormat: currentKeyFormat,
-        });
+	const getSingleBibtex = useCallback(
+		async (
+			input: { doi?: string; title?: string },
+			overrides?: {
+				format?: BibtexFormat;
+				keyFormat?: BibtexKeyFormat;
+				force?: boolean;
+			},
+		): Promise<BibtexSingleResult> => {
+			const currentFormat = overrides?.format ?? format;
+			const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
+			const key = cacheKey({
+				doi: input.doi,
+				title: input.title,
+				format: currentFormat,
+				keyFormat: currentKeyFormat,
+			});
 
-        if (!overrides?.force && sharedCache.has(key)) {
-            return sharedCache.get(key)!;
-        }
+			if (!overrides?.force && sharedCache.has(key)) {
+				return sharedCache.get(key)!;
+			}
 
-        const params = new URLSearchParams();
-        if (input.doi?.trim()) params.set("doi", input.doi.trim());
-        if (input.title?.trim()) params.set("title", input.title.trim());
-        params.set("format", currentFormat);
-        params.set("keyFormat", currentKeyFormat);
+			const params = new URLSearchParams();
+			if (input.doi?.trim()) params.set("doi", input.doi.trim());
+			if (input.title?.trim()) params.set("title", input.title.trim());
+			params.set("format", currentFormat);
+			params.set("keyFormat", currentKeyFormat);
 
-        const res = await fetch(`/api/bibtex?${params.toString()}`);
-        const data = await res.json();
-        if (!res.ok) {
-            throw new Error(data.error ?? "BibTeX の取得に失敗しました");
-        }
+			const res = await fetch(`/api/bibtex?${params.toString()}`);
+			const data = await res.json();
+			if (!res.ok) {
+				throw new Error(data.error ?? "BibTeX の取得に失敗しました");
+			}
 
-        const result: BibtexSingleResult = {
-            bibtex: String(data.bibtex ?? ""),
-            source: String(data.source ?? "unknown"),
-            warnings: Array.isArray(data.warnings) ? data.warnings.map(String) : [],
-        };
-        setCacheWithEviction(key, result);
-        return result;
-    }, [format, keyFormat]);
+			const result: BibtexSingleResult = {
+				bibtex: String(data.bibtex ?? ""),
+				source: String(data.source ?? "unknown"),
+				warnings: Array.isArray(data.warnings) ? data.warnings.map(String) : [],
+			};
+			setCacheWithEviction(key, result);
+			return result;
+		},
+		[format, keyFormat],
+	);
 
-    const getBulkBibtex = useCallback(async (
-        papers: BibtexPaperInput[],
-        overrides?: { format?: BibtexFormat; keyFormat?: BibtexKeyFormat },
-        onProgress?: (done: number, total: number) => void,
-    ): Promise<BibtexBulkResult> => {
-        const currentFormat = overrides?.format ?? format;
-        const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
-        onProgress?.(0, papers.length);
+	const getBulkBibtex = useCallback(
+		async (
+			papers: BibtexPaperInput[],
+			overrides?: { format?: BibtexFormat; keyFormat?: BibtexKeyFormat },
+			onProgress?: (done: number, total: number) => void,
+		): Promise<BibtexBulkResult> => {
+			const currentFormat = overrides?.format ?? format;
+			const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
+			onProgress?.(0, papers.length);
 
-        const res = await fetch("/api/bibtex/bulk", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-                papers,
-                format: currentFormat,
-                keyFormat: currentKeyFormat,
-            }),
-        });
+			const res = await fetch("/api/bibtex/bulk", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					papers,
+					format: currentFormat,
+					keyFormat: currentKeyFormat,
+				}),
+			});
 
-        const data = await res.json();
-        if (!res.ok) {
-            throw new Error(data.error ?? "BibTeX 一括取得に失敗しました");
-        }
+			const data = await res.json();
+			if (!res.ok) {
+				throw new Error(data.error ?? "BibTeX 一括取得に失敗しました");
+			}
 
-        const result: BibtexBulkResult = {
-            bibtex: String(data.bibtex ?? ""),
-            count: Number(data.count ?? 0),
-            errors: Array.isArray(data.errors) ? data.errors : [],
-        };
+			const result: BibtexBulkResult = {
+				bibtex: String(data.bibtex ?? ""),
+				count: Number(data.count ?? 0),
+				errors: Array.isArray(data.errors) ? data.errors : [],
+			};
 
-        onProgress?.(papers.length, papers.length);
-        return result;
-    }, [format, keyFormat]);
+			onProgress?.(papers.length, papers.length);
+			return result;
+		},
+		[format, keyFormat],
+	);
 
-    return useMemo(() => ({
-        format,
-        keyFormat,
-        setFormat,
-        setKeyFormat,
-        getSingleBibtex,
-        getBulkBibtex,
-    }), [format, keyFormat, getSingleBibtex, getBulkBibtex]);
+	return useMemo(
+		() => ({
+			format,
+			keyFormat,
+			setFormat,
+			setKeyFormat,
+			getSingleBibtex,
+			getBulkBibtex,
+		}),
+		[format, keyFormat, getSingleBibtex, getBulkBibtex],
+	);
 }

--- a/packages/web/src/components/bibtex/useBibtex.ts
+++ b/packages/web/src/components/bibtex/useBibtex.ts
@@ -6,20 +6,20 @@ export type BibtexFormat = "bibtex" | "biblatex";
 export type BibtexKeyFormat = "default" | "short" | "venue";
 
 type BibtexSingleResult = {
-	bibtex: string;
-	source: string;
-	warnings: string[];
+    bibtex: string;
+    source: string;
+    warnings: string[];
 };
 
 export type BibtexPaperInput = {
-	doi?: string;
-	title: string;
+    doi?: string;
+    title: string;
 };
 
 type BibtexBulkResult = {
-	bibtex: string;
-	count: number;
-	errors: Array<{ title?: string; doi?: string; message: string }>;
+    bibtex: string;
+    count: number;
+    errors: Array<{ title?: string; doi?: string; message: string }>;
 };
 
 const SETTINGS_STORAGE_KEY = "paper-tools:bibtex-settings";
@@ -27,169 +27,132 @@ const sharedCache = new Map<string, BibtexSingleResult>();
 const MAX_CACHE_ENTRIES = 200;
 
 function setCacheWithEviction(key: string, value: BibtexSingleResult): void {
-	if (!sharedCache.has(key) && sharedCache.size >= MAX_CACHE_ENTRIES) {
-		const oldestKey = sharedCache.keys().next().value as string | undefined;
-		if (oldestKey) {
-			sharedCache.delete(oldestKey);
-		}
-	}
-	sharedCache.set(key, value);
+    if (!sharedCache.has(key) && sharedCache.size >= MAX_CACHE_ENTRIES) {
+        const oldestKey = sharedCache.keys().next().value as string | undefined;
+        if (oldestKey) {
+            sharedCache.delete(oldestKey);
+        }
+    }
+    sharedCache.set(key, value);
 }
 
 function normalizeDoi(value?: string): string {
-	if (!value) return "";
-	return value
-		.trim()
-		.replace(/^https?:\/\/doi\.org\//i, "")
-		.replace(/^doi:/i, "")
-		.trim();
+    if (!value) return "";
+    return value.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
 }
 
-function cacheKey(input: {
-	doi?: string;
-	title?: string;
-	format: BibtexFormat;
-	keyFormat: BibtexKeyFormat;
-}): string {
-	return [
-		normalizeDoi(input.doi),
-		(input.title ?? "").trim().toLowerCase(),
-		input.format,
-		input.keyFormat,
-	].join("|");
+function cacheKey(input: { doi?: string; title?: string; format: BibtexFormat; keyFormat: BibtexKeyFormat }): string {
+    return [normalizeDoi(input.doi), (input.title ?? "").trim().toLowerCase(), input.format, input.keyFormat].join("|");
 }
 
 export function useBibtex() {
-	const [format, setFormat] = useState<BibtexFormat>("bibtex");
-	const [keyFormat, setKeyFormat] = useState<BibtexKeyFormat>("default");
-	const didLoadSettings = useRef(false);
+    const [format, setFormat] = useState<BibtexFormat>("bibtex");
+    const [keyFormat, setKeyFormat] = useState<BibtexKeyFormat>("default");
+    const didLoadSettings = useRef(false);
 
-	useEffect(() => {
-		try {
-			const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
-			if (!raw) return;
-			const parsed = JSON.parse(raw) as {
-				format?: BibtexFormat;
-				keyFormat?: BibtexKeyFormat;
-			};
-			if (parsed.format === "bibtex" || parsed.format === "biblatex") {
-				setFormat(parsed.format);
-			}
-			if (
-				parsed.keyFormat === "default" ||
-				parsed.keyFormat === "short" ||
-				parsed.keyFormat === "venue"
-			) {
-				setKeyFormat(parsed.keyFormat);
-			}
-		} catch {
-			// ignore storage parse errors
-		} finally {
-			didLoadSettings.current = true;
-		}
-	}, []);
+    useEffect(() => {
+        try {
+            const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+            if (!raw) return;
+            const parsed = JSON.parse(raw) as { format?: BibtexFormat; keyFormat?: BibtexKeyFormat };
+            if (parsed.format === "bibtex" || parsed.format === "biblatex") {
+                setFormat(parsed.format);
+            }
+            if (parsed.keyFormat === "default" || parsed.keyFormat === "short" || parsed.keyFormat === "venue") {
+                setKeyFormat(parsed.keyFormat);
+            }
+        } catch {
+            // ignore storage parse errors
+        } finally {
+            didLoadSettings.current = true;
+        }
+    }, []);
 
-	useEffect(() => {
-		if (!didLoadSettings.current) {
-			return;
-		}
-		localStorage.setItem(
-			SETTINGS_STORAGE_KEY,
-			JSON.stringify({ format, keyFormat }),
-		);
-	}, [format, keyFormat]);
+    useEffect(() => {
+        if (!didLoadSettings.current) {
+            return;
+        }
+        localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ format, keyFormat }));
+    }, [format, keyFormat]);
 
-	const getSingleBibtex = useCallback(
-		async (
-			input: { doi?: string; title?: string },
-			overrides?: {
-				format?: BibtexFormat;
-				keyFormat?: BibtexKeyFormat;
-				force?: boolean;
-			},
-		): Promise<BibtexSingleResult> => {
-			const currentFormat = overrides?.format ?? format;
-			const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
-			const key = cacheKey({
-				doi: input.doi,
-				title: input.title,
-				format: currentFormat,
-				keyFormat: currentKeyFormat,
-			});
+    const getSingleBibtex = useCallback(async (
+        input: { doi?: string; title?: string },
+        overrides?: { format?: BibtexFormat; keyFormat?: BibtexKeyFormat; force?: boolean },
+    ): Promise<BibtexSingleResult> => {
+        const currentFormat = overrides?.format ?? format;
+        const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
+        const key = cacheKey({
+            doi: input.doi,
+            title: input.title,
+            format: currentFormat,
+            keyFormat: currentKeyFormat,
+        });
 
-			if (!overrides?.force && sharedCache.has(key)) {
-				return sharedCache.get(key)!;
-			}
+        if (!overrides?.force && sharedCache.has(key)) {
+            return sharedCache.get(key)!;
+        }
 
-			const params = new URLSearchParams();
-			if (input.doi?.trim()) params.set("doi", input.doi.trim());
-			if (input.title?.trim()) params.set("title", input.title.trim());
-			params.set("format", currentFormat);
-			params.set("keyFormat", currentKeyFormat);
+        const params = new URLSearchParams();
+        if (input.doi?.trim()) params.set("doi", input.doi.trim());
+        if (input.title?.trim()) params.set("title", input.title.trim());
+        params.set("format", currentFormat);
+        params.set("keyFormat", currentKeyFormat);
 
-			const res = await fetch(`/api/bibtex?${params.toString()}`);
-			const data = await res.json();
-			if (!res.ok) {
-				throw new Error(data.error ?? "BibTeX の取得に失敗しました");
-			}
+        const res = await fetch(`/api/bibtex?${params.toString()}`);
+        const data = await res.json();
+        if (!res.ok) {
+            throw new Error(data.error ?? "BibTeX の取得に失敗しました");
+        }
 
-			const result: BibtexSingleResult = {
-				bibtex: String(data.bibtex ?? ""),
-				source: String(data.source ?? "unknown"),
-				warnings: Array.isArray(data.warnings) ? data.warnings.map(String) : [],
-			};
-			setCacheWithEviction(key, result);
-			return result;
-		},
-		[format, keyFormat],
-	);
+        const result: BibtexSingleResult = {
+            bibtex: String(data.bibtex ?? ""),
+            source: String(data.source ?? "unknown"),
+            warnings: Array.isArray(data.warnings) ? data.warnings.map(String) : [],
+        };
+        setCacheWithEviction(key, result);
+        return result;
+    }, [format, keyFormat]);
 
-	const getBulkBibtex = useCallback(
-		async (
-			papers: BibtexPaperInput[],
-			overrides?: { format?: BibtexFormat; keyFormat?: BibtexKeyFormat },
-			onProgress?: (done: number, total: number) => void,
-		): Promise<BibtexBulkResult> => {
-			const currentFormat = overrides?.format ?? format;
-			const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
-			onProgress?.(0, papers.length);
+    const getBulkBibtex = useCallback(async (
+        papers: BibtexPaperInput[],
+        overrides?: { format?: BibtexFormat; keyFormat?: BibtexKeyFormat },
+        onProgress?: (done: number, total: number) => void,
+    ): Promise<BibtexBulkResult> => {
+        const currentFormat = overrides?.format ?? format;
+        const currentKeyFormat = overrides?.keyFormat ?? keyFormat;
+        onProgress?.(0, papers.length);
 
-			const res = await fetch("/api/bibtex/bulk", {
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify({
-					papers,
-					format: currentFormat,
-					keyFormat: currentKeyFormat,
-				}),
-			});
+        const res = await fetch("/api/bibtex/bulk", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                papers,
+                format: currentFormat,
+                keyFormat: currentKeyFormat,
+            }),
+        });
 
-			const data = await res.json();
-			if (!res.ok) {
-				throw new Error(data.error ?? "BibTeX 一括取得に失敗しました");
-			}
+        const data = await res.json();
+        if (!res.ok) {
+            throw new Error(data.error ?? "BibTeX 一括取得に失敗しました");
+        }
 
-			const result: BibtexBulkResult = {
-				bibtex: String(data.bibtex ?? ""),
-				count: Number(data.count ?? 0),
-				errors: Array.isArray(data.errors) ? data.errors : [],
-			};
+        const result: BibtexBulkResult = {
+            bibtex: String(data.bibtex ?? ""),
+            count: Number(data.count ?? 0),
+            errors: Array.isArray(data.errors) ? data.errors : [],
+        };
 
-			onProgress?.(papers.length, papers.length);
-			return result;
-		},
-		[format, keyFormat],
-	);
+        onProgress?.(papers.length, papers.length);
+        return result;
+    }, [format, keyFormat]);
 
-	return useMemo(
-		() => ({
-			format,
-			keyFormat,
-			setFormat,
-			setKeyFormat,
-			getSingleBibtex,
-			getBulkBibtex,
-		}),
-		[format, keyFormat, getSingleBibtex, getBulkBibtex],
-	);
+    return useMemo(() => ({
+        format,
+        keyFormat,
+        setFormat,
+        setKeyFormat,
+        getSingleBibtex,
+        getBulkBibtex,
+    }), [format, keyFormat, getSingleBibtex, getBulkBibtex]);
 }


### PR DESCRIPTION
🎯 **What:** Removed the unused `export` keyword from `BibtexSingleResult` in `packages/web/src/components/bibtex/useBibtex.ts`.
💡 **Why:** `BibtexSingleResult` is only used internally within `useBibtex.ts`. Removing the export improves maintainability by accurately reflecting the type's scope and preventing unintended external usage.
✅ **Verification:** Verified via `grep` that there are no external references to `BibtexSingleResult`, ran Biome format/lint, and executed the `packages/web` test suite.
✨ **Result:** A cleaner API boundary for `useBibtex.ts` without affecting any existing functionality.

---
*PR created automatically by Jules for task [9336337561093218981](https://jules.google.com/task/9336337561093218981) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `export` keyword from `BibtexSingleResult` in `useBibtex.ts`, correctly scoping it as an internal type. The change is safe — no external references exist. The diff also includes a full Biome reformatting (4-space → tab indentation) not mentioned in the PR title.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

ロジック変更なし・外部参照なしを確認済みのため、マージは安全です。

機能的な問題はなく、P2 の整形スコープ混在コメントのみ。P2 のみの場合は 4/5 となります。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/components/bibtex/useBibtex.ts | `BibtexSingleResult` から `export` を削除（外部参照なしを確認済み）。Biome による全体的なインデント・整形変更も含まれており、ロジックへの影響はなし。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web/src/components/bibtex/useBibtex.ts:8-46
**PR タイトルと実際の変更スコープのずれ**

PR タイトルは「Remove unused BibtexSingleResult export」ですが、diff には `export` の削除だけでなく、ファイル全体のインデント変換（4スペース → タブ）とコード整形（`normalizeDoi`・`cacheKey` 等の改行位置変更）が含まれています。説明文に「Biome format/lint を実行した」との記載はありますが、タイトルや差分の主眼と乖離しており、`git blame` でこの整形変更が混入すると将来の変更追跡が難しくなります。整形コミットを分けるか、タイトル・説明に整形変更を明記することを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove unused BibtexSingleResult ..."](https://github.com/hiroki-org/paper-tools/commit/ae70f8a9629837506077b0ca97eb24ac2fdac24c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30577221)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->