### PR TITLE
🧹 Remove unused import in openalex-client.test.ts

### DIFF
--- a/packages/core/tests/openalex-client.test.ts
+++ b/packages/core/tests/openalex-client.test.ts
@@ -3,146 +3,171 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { getOpenAlexAuthor, resolveOpenAlexAuthorId } from "../src/openalex-client.js";
+import { resolveOpenAlexAuthorId } from "../src/openalex-client.js";
 
 describe("OpenAlex Client", () => {
-    beforeEach(() => {
-        mockFetch.mockReset();
-    });
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
 
-    describe("resolveOpenAlexAuthorId", () => {
-        it("returns null when name and orcid are empty", async () => {
-            const result = await resolveOpenAlexAuthorId({ name: "   ", orcid: "" });
-            expect(result).toBeNull();
-            expect(mockFetch).not.toHaveBeenCalled();
-        });
+	describe("resolveOpenAlexAuthorId", () => {
+		it("returns null when name and orcid are empty", async () => {
+			const result = await resolveOpenAlexAuthorId({ name: "   ", orcid: "" });
+			expect(result).toBeNull();
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
 
-        it("throws error when API responds with not ok", async () => {
-            for (let i = 0; i < 4; i++) {
-                mockFetch.mockResolvedValueOnce({
-                    ok: false,
-                    status: 500,
-                    statusText: "Internal Server Error",
-                    text: async () => "Server crashed",
-                });
-            }
+		it("throws error when API responds with not ok", async () => {
+			for (let i = 0; i < 4; i++) {
+				mockFetch.mockResolvedValueOnce({
+					ok: false,
+					status: 500,
+					statusText: "Internal Server Error",
+					text: async () => "Server crashed",
+				});
+			}
 
-            await expect(resolveOpenAlexAuthorId({ name: "Alice" })).rejects.toThrow(
-                "OpenAlex API error: 500 Internal Server Error - Server crashed"
-            );
-        }, 10000);
+			await expect(resolveOpenAlexAuthorId({ name: "Alice" })).rejects.toThrow(
+				"OpenAlex API error: 500 Internal Server Error - Server crashed",
+			);
+		}, 10000);
 
-        it("uses exact orcid match to boost score", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    results: [
-                        { id: "https://openalex.org/A1", display_name: "Alice", orcid: "0000-0000-0000-0001" },
-                        { id: "https://openalex.org/A2", display_name: "Alice", orcid: "0000-0000-0000-0002" },
-                    ],
-                }),
-            });
+		it("uses exact orcid match to boost score", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					results: [
+						{
+							id: "https://openalex.org/A1",
+							display_name: "Alice",
+							orcid: "0000-0000-0000-0001",
+						},
+						{
+							id: "https://openalex.org/A2",
+							display_name: "Alice",
+							orcid: "0000-0000-0000-0002",
+						},
+					],
+				}),
+			});
 
-            const result = await resolveOpenAlexAuthorId({ name: "Alice", orcid: "0000-0000-0000-0002" });
-            expect(result).toBe("https://openalex.org/A2");
-        });
+			const result = await resolveOpenAlexAuthorId({
+				name: "Alice",
+				orcid: "0000-0000-0000-0002",
+			});
+			expect(result).toBe("https://openalex.org/A2");
+		});
 
-        it("ranks by exact name match and partial name match", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    results: [
-                        { id: "https://openalex.org/A1", display_name: "Bob Builder" }, // partial match (includes Bob)
-                        { id: "https://openalex.org/A2", display_name: "Bob" },         // exact match
-                    ],
-                }),
-            });
+		it("ranks by exact name match and partial name match", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					results: [
+						{ id: "https://openalex.org/A1", display_name: "Bob Builder" }, // partial match (includes Bob)
+						{ id: "https://openalex.org/A2", display_name: "Bob" }, // exact match
+					],
+				}),
+			});
 
-            const result = await resolveOpenAlexAuthorId({ name: "Bob" });
-            expect(result).toBe("https://openalex.org/A2");
-        });
+			const result = await resolveOpenAlexAuthorId({ name: "Bob" });
+			expect(result).toBe("https://openalex.org/A2");
+		});
 
