### PR TITLE
🧪 Add unit tests for SearchForm component

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,6 +33,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/cytoscape": "^3.21.0",
     "@types/node": "^22.19.11",
     "@types/react": "^19.0.0",

--- a/packages/web/src/components/SearchForm.test.tsx
+++ b/packages/web/src/components/SearchForm.test.tsx
@@ -1,29 +1,32 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import SearchForm from "./SearchForm";
 
 describe("SearchForm", () => {
     it("renders correctly with default props", () => {
         render(<SearchForm onSearch={vi.fn()} />);
 
-        expect(screen.getByLabelText("Keyword")).toBeTruthy();
-        expect(screen.getByLabelText("Max Results")).toBeTruthy();
-        expect(screen.getByRole("button", { name: "Search" })).toBeTruthy();
+        screen.getByLabelText("Keyword");
+        screen.getByLabelText("Max Results");
+        screen.getByRole("button", { name: "Search" });
     });
 
-    it("calls onSearch with correct query and maxResults on submit", () => {
+    it("calls onSearch with trimmed query and maxResults on submit", async () => {
         const onSearchMock = vi.fn();
         render(<SearchForm onSearch={onSearchMock} />);
+        const user = userEvent.setup();
 
         const keywordInput = screen.getByLabelText("Keyword");
-        fireEvent.change(keywordInput, { target: { value: "test query" } });
+        await user.type(keywordInput, "  test query  ");
 
         const maxResultsInput = screen.getByLabelText("Max Results");
-        fireEvent.change(maxResultsInput, { target: { value: "50" } });
+        await user.clear(maxResultsInput);
+        await user.type(maxResultsInput, "50");
 
         const submitButton = screen.getByRole("button", { name: "Search" });
-        fireEvent.click(submitButton);
+        await user.click(submitButton);
 
         expect(onSearchMock).toHaveBeenCalledTimes(1);
         expect(onSearchMock).toHaveBeenCalledWith("test query", 50);
@@ -33,16 +36,17 @@ describe("SearchForm", () => {
         const onSearchMock = vi.fn();
         render(<SearchForm onSearch={onSearchMock} />);
 
-        const submitButton = screen.getByRole("button", { name: "Search" });
+        const keywordInput = screen.getByLabelText("Keyword");
+        const formElement = keywordInput.closest("form");
+        if (!formElement) {
+            throw new Error("Form element not found");
+        }
 
-        // Empty query (initial state)
-        fireEvent.click(submitButton);
+        fireEvent.submit(formElement);
         expect(onSearchMock).not.toHaveBeenCalled();
 
-        // Whitespace query
-        const keywordInput = screen.getByLabelText("Keyword");
         fireEvent.change(keywordInput, { target: { value: "   " } });
-        fireEvent.click(submitButton);
+        fireEvent.submit(formElement);
         expect(onSearchMock).not.toHaveBeenCalled();
     });
 
@@ -58,14 +62,15 @@ describe("SearchForm", () => {
         expect(submitButton.disabled).toBe(true);
     });
 
-    it("button is disabled when query is empty", () => {
+    it("button is disabled when query is empty", async () => {
+        const user = userEvent.setup();
         render(<SearchForm onSearch={vi.fn()} />);
 
         const submitButton = screen.getByRole("button", { name: "Search" }) as HTMLButtonElement;
         expect(submitButton.disabled).toBe(true);
 
         const keywordInput = screen.getByLabelText("Keyword");
-        fireEvent.change(keywordInput, { target: { value: "a" } });
+        await user.type(keywordInput, "a");
 
         expect(submitButton.disabled).toBe(false);
     });

--- a/packages/web/src/components/SearchForm.test.tsx
+++ b/packages/web/src/components/SearchForm.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SearchForm from "./SearchForm";
+
+describe("SearchForm", () => {
+    it("renders correctly with default props", () => {
+        render(<SearchForm onSearch={vi.fn()} />);
+
+        expect(screen.getByLabelText("Keyword")).toBeTruthy();
+        expect(screen.getByLabelText("Max Results")).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Search" })).toBeTruthy();
+    });
+
+    it("calls onSearch with correct query and maxResults on submit", () => {
+        const onSearchMock = vi.fn();
+        render(<SearchForm onSearch={onSearchMock} />);
+
+        const keywordInput = screen.getByLabelText("Keyword");
+        fireEvent.change(keywordInput, { target: { value: "test query" } });
+
+        const maxResultsInput = screen.getByLabelText("Max Results");
+        fireEvent.change(maxResultsInput, { target: { value: "50" } });
+
+        const submitButton = screen.getByRole("button", { name: "Search" });
+        fireEvent.click(submitButton);
+
+        expect(onSearchMock).toHaveBeenCalledTimes(1);
+        expect(onSearchMock).toHaveBeenCalledWith("test query", 50);
+    });
+
+    it("does not call onSearch if query is empty or whitespace", () => {
+        const onSearchMock = vi.fn();
+        render(<SearchForm onSearch={onSearchMock} />);
+
+        const submitButton = screen.getByRole("button", { name: "Search" });
+
+        // Empty query (initial state)
+        fireEvent.click(submitButton);
+        expect(onSearchMock).not.toHaveBeenCalled();
+
+        // Whitespace query
+        const keywordInput = screen.getByLabelText("Keyword");
+        fireEvent.change(keywordInput, { target: { value: "   " } });
+        fireEvent.click(submitButton);
+        expect(onSearchMock).not.toHaveBeenCalled();
+    });
+
+    it("disables inputs and button when loading is true", () => {
+        render(<SearchForm onSearch={vi.fn()} loading={true} />);
+
+        const keywordInput = screen.getByLabelText("Keyword") as HTMLInputElement;
+        const maxResultsInput = screen.getByLabelText("Max Results") as HTMLInputElement;
+        const submitButton = screen.getByRole("button", { name: "Searching…" }) as HTMLButtonElement;
+
+        expect(keywordInput.disabled).toBe(true);
+        expect(maxResultsInput.disabled).toBe(true);
+        expect(submitButton.disabled).toBe(true);
+    });
+
+    it("button is disabled when query is empty", () => {
+        render(<SearchForm onSearch={vi.fn()} />);
+
+        const submitButton = screen.getByRole("button", { name: "Search" }) as HTMLButtonElement;
+        expect(submitButton.disabled).toBe(true);
+
+        const keywordInput = screen.getByLabelText("Keyword");
+        fireEvent.change(keywordInput, { target: { value: "a" } });
+
+        expect(submitButton.disabled).toBe(false);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       '@testing-library/react-hooks':
         specifier: ^8.0.1
         version: 8.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/cytoscape':
         specifier: ^3.21.0
         version: 3.31.0
@@ -1068,6 +1071,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2691,6 +2700,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `SearchForm.tsx` component in the `web` package to verify form interaction, submission behavior, and disabled state handling.

📊 **Coverage:** The new test suite covers:
- Correct initial rendering of inputs and buttons
- Successful submission, verifying the `onSearch` prop is called with the correct keyword query and max results
- Edge cases preventing submission when the query is empty or consists only of whitespace
- UI constraints ensuring the submit button is disabled when the keyword input is empty
- Visual states and constraints ensuring inputs and the submit button are disabled when the `loading` prop is `true`

✨ **Result:** Improved test coverage for the core search UI and prevented future regressions in form behavior. All tests pass locally without regressions.

---
*PR created automatically by Jules for task [18180329870528769746](https://jules.google.com/task/18180329870528769746) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`SearchForm.tsx` コンポーネントに対するユニットテストを新規追加するPRです。レンダリング・送信・無効化状態など主要なケースはカバーされており、テスト自体は正常に動作します。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2のみのため、マージは安全です。

テストはすべて正常に動作し、主要なUIの振る舞いをカバーしています。指摘はいずれもP2（スタイル・カバレッジの改善提案）であり、バグや動作の誤りはありません。

packages/web/src/components/SearchForm.test.tsx — handleSubmitの空白ガード検証とtrim()の動作確認を補強するとテスト品質が向上します。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/components/SearchForm.test.tsx | SearchFormコンポーネントのユニットテストを新規追加。主要な動作はカバーされているが、handleSubmitの空白ガードが未検証、trim()の効果が確認できていないなどP2の改善点あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SearchForm
    participant handleSubmit
    participant onSearch

    User->>SearchForm: キーワード入力 (setQuery)
    User->>SearchForm: Max Results 変更 (setMaxResults)
    User->>SearchForm: Search ボタンクリック
    SearchForm->>handleSubmit: onSubmit イベント
    handleSubmit->>handleSubmit: e.preventDefault()
    alt query.trim() が truthy
        handleSubmit->>onSearch: onSearch(query.trim(), maxResults)
    else query が空 / 空白のみ
        handleSubmit-->>SearchForm: 何もしない
    end

    Note over SearchForm: loading=true の場合<br/>inputs・button を disabled に設定
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/web/src/components/SearchForm.test.tsx:38-45
**空白クエリのガード検証が不十分**

`handleSubmit` 内の `if (query.trim())` ガードは全くテストされていません。クエリが空白文字列 `"   "` のとき、ボタンの `disabled={!query.trim()}` も `true` になるため、`fireEvent.click` は jsdom でフォーム送信をトリガーしません。つまり `onSearchMock` が呼ばれないのは「ハンドラが弾いたから」ではなく「ボタンが無効だから」です。`fireEvent.submit(formElement)` でフォームを直接送信することで、ボタンの `disabled` 状態を迂回して `handleSubmit` のガードそのものを検証できます。

### Issue 2 of 3
packages/web/src/components/SearchForm.test.tsx:19-29
**`query.trim()` の動作が検証されていない**

`SearchForm.tsx` の `handleSubmit` では `onSearch(query.trim(), maxResults)` を呼び出しており、先頭・末尾の空白が除去された文字列が渡されます。しかし、テストで入力される `"test query"` は前後に空白がないため、`trim()` の有無に関わらず結果が同じです。`" test query "` など前後にスペースを含む値を入力し、`onSearchMock` が `"test query"` (trimmed) で呼ばれることを確認するテストを追加すると、`trim()` の効果を直接検証できます。

### Issue 3 of 3
packages/web/src/components/SearchForm.test.tsx:1-4
**`@testing-library/user-event` が未導入**

`fireEvent` は DOM イベントを直接発火させるため、実際のユーザー操作（フォーカス移動・入力ディレイ等）を再現できません。`@testing-library/user-event` の `userEvent.type()` / `userEvent.click()` を使うとよりリアルなインタラクションが検証できます。ただし `package.json` の `devDependencies` に `@testing-library/user-event` が含まれていないため、導入が必要です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): add SearchForm component test..."](https://github.com/hiroki-org/paper-tools/commit/e6bd2564b3e22ed07885cef9e72f40d46b9ede5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30577618)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->