### PR TITLE
🧹 Fix Console Log in Production Code for bibtex validation

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -209,8 +209,7 @@ program
 
             const entries = splitBibtexEntries(text);
             if (entries.length === 0) {
-                console.error("No BibTeX entries found.");
-                return;
+                throw new Error("No BibTeX entries found.");
             }
 
             const report = buildValidateReport(entries);

--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -209,7 +209,7 @@ program
 
             const entries = splitBibtexEntries(text);
             if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
+                console.error("No BibTeX entries found.");
                 return;
             }
 


### PR DESCRIPTION
🎯 **What:** 
Replaced `console.log("No BibTeX entries found.");` with `console.error` at line 212 of `packages/bibtex/src/index.ts` within the `validate` CLI command action.

💡 **Why:** 
In a CLI application, primary data outputs meant for standard use or pipelining should go to `stdout` (`console.log`), while diagnostic messages, warnings, and errors should be routed to `stderr` (`console.error` or `console.warn`). Printing an error state ("No entries found") to `stdout` violates this convention. This change ensures proper output stream routing and aligns with CLI best practices, resolving the code health issue.

✅ **Verification:** 
1. Verified the file change explicitly.
2. Ran the test suite for the `@paper-tools/bibtex` package (`pnpm test` passed).
3. Ran automated code review verifying the change correctly routes CLI error messages.

✨ **Result:** 
The `paper-bib validate` command now outputs "No BibTeX entries found." to `stderr`, aligning with standard CLI design patterns and maintaining codebase health.

---
*PR created automatically by Jules for task [18343224854096054827](https://jules.google.com/task/18343224854096054827) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`paper-bib validate` コマンドで BibTeX エントリが0件のとき、`console.log` + `return`（stdout 出力・exit code 0）だった処理を `throw new Error` に置き換え、既存の catch ブロックを通じて stderr 出力・exit code 1 で終了するように修正した PR です。

- `throw new Error(\"No BibTeX entries found.\")` により、catch ブロック（line 232–235）が `console.error` + `process.exit(1)` を実行し、CLIの出力ストリーム規約と終了コードの両方を正しく修正しています。
- 変更は1行削除・1行追加と最小限であり、既存の catch ハンドラを再利用することでコードの重複もありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は1行の置き換えのみで、既存の catch ハンドラを活用した安全な修正です。

変更箇所は validate コマンドのエントリゼロ処理のみ。`throw new Error` を使うことで既存の catch ブロック（stderr 出力 + exit code 1）が確実に呼ばれ、stdout 汚染と誤った成功終了コードの両方を同時に解消しています。テストスイートも通過しており、回帰リスクはほぼありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/index.ts | BibTeX エントリが0件の場合の処理を `console.log` + `return` から `throw new Error` に変更。既存の catch ブロックを通じて stderr への出力と exit code 1 の返却が適切に行われるようになった。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[paper-bib validate input] --> B[ファイル読み込み / stdin 読み込み]
    B --> C{splitBibtexEntries}
    C -->|entries.length === 0| D["throw new Error('No BibTeX entries found.')"]    
    C -->|entries あり| E[buildValidateReport]
    D --> F["catch ブロック: console.error + process.exit(1)"]
    E --> H[結果を stdout に出力]
    H --> I{errors.length > 0?}
    I -->|Yes| F
    I -->|No| J[process.exit 0]
```

<sub>Reviews (2): Last reviewed commit: ["fix: fail validation when bibtex has no ..."](https://github.com/hiroki-org/paper-tools/commit/dc4c1211a55caf939c48b1d5b948ffc68178239a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476617)</sub>

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->