-        it("ranks by affiliation matching with affiliations array", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    results: [
-                        {
-                            id: "https://openalex.org/A1",
-                            display_name: "Charlie",
-                            affiliations: [{ institution: { display_name: "MIT" } }]
-                        },
-                        {
-                            id: "https://openalex.org/A2",
-                            display_name: "Charlie",
-                            affiliations: [{ institution: { display_name: "Stanford" } }]
-                        },
-                    ],
-                }),
-            });
+		it("ranks by affiliation matching with affiliations array", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					results: [
+						{
+							id: "https://openalex.org/A1",
+							display_name: "Charlie",
+							affiliations: [{ institution: { display_name: "MIT" } }],
+						},
+						{
+							id: "https://openalex.org/A2",
+							display_name: "Charlie",
+							affiliations: [{ institution: { display_name: "Stanford" } }],
+						},
+					],
+				}),
+			});
 
-            const result = await resolveOpenAlexAuthorId({ name: "Charlie", affiliation: "Stanford" });
-            expect(result).toBe("https://openalex.org/A2");
-        });
+			const result = await resolveOpenAlexAuthorId({
+				name: "Charlie",
+				affiliation: "Stanford",
+			});
+			expect(result).toBe("https://openalex.org/A2");
+		});
 
-        it("ranks by affiliation matching with last_known_institutions array", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    results: [
-                        {
-                            id: "https://openalex.org/A1",
-                            display_name: "Charlie",
-                            last_known_institutions: [{ display_name: "MIT" }]
-                        },
-                        {
-                            id: "https://openalex.org/A2",
-                            display_name: "Charlie",
-                            last_known_institutions: [{ display_name: "Harvard" }]
-                        },
-                    ],
-                }),
-            });
+		it("ranks by affiliation matching with last_known_institutions array", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					results: [
+						{
+							id: "https://openalex.org/A1",
+							display_name: "Charlie",
+							last_known_institutions: [{ display_name: "MIT" }],
+						},
+						{
+							id: "https://openalex.org/A2",
+							display_name: "Charlie",
+							last_known_institutions: [{ display_name: "Harvard" }],
+						},
+					],
+				}),
+			});
 
-            const result = await resolveOpenAlexAuthorId({ name: "Charlie", affiliation: "Harvard" });
-            expect(result).toBe("https://openalex.org/A2");
-        });
+			const result = await resolveOpenAlexAuthorId({
+				name: "Charlie",
+				affiliation: "Harvard",
+			});
+			expect(result).toBe("https://openalex.org/A2");
+		});
 
-        it("ranks by works_count", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    results: [
-                        { id: "https://openalex.org/A1", display_name: "Dave", works_count: 50 }, // score += 1
-                        { id: "https://openalex.org/A2", display_name: "Dave", works_count: 500 }, // score += 10
-                    ],
-                }),
-            });
+		it("ranks by works_count", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					results: [
+						{
+							id: "https://openalex.org/A1",
+							display_name: "Dave",
+							works_count: 50,
+						}, // score += 1
+						{
+							id: "https://openalex.org/A2",
+							display_name: "Dave",
+							works_count: 500,
+						}, // score += 10
+					],
+				}),
+			});
 
-            const result = await resolveOpenAlexAuthorId({ name: "Dave" });
-            expect(result).toBe("https://openalex.org/A2");
-        });
+			const result = await resolveOpenAlexAuthorId({ name: "Dave" });
+			expect(result).toBe("https://openalex.org/A2");
+		});
 
-        it("returns null when no results are found", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    results: [],
-                }),
-            });
+		it("returns null when no results are found", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					results: [],
+				}),
+			});
 
-            const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
-            expect(result).toBeNull();
-        });
+			const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
+			expect(result).toBeNull();
+		});
 
-        it("handles missing results field gracefully", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({}),
-            });
+		it("handles missing results field gracefully", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({}),
+			});
 
-            const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
-            expect(result).toBeNull();
-        });
-    });
+			const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
+			expect(result).toBeNull();
+		});
+	});
 });

