### PR TITLE
🔒 Update vite and postcss to resolve security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,40 @@
 {
-  "name": "paper-tools",
-  "private": true,
-  "packageManager": "pnpm@10.18.3",
-  "description": "論文関連ツール群のモノレポ",
-  "license": "MIT",
-  "scripts": {
-    "build": "pnpm -r build",
-    "test": "pnpm -r test",
-    "clean": "pnpm -r clean"
-  },
-  "engines": {
-    "node": ">=20"
-  },
-  "devDependencies": {
-    "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.2",
-    "@testing-library/react-hooks": "^8.0.1",
-    "@vitest/coverage-v8": "^4.1.4",
-    "jsdom": "^29.0.1",
-    "rimraf": "^6.1.2",
-    "vitest": "^4.1.0"
-  },
-  "dependencies": {
-    "lucide-react": "^0.564.0"
-  },
-  "type": "module",
-  "pnpm": {
-    "overrides": {
-      "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
-      "brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
-      "undici@>=7.0.0 <7.24.0": "7.24.0",
-      "picomatch": "4.0.4",
-      "rollup@>=4.0.0 <4.59.0": "4.59.0",
-      "minimatch@>=10.0.0 <10.2.3": "10.2.4"
-    }
-  }
+	"name": "paper-tools",
+	"private": true,
+	"packageManager": "pnpm@10.18.3",
+	"description": "論文関連ツール群のモノレポ",
+	"license": "MIT",
+	"scripts": {
+		"build": "pnpm -r build",
+		"test": "pnpm -r test",
+		"clean": "pnpm -r clean"
+	},
+	"engines": {
+		"node": ">=20"
+	},
+	"devDependencies": {
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/react": "^16.3.2",
+		"@testing-library/react-hooks": "^8.0.1",
+		"@vitest/coverage-v8": "^4.1.4",
+		"jsdom": "^29.0.1",
+		"rimraf": "^6.1.2",
+		"vitest": "^4.1.0"
+	},
+	"dependencies": {
+		"lucide-react": "^0.564.0"
+	},
+	"type": "module",
+	"pnpm": {
+		"overrides": {
+			"brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
+			"brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
+			"undici@>=7.0.0 <7.24.0": "7.24.0",
+			"picomatch": "4.0.4",
+			"rollup@>=4.0.0 <4.59.0": "4.59.0",
+			"minimatch@>=10.0.0 <10.2.3": "10.2.4",
+			"postcss": "^8.5.10",
+			"vite": "^7.3.2"
+		}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,8 @@ overrides:
   picomatch: 4.0.4
   rollup@>=4.0.0 <4.59.0: 4.59.0
   minimatch@>=10.0.0 <10.2.3: 10.2.4
+  postcss: ^8.5.10
+  vite: ^7.3.2
 
 importers:
 
@@ -31,7 +33,7 @@ importers:
         version: 8.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
-        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -40,7 +42,7 @@ importers:
         version: 6.1.2
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/author-profiler:
     dependencies:
@@ -1139,7 +1141,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^7.3.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1150,7 +1152,7 @@ packages:
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^7.3.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1805,12 +1807,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -2032,8 +2030,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2114,7 +2112,7 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^7.3.2
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2668,7 +2666,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
-      postcss: 8.5.6
+      postcss: 8.5.14
       tailwindcss: 4.1.18
 
   '@testing-library/dom@10.4.1':
@@ -2761,7 +2759,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.4
@@ -2773,7 +2771,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+      vitest: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -2792,21 +2790,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3410,7 +3408,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
-      postcss: 8.4.31
+      postcss: 8.5.14
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
@@ -3477,13 +3475,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3714,7 +3706,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3729,12 +3721,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.14
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -3747,7 +3739,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3765,7 +3757,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
       vite-node: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -3785,10 +3777,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)):
+  vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -3805,7 +3797,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11


### PR DESCRIPTION
🎯 **What:**
Updates `vite` to `>=7.3.2` and `postcss` to `>=8.5.10` via `pnpm` overrides to resolve high and moderate severity security vulnerabilities.

