### PR TITLE
🧪 Add tests for CoauthorNetworkGraph

### DIFF
--- a/packages/web/src/components/author/CoauthorNetworkGraph.test.tsx
+++ b/packages/web/src/components/author/CoauthorNetworkGraph.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import CoauthorNetworkGraph from "./CoauthorNetworkGraph";
+
+const mockCytoscape = vi.fn(() => ({
+    destroy: vi.fn(),
+}));
+
+vi.mock("cytoscape", () => {
+    return {
+        default: mockCytoscape
+    };
+});
+
+describe("CoauthorNetworkGraph", () => {
+    beforeEach(() => {
+        mockCytoscape.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("renders empty state when no coauthors are provided", () => {
+        render(
+            <CoauthorNetworkGraph
+                authorId="1"
+                authorName="John Doe"
+                coauthors={[]}
+            />
+        );
+        expect(screen.getByText("共著ネットワークのデータがありません。")).toBeTruthy();
+    });
+
+    it("renders the graph container when coauthors are provided", async () => {
+        const { container, unmount } = render(
+            <CoauthorNetworkGraph
+                authorId="1"
+                authorName="John Doe"
+                coauthors={[
+                    { authorId: "2", name: "Jane Smith", paperCount: 5 }
+                ]}
+            />
+        );
+
+        expect(container.querySelector('.h-\\[360px\\]')).toBeTruthy();
+
+        await waitFor(() => {
+            expect(mockCytoscape).toHaveBeenCalled();
+        });
+
+        // Test unmounting to cover the destroy path
+        unmount();
+    });
+});

--- a/packages/web/src/components/author/CoauthorNetworkGraph.test.tsx
+++ b/packages/web/src/components/author/CoauthorNetworkGraph.test.tsx
@@ -1,25 +1,22 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import CoauthorNetworkGraph from "./CoauthorNetworkGraph";
 
-const mockCytoscape = vi.fn(() => ({
+const createCytoscapeMockInstance = () => ({
     destroy: vi.fn(),
-}));
-
-vi.mock("cytoscape", () => {
-    return {
-        default: mockCytoscape
-    };
 });
+
+const mockCytoscape = vi.fn(createCytoscapeMockInstance);
+
+vi.mock("cytoscape", () => ({
+    default: mockCytoscape,
+}));
 
 describe("CoauthorNetworkGraph", () => {
     beforeEach(() => {
-        mockCytoscape.mockClear();
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
+        vi.resetAllMocks();
+        mockCytoscape.mockImplementation(createCytoscapeMockInstance);
     });
 
     it("renders empty state when no coauthors are provided", () => {
@@ -50,7 +47,8 @@ describe("CoauthorNetworkGraph", () => {
             expect(mockCytoscape).toHaveBeenCalled();
         });
 
-        // Test unmounting to cover the destroy path
+        const instance = mockCytoscape.mock.results[0]?.value;
         unmount();
+        expect(instance?.destroy).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap for the `CoauthorNetworkGraph` component has been addressed by introducing a unit test file.

📊 **Coverage:** The tests now cover:
- Rendering the empty state correctly when there are no co-authors.
- Rendering the graph container when co-authors are provided.
- Ensuring the dynamic import of `cytoscape` is executed successfully and initialized.
- Asserting component unmount logic invokes the `destroy()` cleanup path of Cytoscape correctly.

✨ **Result:** Increased testing coverage and robustness, ensuring that visual networking elements and third-party interactions (Cytoscape) are functionally verified without runtime Canvas/WebGL crashes in JSDom.

---
*PR created automatically by Jules for task [1456145529660854088](https://jules.google.com/task/1456145529660854088) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`CoauthorNetworkGraph` コンポーネントに対するユニットテストを新規追加するPRです。空状態レンダリング・グラフコンテナ表示・Cytoscape の動的インポートの基本的なカバレッジは確保されています。ただし、PR説明で「`destroy()` クリーンアップパスの検証」を明示しているにもかかわらず、`unmount()` 後に `cy.destroy()` が実際に呼ばれたことをアサートするコードが欠落しており、クリーンアップテストが事実上機能していません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの追加であり、プロダクションコードへの影響はないためマージ自体は安全です。

P2のみの指摘（destroy() アサーション欠落）であり、P2のみの場合は4/5が上限となります。

packages/web/src/components/author/CoauthorNetworkGraph.test.tsx — destroy() の呼び出し検証が欠落しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/components/author/CoauthorNetworkGraph.test.tsx | CoauthorNetworkGraph の新規ユニットテストファイル。空状態とグラフ描画の基本的なカバレッジは確保されているが、unmount 後に cy.destroy() が実際に呼ばれたことを検証するアサーションが欠落しており、PR説明で謳うクリーンアップテストが実質的に不完全。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テスト
    participant Comp as CoauthorNetworkGraph
    participant Mock as mockCytoscape

    Test->>Comp: render(coauthors が空配列)
    Comp-->>Test: 「データがありません」テキストを表示

    Test->>Comp: render(coauthors あり)
    Comp->>Mock: dynamic import cytoscape()
    Mock-->>Comp: cy インスタンス返却
    Test->>Test: waitFor でモック呼び出しを確認
    Test->>Comp: unmount()
    Comp->>Mock: cy.destroy() を呼ぶ
    Note over Test,Mock: destroy() の呼び出しがアサートされない問題あり
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web/src/components/author/CoauthorNetworkGraph.test.tsx:49-54
`mockCytoscape` が呼ばれた後、`unmount()` を呼んでも `destroy()` が実際に呼ばれたことは検証されていません。`mockCytoscape.mock.results[0].value` でインスタンスを取り出して `destroy` の呼び出しをアサートすることで、コンポーネントのクリーンアップロジックを正しく検証できます。

```suggestion
        await waitFor(() => {
            expect(mockCytoscape).toHaveBeenCalled();
        });

        // Test unmounting to cover the destroy path
        unmount();

        const instance = mockCytoscape.mock.results[0]?.value;
        expect(instance.destroy).toHaveBeenCalledTimes(1);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add unit tests for CoauthorNetwork..."](https://github.com/hiroki-org/paper-tools/commit/26d23d8ee4486224aca5884d16a48f8963d263af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30577237)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->