--- a/packages/core/tests/openalex-client.test.ts
+++ b/packages/core/tests/openalex-client.test.ts
@@ -6,168 +6,143 @@ vi.stubGlobal("fetch", mockFetch);
 import { resolveOpenAlexAuthorId } from "../src/openalex-client.js";
 
 describe("OpenAlex Client", () => {
-	beforeEach(() => {
-		mockFetch.mockReset();
-	});
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
 
-	describe("resolveOpenAlexAuthorId", () => {
-		it("returns null when name and orcid are empty", async () => {
-			const result = await resolveOpenAlexAuthorId({ name: "   ", orcid: "" });
-			expect(result).toBeNull();
-			expect(mockFetch).not.toHaveBeenCalled();
-		});
+    describe("resolveOpenAlexAuthorId", () => {
+        it("returns null when name and orcid are empty", async () => {
+            const result = await resolveOpenAlexAuthorId({ name: "   ", orcid: "" });
+            expect(result).toBeNull();
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
 
-		it("throws error when API responds with not ok", async () => {
-			for (let i = 0; i < 4; i++) {
-				mockFetch.mockResolvedValueOnce({
-					ok: false,
-					status: 500,
-					statusText: "Internal Server Error",
-					text: async () => "Server crashed",
-				});
-			}
+        it("throws error when API responds with not ok", async () => {
+            for (let i = 0; i < 4; i++) {
+                mockFetch.mockResolvedValueOnce({
+                    ok: false,
+                    status: 500,
+                    statusText: "Internal Server Error",
+                    text: async () => "Server crashed",
+                });
+            }
 
-			await expect(resolveOpenAlexAuthorId({ name: "Alice" })).rejects.toThrow(
-				"OpenAlex API error: 500 Internal Server Error - Server crashed",
-			);
-		}, 10000);
+            await expect(resolveOpenAlexAuthorId({ name: "Alice" })).rejects.toThrow(
+                "OpenAlex API error: 500 Internal Server Error - Server crashed"
+            );
+        }, 10000);
 
-		it("uses exact orcid match to boost score", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					results: [
-						{
-							id: "https://openalex.org/A1",
-							display_name: "Alice",
-							orcid: "0000-0000-0000-0001",
-						},
-						{
-							id: "https://openalex.org/A2",
-							display_name: "Alice",
-							orcid: "0000-0000-0000-0002",
-						},
-					],
-				}),
-			});
+        it("uses exact orcid match to boost score", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    results: [
+                        { id: "https://openalex.org/A1", display_name: "Alice", orcid: "0000-0000-0000-0001" },
+                        { id: "https://openalex.org/A2", display_name: "Alice", orcid: "0000-0000-0000-0002" },
+                    ],
+                }),
+            });
 
-			const result = await resolveOpenAlexAuthorId({
-				name: "Alice",
-				orcid: "0000-0000-0000-0002",
-			});
-			expect(result).toBe("https://openalex.org/A2");
-		});
+            const result = await resolveOpenAlexAuthorId({ name: "Alice", orcid: "0000-0000-0000-0002" });
+            expect(result).toBe("https://openalex.org/A2");
+        });
 
-		it("ranks by exact name match and partial name match", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					results: [
-						{ id: "https://openalex.org/A1", display_name: "Bob Builder" }, // partial match (includes Bob)
-						{ id: "https://openalex.org/A2", display_name: "Bob" }, // exact match
-					],
-				}),
-			});
+        it("ranks by exact name match and partial name match", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    results: [
+                        { id: "https://openalex.org/A1", display_name: "Bob Builder" }, // partial match (includes Bob)
+                        { id: "https://openalex.org/A2", display_name: "Bob" },         // exact match
+                    ],
+                }),
+            });
 
-			const result = await resolveOpenAlexAuthorId({ name: "Bob" });
-			expect(result).toBe("https://openalex.org/A2");
-		});
+            const result = await resolveOpenAlexAuthorId({ name: "Bob" });
+            expect(result).toBe("https://openalex.org/A2");
+        });
 
-		it("ranks by affiliation matching with affiliations array", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					results: [
-						{
-							id: "https://openalex.org/A1",
-							display_name: "Charlie",
-							affiliations: [{ institution: { display_name: "MIT" } }],
-						},
-						{
-							id: "https://openalex.org/A2",
-							display_name: "Charlie",
-							affiliations: [{ institution: { display_name: "Stanford" } }],
-						},
-					],
-				}),
-			});
+        it("ranks by affiliation matching with affiliations array", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    results: [
+                        {
+                            id: "https://openalex.org/A1",
+                            display_name: "Charlie",
+                            affiliations: [{ institution: { display_name: "MIT" } }]
+                        },
+                        {
+                            id: "https://openalex.org/A2",
+                            display_name: "Charlie",
+                            affiliations: [{ institution: { display_name: "Stanford" } }]
+                        },
+                    ],
+                }),
+            });
 
-			const result = await resolveOpenAlexAuthorId({
-				name: "Charlie",
-				affiliation: "Stanford",
-			});
-			expect(result).toBe("https://openalex.org/A2");
-		});
+            const result = await resolveOpenAlexAuthorId({ name: "Charlie", affiliation: "Stanford" });
+            expect(result).toBe("https://openalex.org/A2");
+        });
 
