### PR TITLE
ci: skip codecov upload without token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -110,12 +112,13 @@ jobs:
         run: pnpm --filter @paper-tools/${{ matrix.package }} exec vitest run --coverage.enabled --coverage.reporter=lcov
 
       - name: Upload coverage report to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           files: packages/${{ matrix.package }}/coverage/lcov.info
           flags: ${{ matrix.package }}
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
 
   web-unit-tests:
     name: Web unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         run: pnpm --filter @paper-tools/${{ matrix.package }} test
 
       - name: Generate coverage (lcov)
+        if: ${{ env.CODECOV_TOKEN != '' }}
         run: pnpm --filter @paper-tools/${{ matrix.package }} exec vitest run --coverage.enabled --coverage.reporter=lcov
 
       - name: Upload coverage report to Codecov


### PR DESCRIPTION
## Summary
- keep Codecov uploads strict when CODECOV_TOKEN is available
- skip package coverage upload when the token is unavailable, such as Dependabot PRs

## Validation
- git diff --check
- pnpm --filter @paper-tools/web test

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Dependabot などトークンが利用できない PR でのカバレッジ生成・アップロードをスキップするための変更です。`CODECOV_TOKEN` をジョブレベルの `env` に移動し、`if:` 条件で評価できるようにしています。

- `CODECOV_TOKEN` を `package-tests` ジョブの `env` に配置し、`if: ${{ env.CODECOV_TOKEN != '' }}` で `Generate coverage (lcov)` と `Upload coverage report to Codecov` の両ステップをスキップ可能にした。
- トークンが存在する場合は従来通り厳密（`fail_ci_if_error: true`）にアップロードする動作を維持している。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は安全にマージできます。既存のテスト実行には手が加えられておらず、カバレッジ関連ステップのみが条件付きスキップの対象です。

GitHub Actions でシークレットを `if:` 条件で評価するための定番パターン（ジョブレベル env への移動）を正しく採用しており、論理的な誤りはありません。

特に注意が必要なファイルはありません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | CODECOV_TOKEN をジョブレベルの env に移動し、トークンが空の場合にカバレッジ生成とアップロードをスキップする `if:` ガードを両ステップに追加した。ロジックは正しく、既存のテスト実行には影響しない。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci.yml`, line 111-115 ([link](https://github.com/hiroki-org/paper-tools/blob/656b830dc252f161644696c84978af36d46ef81b/.github/workflows/ci.yml#L111-L115)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `CODECOV_TOKEN` が空の場合、lcovカバレッジの生成ステップも実行されますが、その結果はアップロードされず無駄になります。トークンが存在しない Dependabot PR では、`Generate coverage (lcov)` もスキップするとランナーの時間を節約できます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/ci.yml
   Line: 111-115

   Comment:
   `CODECOV_TOKEN` が空の場合、lcovカバレッジの生成ステップも実行されますが、その結果はアップロードされず無駄になります。トークンが存在しない Dependabot PR では、`Generate coverage (lcov)` もスキップするとランナーの時間を節約できます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["ci: skip package coverage without codeco..."](https://github.com/hiroki-org/paper-tools/commit/09088fb73785eb086941bae9006dd2e5e6c10d22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32273154)</sub>

<!-- /greptile_comment -->