⚠️ **Risk:**
The `vite` vulnerabilities could lead to arbitrary file reads (`GHSA-p9ff-h696-f583`) and bypassing `server.fs.deny` constraints (`GHSA-v2wj-q39q-566r`). `postcss` had an XSS vulnerability (`GHSA-qx2v-qp2m-jg93`).

🛡️ **Solution:**
Added `vite` and `postcss` to the `pnpm.overrides` field in the root `package.json` to enforce the patched versions across the monorepo, regenerating `pnpm-lock.yaml` to secure all sub-dependencies.

---
*PR created automatically by Jules for task [565795018723532277](https://jules.google.com/task/565795018723532277) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、`vite`（任意ファイル読み取りおよび`server.fs.deny`バイパスの脆弱性）と`postcss`（XSS脆弱性）に対処するため、ルートの `package.json` の `pnpm.overrides` にバージョン制約を追加し、`pnpm-lock.yaml` を再生成しています。

- `vite` を `7.3.1` → `7.3.2` に更新し、GHSA-p9ff-h696-f583・GHSA-v2wj-q39q-566r を修正。
- `postcss` を `8.4.31`/`8.5.6` → `8.5.14` に統一し、GHSA-qx2v-qp2m-jg93 を修正。
- `package.json` 全体のインデントがスペースからタブに変更されており、セキュリティ修正と無関係な差分ノイズが生じている点に注意が必要。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

セキュリティ修正の内容は正確で、ロックファイルも一致しており、モノレポ全体に適用されているためマージして問題ない。

コアとなる脆弱性修正（vite・postcss のオーバーライド追加とロックファイル再生成）は正しく実施されており、ロックファイルのスナップショットも整合している。一方で、vite オーバーライドが `^7.3.2`（上限 8.x 未満）となっており、将来 vite 8.x を要求するパッケージが追加された場合に競合する可能性がある。また、package.json 全体のインデントがスペースからタブへ変更されており、本来の修正と無関係な差分が含まれている。

package.json のインデント変更と vite オーバーライドのバージョン範囲を確認することを推奨。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | viteとpostcssのセキュリティオーバーライドを追加。インデントがスペースからタブに変更されており、意図しない差分ノイズが発生している。 |
| pnpm-lock.yaml | vite 7.3.1→7.3.2、postcss 8.4.31/8.5.6→8.5.14 に更新。@vitest/browserのpeer依存バージョン範囲がオーバーライドにより狭められている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm.overrides in package.json] --> B[vite 7.3.2]
    A --> C[postcss 8.5.14]
    B --> D[vitest 4.1.0]
    B --> E[vitest-mocker]
    B --> F[vitest-coverage-v8]
    C --> G[tailwindcss 4.1.18]
    C --> H[next/styled-jsx]
    I[CVE: arbitrary file read bypass] -->|patched| B
    J[CVE: postcss XSS] -->|patched| C
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
package.json:28-39
`package.json` 全体のインデントがスペース（2スペース）からタブに変わっています。セキュリティ修正とは無関係な変更であり、差分ノイズが増え、他のPRとのコンフリクトリスクが高まります。インデントは元のスペース形式のままにすることをお勧めします。

```suggestion
  "pnpm": {
    "overrides": {
      "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
      "brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
      "undici@>=7.0.0 <7.24.0": "7.24.0",
      "picomatch": "4.0.4",
      "rollup@>=4.0.0 <4.59.0": "4.59.0",
      "minimatch@>=10.0.0 <10.2.3": "10.2.4",
      "postcss": "^8.5.10",
      "vite": "^7.3.2"
    }
  }
```

### Issue 2 of 2
package.json:37
`vite` のオーバーライドが `^7.3.2`（`>=7.3.2 <8.0.0`）となっています。PRの説明では `>=7.3.2` と記載されており、将来的にいずれかのサブパッケージが vite 8.x を要求した場合、このオーバーライドが競合して解決できなくなります。セキュリティ修正が確実に適用される範囲を広げるため、`>=7.3.2` の形式を検討してください。

```suggestion
			"vite": ">=7.3.2"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Update vite and postcss to resolve se..."](https://github.com/hiroki-org/paper-tools/commit/bece43c98c7d8823255331eb25e8be937a9d11db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30815645)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->