-		it("ranks by affiliation matching with last_known_institutions array", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					results: [
-						{
-							id: "https://openalex.org/A1",
-							display_name: "Charlie",
-							last_known_institutions: [{ display_name: "MIT" }],
-						},
-						{
-							id: "https://openalex.org/A2",
-							display_name: "Charlie",
-							last_known_institutions: [{ display_name: "Harvard" }],
-						},
-					],
-				}),
-			});
+        it("ranks by affiliation matching with last_known_institutions array", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    results: [
+                        {
+                            id: "https://openalex.org/A1",
+                            display_name: "Charlie",
+                            last_known_institutions: [{ display_name: "MIT" }]
+                        },
+                        {
+                            id: "https://openalex.org/A2",
+                            display_name: "Charlie",
+                            last_known_institutions: [{ display_name: "Harvard" }]
+                        },
+                    ],
+                }),
+            });
 
-			const result = await resolveOpenAlexAuthorId({
-				name: "Charlie",
-				affiliation: "Harvard",
-			});
-			expect(result).toBe("https://openalex.org/A2");
-		});
+            const result = await resolveOpenAlexAuthorId({ name: "Charlie", affiliation: "Harvard" });
+            expect(result).toBe("https://openalex.org/A2");
+        });
 
-		it("ranks by works_count", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					results: [
-						{
-							id: "https://openalex.org/A1",
-							display_name: "Dave",
-							works_count: 50,
-						}, // score += 1
-						{
-							id: "https://openalex.org/A2",
-							display_name: "Dave",
-							works_count: 500,
-						}, // score += 10
-					],
-				}),
-			});
+        it("ranks by works_count", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    results: [
+                        { id: "https://openalex.org/A1", display_name: "Dave", works_count: 50 }, // score += 1
+                        { id: "https://openalex.org/A2", display_name: "Dave", works_count: 500 }, // score += 10
+                    ],
+                }),
+            });
 
-			const result = await resolveOpenAlexAuthorId({ name: "Dave" });
-			expect(result).toBe("https://openalex.org/A2");
-		});
+            const result = await resolveOpenAlexAuthorId({ name: "Dave" });
+            expect(result).toBe("https://openalex.org/A2");
+        });
 
-		it("returns null when no results are found", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					results: [],
-				}),
-			});
+        it("returns null when no results are found", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    results: [],
+                }),
+            });
 
-			const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
-			expect(result).toBeNull();
-		});
+            const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
+            expect(result).toBeNull();
+        });
 
-		it("handles missing results field gracefully", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({}),
-			});
+        it("handles missing results field gracefully", async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({}),
+            });
 
-			const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
-			expect(result).toBeNull();
-		});
-	});
+            const result = await resolveOpenAlexAuthorId({ name: "Unknown Author" });
+            expect(result).toBeNull();
+        });
+    });
 });


### PR DESCRIPTION
🎯 **What:** Removed the unused `getOpenAlexAuthor` import in `packages/core/tests/openalex-client.test.ts`.

💡 **Why:** To improve code health, maintainability, and readability by eliminating dead code.

✅ **Verification:** Ran `pnpm dlx @biomejs/biome check --write` to ensure the file was formatted correctly. Executed `pnpm test` in the `packages/core` directory and verified that all 54 tests passed successfully without regressions.

✨ **Result:** A cleaner test file with no unused dependencies, formatted consistently with the repository's configuration.

---
*PR created automatically by Jules for task [15486698394537272501](https://jules.google.com/task/15486698394537272501) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

未使用の `getOpenAlexAuthor` インポートを `packages/core/tests/openalex-client.test.ts` から削除するクリーンアップPRです。テストファイルでは `resolveOpenAlexAuthorId` のみが使用されており、変更はその実態に合わせたものです。

- `getOpenAlexAuthor` のインポートを削除。テスト内で一度も参照されていなかったデッドコードを排除。
- 既存の54件のテストはすべてパス済みであり、動作への影響はありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

未使用インポートの1行削除のみで、テストロジックや本体コードへの変更は一切なく、安全にマージできます。

変更は `getOpenAlexAuthor` インポートの削除1行に限定されており、テストファイル内でこのシンボルが参照されていないことも確認済みです。全54テストがパスしており、リグレッションのリスクはありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/tests/openalex-client.test.ts | 未使用の `getOpenAlexAuthor` インポートを1行削除するのみ。テストロジックへの変更はなく、安全な変更。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[openalex-client.test.ts] -->|使用| B[resolveOpenAlexAuthorId]
    A -. 削除された未使用インポート .-> C[getOpenAlexAuthor]
    B -->|呼び出し| D[../src/openalex-client.js]
    C -->|定義元| D
```

<sub>Reviews (2): Last reviewed commit: ["test: narrow openalex unused import clea..."](https://github.com/hiroki-org/paper-tools/commit/cb8d36e020a32e9106686178971d5298314db007) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476593)</sub>

<!-- /greptile_comment -->