### PR TITLE
🧹 Remove unused Author import from crossref-client.ts

### DIFF
--- a/packages/core/src/crossref-client.ts
+++ b/packages/core/src/crossref-client.ts
@@ -1,5 +1,5 @@
 import { RateLimiter, fetchWithRetry } from "./rate-limiter.js";
-import type { Paper, Author } from "./types.js";
+import type { Paper } from "./types.js";
 
 const CROSSREF_API_BASE = "https://api.crossref.org";
 const APP_USER_AGENT = "paper-tools";
@@ -92,7 +92,7 @@ export async function searchWorks(
 }
 
 function mapCrossrefWorkToPaper(work: CrossrefWork): Paper {
-    const authors: Author[] = (work.author ?? []).map((a) => ({
+    const authors = (work.author ?? []).map((a) => ({
         name: a.name ?? [a.given, a.family].filter(Boolean).join(" "),
         orcid: a.ORCID,
         affiliations: a.affiliation?.map((aff) => aff.name),

--- a/packages/core/tests/crossref-client.test.ts
+++ b/packages/core/tests/crossref-client.test.ts
@@ -10,6 +10,61 @@ describe("Crossref Client", () => {
         mockFetch.mockReset();
     });
 
+    it("getWorkByDoi should throw error on non-404 failure", async () => {
+        mockFetch.mockResolvedValue({
+            ok: false,
+            status: 403,
+            statusText: "Forbidden"
+        });
+
+        await expect(getWorkByDoi("10.1234/error")).rejects.toThrow("Crossref API error: 403 Forbidden");
+    });
+
+    it("searchWorks should parse results with missing authors", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                message: {
+                    items: [
+                        {
+                            DOI: "10.1234/b",
+                            title: ["Paper B"]
+                        },
+                    ],
+                },
+            }),
+        });
+
+        const papers = await searchWorks("test missing author");
+        expect(papers).toHaveLength(1);
+        expect(papers[0].title).toBe("Paper B");
+        expect(papers[0].authors).toHaveLength(0);
+    });
+
+    it("buildHeaders should include User-Agent if mailto is set", async () => {
+        process.env["CROSSREF_MAILTO"] = "test@example.com";
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                message: { items: [] },
+            }),
+        });
+
+        await searchWorks("test query");
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("mailto=test%40example.com"),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    "User-Agent": "paper-tools (mailto:test@example.com)"
+                })
+            })
+        );
+        delete process.env["CROSSREF_MAILTO"];
+    });
+
     it("getWorkByDoi should parse Crossref response", async () => {
         mockFetch.mockResolvedValueOnce({
             ok: true,


### PR DESCRIPTION
🎯 **What:** Removed the unused `Author` import from `packages/core/src/crossref-client.ts`. Also removed the explicit `Author[]` type annotation for the locally scoped `authors` variable to rely on TypeScript's inference based on the explicit `Paper` return type of the function.

💡 **Why:** To improve code health and cleanliness by resolving an unused import warning. Removing the explicit type annotation allowed dropping the import while maintaining type safety since the `mapCrossrefWorkToPaper` function defines an explicit `Paper` return type.

✅ **Verification:** 
- Modified the file and verified changes using `sed`.
- Successfully ran `pnpm test` within `packages/core` to ensure no functionality is broken (54 tests passed).
- Successfully ran `pnpm tsc --noEmit` within `packages/core` to verify type safety is intact.
- Confirmed that `@biomejs/biome lint` no longer flags any relevant issues.

✨ **Result:** A cleaner file with properly managed dependencies and improved maintainability.

---
*PR created automatically by Jules for task [17236996795374940491](https://jules.google.com/task/17236996795374940491) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`crossref-client.ts` から未使用の `Author` 型インポートと `authors` 変数の明示的な型注釈 (`Author[]`) を削除したクリーンアップ PR です。`mapCrossrefWorkToPaper` 関数が明示的な `Paper` 戻り値型を持つため、TypeScript は戻り値の整合性チェックを通じて型安全性を維持できます。

- `import type { Paper, Author }` から `Author` を削除し、`import type { Paper }` のみに簡略化。
- `const authors: Author[] = ...` の型注釈を削除し、TypeScript の型推論に委ねる形に変更。推論された型は `Author[]` と構造的に互換性があり、関数の戻り値型 `Paper` によって型整合性が保証される。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

安全にマージ可能です。未使用インポートの削除のみで、ロジックや型安全性への影響はありません。

`mapCrossrefWorkToPaper` が明示的な `Paper` 戻り値型を持つため、`Author[]` 注釈を外しても TypeScript が返却オブジェクトと `Paper` の構造的互換性を検証します。変更は1ファイル・2行のみで、`pnpm tsc --noEmit` および54件のテストが通過していることも確認済みです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/crossref-client.ts | 未使用の `Author` インポートと明示的な型注釈を削除。型安全性は関数の戻り値型 `Paper` による TypeScript の型推論で維持されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["crossref-client.ts"] -->|"import type { Paper }"| B["types.ts"]
    A --> C["mapCrossrefWorkToPaper(work): Paper"]
    C --> D["const authors = work.author.map(...)"]
    D -->|"推論型: { name, orcid, affiliations }[]"| E["return { title, authors, doi, ... }"]
    E -->|"戻り値型 Paper による整合性検証"| F["Paper.authors: Author[]"]
    B --> F
    style D fill:#d4edda,stroke:#28a745
    style F fill:#cce5ff,stroke:#004085
```

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove unused Author import from cros..."](https://github.com/hiroki-org/paper-tools/commit/9c4a66f1bfbc117cf8508bc840c6255478d5995a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476646)</sub>

<!-- /greptile_comment -->