### PR TITLE
🧹 refactor(bibtex): Replace console.log with process.stdout.write

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -1,290 +1,239 @@
 #!/usr/bin/env node
 
 import "dotenv/config";
+import { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
 import { stdin as input } from "node:process";
-import { queryPapers } from "@paper-tools/recommender";
-import { Command } from "commander";
 import { fetchBibtex } from "./bibtex-fetcher.js";
-import {
-	deriveBibtexKey,
-	formatBibtex,
-	getValidationWarnings,
-	parseBibtexEntry,
-	splitBibtexEntries,
-} from "./bibtex-formatter.js";
+import { deriveBibtexKey, formatBibtex, getValidationWarnings, parseBibtexEntry, splitBibtexEntries } from "./bibtex-formatter.js";
 import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
+import { queryPapers } from "@paper-tools/recommender";
 
 const program = new Command();
 
 function requireDatabaseId(): string {
-	const databaseId = process.env["NOTION_DATABASE_ID"];
-	if (!databaseId) {
-		throw new Error("NOTION_DATABASE_ID が未設定です");
-	}
-	return databaseId;
+    const databaseId = process.env["NOTION_DATABASE_ID"];
+    if (!databaseId) {
+        throw new Error("NOTION_DATABASE_ID が未設定です");
+    }
+    return databaseId;
 }
 
 function looksLikeDoi(inputValue: string): boolean {
-	const s = inputValue.trim();
-	return (
-		/^10\.[^\s/]+\/.+/i.test(s) ||
-		/^https?:\/\/doi\.org\//i.test(s) ||
-		/^doi:/i.test(s)
-	);
+    const s = inputValue.trim();
+    return /^10\.[^\s/]+\/.+/i.test(s) || /^https?:\/\/doi\.org\//i.test(s) || /^doi:/i.test(s);
 }
 
 function normalizeDoi(inputValue: string): string {
-	return inputValue
-		.trim()
-		.replace(/^https?:\/\/doi\.org\//i, "")
-		.replace(/^doi:/i, "")
-		.trim();
+    return inputValue.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
 }
 
 function parseKeyFormat(value: string | undefined): BibtexKeyFormat {
-	if (value === "short" || value === "venue") return value;
-	return "default";
+    if (value === "short" || value === "venue") return value;
+    return "default";
 }
 
 function parseFormat(value: string | undefined): BibtexFormat {
-	if (value === "biblatex") return "biblatex";
-	return "bibtex";
+    if (value === "biblatex") return "biblatex";
+    return "bibtex";
 }
 
-function deriveCustomKey(
-	rawBibtex: string,
-	keyFormat: BibtexKeyFormat,
-): string | undefined {
-	return deriveBibtexKey(rawBibtex, keyFormat);
+function deriveCustomKey(rawBibtex: string, keyFormat: BibtexKeyFormat): string | undefined {
+    return deriveBibtexKey(rawBibtex, keyFormat);
 }
 
 async function readStdinText(): Promise<string> {
-	const chunks: Buffer[] = [];
-	for await (const chunk of input) {
-		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-	}
-	return Buffer.concat(chunks).toString("utf8");
+    const chunks: Buffer[] = [];
+    for await (const chunk of input) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString("utf8");
 }
 
-function buildValidateReport(entries: string[]): {
-	issues: ValidateIssue[];
-	total: number;
-} {
-	const issues: ValidateIssue[] = [];
-	const keySeen = new Map<string, number>();
-	const doiSeen = new Map<string, number>();
+function buildValidateReport(entries: string[]): { issues: ValidateIssue[]; total: number } {
+    const issues: ValidateIssue[] = [];
+    const keySeen = new Map<string, number>();
+    const doiSeen = new Map<string, number>();
 
-	entries.forEach((raw, index) => {
-		try {
-			const parsed = parseBibtexEntry(raw);
-			const key = parsed.key;
-			const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
+    entries.forEach((raw, index) => {
+        try {
+            const parsed = parseBibtexEntry(raw);
+            const key = parsed.key;
+            const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
 
-			for (const warning of getValidationWarnings(parsed)) {
-				issues.push({ level: "warning", message: warning, key });
-			}
+            for (const warning of getValidationWarnings(parsed)) {
+                issues.push({ level: "warning", message: warning, key });
+            }
 
-			if (key) {
-				keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
-			}
-			if (doi) {
-				doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
-			}
-		} catch (error) {
-			issues.push({
-				level: "error",
-				message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
-			});
-		}
-	});
+            if (key) {
+                keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
+            }
+            if (doi) {
+                doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
+            }
+        } catch (error) {
+            issues.push({
+                level: "error",
+                message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
+            });
+        }
+    });
 
-	for (const [key, count] of keySeen) {
-		if (count > 1) {
-			issues.push({
-				level: "error",
-				key,
-				message: `Duplicate key detected: ${key} (${count})`,
-			});
-		}
-	}
-	for (const [doi, count] of doiSeen) {
-		if (count > 1) {
-			issues.push({
-				level: "error",
-				message: `Duplicate DOI detected: ${doi} (${count})`,
-			});
-		}
-	}
+    for (const [key, count] of keySeen) {
+        if (count > 1) {
+            issues.push({ level: "error", key, message: `Duplicate key detected: ${key} (${count})` });
+        }
+    }
+    for (const [doi, count] of doiSeen) {
+        if (count > 1) {
+            issues.push({ level: "error", message: `Duplicate DOI detected: ${doi} (${count})` });
+        }
+    }
 
-	return { issues, total: entries.length };
+    return { issues, total: entries.length };
 }
 
 program
-	.name("paper-bib")
-	.description(
-		"Generate and validate BibTeX entries from DOI/title and Notion DB records",
-	)
-	.version("0.1.0");
+    .name("paper-bib")
+    .description("Generate and validate BibTeX entries from DOI/title and Notion DB records")
+    .version("0.1.0");
 
 program
-	.command("get")
-	.argument("<identifier>", "DOI or paper title")
-	.option("--format <format>", "bibtex|biblatex", "bibtex")
-	.option("--key-format <keyFormat>", "default|short|venue", "default")
-	.action(
-		async (
-			identifier: string,
-			options: { format?: string; keyFormat?: string },
-		) => {
-			try {
-				const format = parseFormat(options.format);
-				const keyFormat = parseKeyFormat(options.keyFormat);
-				const lookup = looksLikeDoi(identifier)
-					? { doi: normalizeDoi(identifier) }
-					: { title: identifier.trim() };
+    .command("get")
+    .argument("<identifier>", "DOI or paper title")
+    .option("--format <format>", "bibtex|biblatex", "bibtex")
+    .option("--key-format <keyFormat>", "default|short|venue", "default")
+    .action(async (identifier: string, options: { format?: string; keyFormat?: string }) => {
+        try {
+            const format = parseFormat(options.format);
+            const keyFormat = parseKeyFormat(options.keyFormat);
+            const lookup = looksLikeDoi(identifier)
+                ? { doi: normalizeDoi(identifier) }
+                : { title: identifier.trim() };
 
-				const result = await fetchBibtex(lookup);
-				if (!result) {
-					throw new Error("BibTeX を取得できませんでした");
-				}
+            const result = await fetchBibtex(lookup);
+            if (!result) {
+                throw new Error("BibTeX を取得できませんでした");
+            }
 
-				const customKey = deriveCustomKey(result.bibtex, keyFormat);
-				const formatted = formatBibtex(result.bibtex, {
-					format,
-					key: customKey,
-					keyFormat,
-				});
-				if (formatted.warnings.length > 0) {
-					for (const warning of formatted.warnings) {
-						console.error(`Warning: ${warning}`);
-					}
-				}
-				process.stdout.write(`${formatted.formatted}\n`);
-			} catch (error) {
-				console.error("Error:", error instanceof Error ? error.message : error);
-				process.exit(1);
-			}
-		},
-	);
+            const customKey = deriveCustomKey(result.bibtex, keyFormat);
+            const formatted = formatBibtex(result.bibtex, {
+                format,
+                key: customKey,
+                keyFormat,
+            });
+            if (formatted.warnings.length > 0) {
+                for (const warning of formatted.warnings) {
+                    console.error(`Warning: ${warning}`);
+                }
+            }
+            process.stdout.write(`${formatted.formatted}\n`);
+        } catch (error) {
+            console.error("Error:", error instanceof Error ? error.message : error);
+            process.exit(1);
+        }
+    });
 
 program
-	.command("export")
-	.option("--tag <tag>", "Tag filter (best-effort)")
-	.option("--format <format>", "bibtex|biblatex", "bibtex")
-	.option("--key-format <keyFormat>", "default|short|venue", "default")
-	.option("--output <file>", "Output file path")
-	.action(
-		async (options: {
-			tag?: string;
-			format?: string;
-			keyFormat?: string;
-			output?: string;
-		}) => {
-			try {
-				const databaseId = requireDatabaseId();
-				const format = parseFormat(options.format);
-				const keyFormat = parseKeyFormat(options.keyFormat);
+    .command("export")
+    .option("--tag <tag>", "Tag filter (best-effort)")
+    .option("--format <format>", "bibtex|biblatex", "bibtex")
+    .option("--key-format <keyFormat>", "default|short|venue", "default")
+    .option("--output <file>", "Output file path")
+    .action(async (options: { tag?: string; format?: string; keyFormat?: string; output?: string }) => {
+        try {
+            const databaseId = requireDatabaseId();
+            const format = parseFormat(options.format);
+            const keyFormat = parseKeyFormat(options.keyFormat);
 
-				const records = await queryPapers(databaseId);
-				let targets = records;
+            const records = await queryPapers(databaseId);
+            let targets = records;
 
-				if (options.tag) {
-					// recommender notion-client currently does not expose tag fields.
-					// We keep this as a best-effort title filter to avoid blocking the export flow.
-					targets = records.filter((r) =>
-						r.title.toLowerCase().includes(options.tag!.toLowerCase()),
-					);
-					console.error(
-						`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`,
-					);
-				}
+            if (options.tag) {
+                // recommender notion-client currently does not expose tag fields.
+                // We keep this as a best-effort title filter to avoid blocking the export flow.
+                targets = records.filter((r) => r.title.toLowerCase().includes(options.tag!.toLowerCase()));
+                console.error(`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`);
+            }
 
-				const results: (string | null)[] = [];
-				const BATCH_SIZE = 10;
-				for (let i = 0; i < targets.length; i += BATCH_SIZE) {
-					const batch = targets.slice(i, i + BATCH_SIZE);
-					const batchResults = await Promise.all(
-						batch.map(async (record) => {
-							const fetched = await fetchBibtex({
-								doi: record.doi,
-								title: record.title,
-							});
-							if (!fetched) {
-								console.error(`Warning: BibTeX取得失敗: ${record.title}`);
-								return null;
-							}
+            const results: (string | null)[] = [];
+            const BATCH_SIZE = 10;
+            for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+                const batch = targets.slice(i, i + BATCH_SIZE);
+                const batchResults = await Promise.all(
+                    batch.map(async (record) => {
+                        const fetched = await fetchBibtex({ doi: record.doi, title: record.title });
+                        if (!fetched) {
+                            console.error(`Warning: BibTeX取得失敗: ${record.title}`);
+                            return null;
+                        }
 
-							const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
-							const formatted = formatBibtex(fetched.bibtex, {
-								format,
-								key: customKey,
-								keyFormat,
-							});
+                        const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
+                        const formatted = formatBibtex(fetched.bibtex, {
+                            format,
+                            key: customKey,
+                            keyFormat,
+                        });
 
-							if (formatted.warnings.length > 0) {
-								console.error(
-									`Warning (${record.title}): ${formatted.warnings.join("; ")}`,
-								);
-							}
-							return formatted.formatted;
-						}),
-					);
-					results.push(...batchResults);
-				}
-				const chunks = results.filter((c): c is string => c !== null);
+                        if (formatted.warnings.length > 0) {
+                            console.error(`Warning (${record.title}): ${formatted.warnings.join("; ")}`);
+                        }
+                        return formatted.formatted;
+                    })
+                );
+                results.push(...batchResults);
+            }
+            const chunks = results.filter((c): c is string => c !== null);
 
-				const outputText = chunks.join("\n\n");
-				if (options.output) {
-					await writeFile(options.output, outputText, "utf8");
-					console.error(`Wrote ${chunks.length} entries to ${options.output}`);
-				} else {
-					process.stdout.write(outputText + (outputText ? "\n" : ""));
-				}
-			} catch (error) {
-				console.error("Error:", error instanceof Error ? error.message : error);
-				process.exit(1);
-			}
-		},
-	);
+            const outputText = chunks.join("\n\n");
+            if (options.output) {
+                await writeFile(options.output, outputText, "utf8");
+                console.error(`Wrote ${chunks.length} entries to ${options.output}`);
+            } else {
+                process.stdout.write(outputText + (outputText ? "\n" : ""));
+            }
+        } catch (error) {
+            console.error("Error:", error instanceof Error ? error.message : error);
+            process.exit(1);
+        }
+    });
 
 program
-	.command("validate")
-	.argument("<input>", "BibTeX file path, or '-' to read stdin")
-	.action(async (inputArg: string) => {
-		try {
-			const text =
-				inputArg === "-"
-					? await readStdinText()
-					: await readFile(inputArg, "utf8");
+    .command("validate")
+    .argument("<input>", "BibTeX file path, or '-' to read stdin")
+    .action(async (inputArg: string) => {
+        try {
+            const text = inputArg === "-"
+                ? await readStdinText()
+                : await readFile(inputArg, "utf8");
 
-			const entries = splitBibtexEntries(text);
-			if (entries.length === 0) {
-				process.stdout.write("No BibTeX entries found.\n");
-				return;
-			}
+            const entries = splitBibtexEntries(text);
+            if (entries.length === 0) {
+                process.stdout.write("No BibTeX entries found.\n");
+                return;
+            }
 
-			const report = buildValidateReport(entries);
-			const errors = report.issues.filter((i) => i.level === "error");
-			const warnings = report.issues.filter((i) => i.level === "warning");
+            const report = buildValidateReport(entries);
+            const errors = report.issues.filter((i) => i.level === "error");
+            const warnings = report.issues.filter((i) => i.level === "warning");
 
-			process.stdout.write(`Entries: ${report.total}\n`);
-			process.stdout.write(`Errors: ${errors.length}\n`);
-			process.stdout.write(`Warnings: ${warnings.length}\n`);
+            process.stdout.write(`Entries: ${report.total}\n`);
+            process.stdout.write(`Errors: ${errors.length}\n`);
+            process.stdout.write(`Warnings: ${warnings.length}\n`);
 
-			for (const issue of report.issues) {
-				const prefix = issue.level.toUpperCase();
-				const keyInfo = issue.key ? ` [${issue.key}]` : "";
-				process.stdout.write(`${prefix}${keyInfo}: ${issue.message}\n`);
-			}
+            for (const issue of report.issues) {
+                const prefix = issue.level.toUpperCase();
+                const keyInfo = issue.key ? ` [${issue.key}]` : "";
+                process.stdout.write(`${prefix}${keyInfo}: ${issue.message}\n`);
+            }
 
-			if (errors.length > 0) {
-				process.exit(1);
-			}
-		} catch (error) {
-			console.error("Error:", error instanceof Error ? error.message : error);
-			process.exit(1);
-		}
-	});
+            if (errors.length > 0) {
+                process.exitCode = 1;
+            }
+        } catch (error) {
+            console.error("Error:", error instanceof Error ? error.message : error);
+            process.exitCode = 1;
+        }
+    });
 
 program.parse();

--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -1,239 +1,290 @@
 #!/usr/bin/env node
 
 import "dotenv/config";
-import { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
 import { stdin as input } from "node:process";
-import { fetchBibtex } from "./bibtex-fetcher.js";
-import { deriveBibtexKey, formatBibtex, getValidationWarnings, parseBibtexEntry, splitBibtexEntries } from "./bibtex-formatter.js";
-import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 import { queryPapers } from "@paper-tools/recommender";
+import { Command } from "commander";
+import { fetchBibtex } from "./bibtex-fetcher.js";
+import {
+	deriveBibtexKey,
+	formatBibtex,
+	getValidationWarnings,
+	parseBibtexEntry,
+	splitBibtexEntries,
+} from "./bibtex-formatter.js";
+import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 
 const program = new Command();
 
 function requireDatabaseId(): string {
-    const databaseId = process.env["NOTION_DATABASE_ID"];
-    if (!databaseId) {
-        throw new Error("NOTION_DATABASE_ID が未設定です");
-    }
-    return databaseId;
+	const databaseId = process.env["NOTION_DATABASE_ID"];
+	if (!databaseId) {
+		throw new Error("NOTION_DATABASE_ID が未設定です");
+	}
+	return databaseId;
 }
 
 function looksLikeDoi(inputValue: string): boolean {
-    const s = inputValue.trim();
-    return /^10\.[^\s/]+\/.+/i.test(s) || /^https?:\/\/doi\.org\//i.test(s) || /^doi:/i.test(s);
+	const s = inputValue.trim();
+	return (
+		/^10\.[^\s/]+\/.+/i.test(s) ||
+		/^https?:\/\/doi\.org\//i.test(s) ||
+		/^doi:/i.test(s)
+	);
 }
 
 function normalizeDoi(inputValue: string): string {
-    return inputValue.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	return inputValue
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
 function parseKeyFormat(value: string | undefined): BibtexKeyFormat {
-    if (value === "short" || value === "venue") return value;
-    return "default";
+	if (value === "short" || value === "venue") return value;
+	return "default";
 }
 
 function parseFormat(value: string | undefined): BibtexFormat {
-    if (value === "biblatex") return "biblatex";
-    return "bibtex";
+	if (value === "biblatex") return "biblatex";
+	return "bibtex";
 }
 
-function deriveCustomKey(rawBibtex: string, keyFormat: BibtexKeyFormat): string | undefined {
-    return deriveBibtexKey(rawBibtex, keyFormat);
+function deriveCustomKey(
+	rawBibtex: string,
+	keyFormat: BibtexKeyFormat,
+): string | undefined {
+	return deriveBibtexKey(rawBibtex, keyFormat);
 }
 
 async function readStdinText(): Promise<string> {
-    const chunks: Buffer[] = [];
-    for await (const chunk of input) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks).toString("utf8");
+	const chunks: Buffer[] = [];
+	for await (const chunk of input) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf8");
 }
 
-function buildValidateReport(entries: string[]): { issues: ValidateIssue[]; total: number } {
-    const issues: ValidateIssue[] = [];
-    const keySeen = new Map<string, number>();
-    const doiSeen = new Map<string, number>();
+function buildValidateReport(entries: string[]): {
+	issues: ValidateIssue[];
+	total: number;
+} {
+	const issues: ValidateIssue[] = [];
+	const keySeen = new Map<string, number>();
+	const doiSeen = new Map<string, number>();
 
-    entries.forEach((raw, index) => {
-        try {
-            const parsed = parseBibtexEntry(raw);
-            const key = parsed.key;
-            const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
+	entries.forEach((raw, index) => {
+		try {
+			const parsed = parseBibtexEntry(raw);
+			const key = parsed.key;
+			const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
 
-            for (const warning of getValidationWarnings(parsed)) {
-                issues.push({ level: "warning", message: warning, key });
-            }
+			for (const warning of getValidationWarnings(parsed)) {
+				issues.push({ level: "warning", message: warning, key });
+			}
 
-            if (key) {
-                keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
-            }
-            if (doi) {
-                doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
-            }
-        } catch (error) {
-            issues.push({
-                level: "error",
-                message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
-            });
-        }
-    });
+			if (key) {
+				keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
+			}
+			if (doi) {
+				doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
+			}
+		} catch (error) {
+			issues.push({
+				level: "error",
+				message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+	});
 
-    for (const [key, count] of keySeen) {
-        if (count > 1) {
-            issues.push({ level: "error", key, message: `Duplicate key detected: ${key} (${count})` });
-        }
-    }
-    for (const [doi, count] of doiSeen) {
-        if (count > 1) {
-            issues.push({ level: "error", message: `Duplicate DOI detected: ${doi} (${count})` });
-        }
-    }
+	for (const [key, count] of keySeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				key,
+				message: `Duplicate key detected: ${key} (${count})`,
+			});
+		}
+	}
+	for (const [doi, count] of doiSeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				message: `Duplicate DOI detected: ${doi} (${count})`,
+			});
+		}
+	}
 
-    return { issues, total: entries.length };
+	return { issues, total: entries.length };
 }
 
 program
-    .name("paper-bib")
-    .description("Generate and validate BibTeX entries from DOI/title and Notion DB records")
-    .version("0.1.0");
+	.name("paper-bib")
+	.description(
+		"Generate and validate BibTeX entries from DOI/title and Notion DB records",
+	)
+	.version("0.1.0");
 
 program
-    .command("get")
-    .argument("<identifier>", "DOI or paper title")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .action(async (identifier: string, options: { format?: string; keyFormat?: string }) => {
-        try {
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-            const lookup = looksLikeDoi(identifier)
-                ? { doi: normalizeDoi(identifier) }
-                : { title: identifier.trim() };
+	.command("get")
+	.argument("<identifier>", "DOI or paper title")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.action(
+		async (
+			identifier: string,
+			options: { format?: string; keyFormat?: string },
+		) => {
+			try {
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
+				const lookup = looksLikeDoi(identifier)
+					? { doi: normalizeDoi(identifier) }
+					: { title: identifier.trim() };
 
-            const result = await fetchBibtex(lookup);
-            if (!result) {
-                throw new Error("BibTeX を取得できませんでした");
-            }
+				const result = await fetchBibtex(lookup);
+				if (!result) {
+					throw new Error("BibTeX を取得できませんでした");
+				}
 
-            const customKey = deriveCustomKey(result.bibtex, keyFormat);
-            const formatted = formatBibtex(result.bibtex, {
-                format,
-                key: customKey,
-                keyFormat,
-            });
-            if (formatted.warnings.length > 0) {
-                for (const warning of formatted.warnings) {
-                    console.error(`Warning: ${warning}`);
-                }
-            }
-            process.stdout.write(`${formatted.formatted}\n`);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
-
-program
-    .command("export")
-    .option("--tag <tag>", "Tag filter (best-effort)")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .option("--output <file>", "Output file path")
-    .action(async (options: { tag?: string; format?: string; keyFormat?: string; output?: string }) => {
-        try {
-            const databaseId = requireDatabaseId();
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-
-            const records = await queryPapers(databaseId);
-            let targets = records;
-
-            if (options.tag) {
-                // recommender notion-client currently does not expose tag fields.
-                // We keep this as a best-effort title filter to avoid blocking the export flow.
-                targets = records.filter((r) => r.title.toLowerCase().includes(options.tag!.toLowerCase()));
-                console.error(`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`);
-            }
-
-            const results: (string | null)[] = [];
-            const BATCH_SIZE = 10;
-            for (let i = 0; i < targets.length; i += BATCH_SIZE) {
-                const batch = targets.slice(i, i + BATCH_SIZE);
-                const batchResults = await Promise.all(
-                    batch.map(async (record) => {
-                        const fetched = await fetchBibtex({ doi: record.doi, title: record.title });
-                        if (!fetched) {
-                            console.error(`Warning: BibTeX取得失敗: ${record.title}`);
-                            return null;
-                        }
-
-                        const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
-                        const formatted = formatBibtex(fetched.bibtex, {
-                            format,
-                            key: customKey,
-                            keyFormat,
-                        });
-
-                        if (formatted.warnings.length > 0) {
-                            console.error(`Warning (${record.title}): ${formatted.warnings.join("; ")}`);
-                        }
-                        return formatted.formatted;
-                    })
-                );
-                results.push(...batchResults);
-            }
-            const chunks = results.filter((c): c is string => c !== null);
-
-            const outputText = chunks.join("\n\n");
-            if (options.output) {
-                await writeFile(options.output, outputText, "utf8");
-                console.error(`Wrote ${chunks.length} entries to ${options.output}`);
-            } else {
-                process.stdout.write(outputText + (outputText ? "\n" : ""));
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+				const customKey = deriveCustomKey(result.bibtex, keyFormat);
+				const formatted = formatBibtex(result.bibtex, {
+					format,
+					key: customKey,
+					keyFormat,
+				});
+				if (formatted.warnings.length > 0) {
+					for (const warning of formatted.warnings) {
+						console.error(`Warning: ${warning}`);
+					}
+				}
+				process.stdout.write(`${formatted.formatted}\n`);
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("validate")
-    .argument("<input>", "BibTeX file path, or '-' to read stdin")
-    .action(async (inputArg: string) => {
-        try {
-            const text = inputArg === "-"
-                ? await readStdinText()
-                : await readFile(inputArg, "utf8");
+	.command("export")
+	.option("--tag <tag>", "Tag filter (best-effort)")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.option("--output <file>", "Output file path")
+	.action(
+		async (options: {
+			tag?: string;
+			format?: string;
+			keyFormat?: string;
+			output?: string;
+		}) => {
+			try {
+				const databaseId = requireDatabaseId();
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
 
-            const entries = splitBibtexEntries(text);
-            if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
-                return;
-            }
+				const records = await queryPapers(databaseId);
+				let targets = records;
 
-            const report = buildValidateReport(entries);
-            const errors = report.issues.filter((i) => i.level === "error");
-            const warnings = report.issues.filter((i) => i.level === "warning");
+				if (options.tag) {
+					// recommender notion-client currently does not expose tag fields.
+					// We keep this as a best-effort title filter to avoid blocking the export flow.
+					targets = records.filter((r) =>
+						r.title.toLowerCase().includes(options.tag!.toLowerCase()),
+					);
+					console.error(
+						`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`,
+					);
+				}
 
-            console.log(`Entries: ${report.total}`);
-            console.log(`Errors: ${errors.length}`);
-            console.log(`Warnings: ${warnings.length}`);
+				const results: (string | null)[] = [];
+				const BATCH_SIZE = 10;
+				for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+					const batch = targets.slice(i, i + BATCH_SIZE);
+					const batchResults = await Promise.all(
+						batch.map(async (record) => {
+							const fetched = await fetchBibtex({
+								doi: record.doi,
+								title: record.title,
+							});
+							if (!fetched) {
+								console.error(`Warning: BibTeX取得失敗: ${record.title}`);
+								return null;
+							}
 
-            for (const issue of report.issues) {
-                const prefix = issue.level.toUpperCase();
-                const keyInfo = issue.key ? ` [${issue.key}]` : "";
-                console.log(`${prefix}${keyInfo}: ${issue.message}`);
-            }
+							const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
+							const formatted = formatBibtex(fetched.bibtex, {
+								format,
+								key: customKey,
+								keyFormat,
+							});
 
-            if (errors.length > 0) {
-                process.exit(1);
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+							if (formatted.warnings.length > 0) {
+								console.error(
+									`Warning (${record.title}): ${formatted.warnings.join("; ")}`,
+								);
+							}
+							return formatted.formatted;
+						}),
+					);
+					results.push(...batchResults);
+				}
+				const chunks = results.filter((c): c is string => c !== null);
+
+				const outputText = chunks.join("\n\n");
+				if (options.output) {
+					await writeFile(options.output, outputText, "utf8");
+					console.error(`Wrote ${chunks.length} entries to ${options.output}`);
+				} else {
+					process.stdout.write(outputText + (outputText ? "\n" : ""));
+				}
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
+
+program
+	.command("validate")
+	.argument("<input>", "BibTeX file path, or '-' to read stdin")
+	.action(async (inputArg: string) => {
+		try {
+			const text =
+				inputArg === "-"
+					? await readStdinText()
+					: await readFile(inputArg, "utf8");
+
+			const entries = splitBibtexEntries(text);
+			if (entries.length === 0) {
+				process.stdout.write("No BibTeX entries found.\n");
+				return;
+			}
+
+			const report = buildValidateReport(entries);
+			const errors = report.issues.filter((i) => i.level === "error");
+			const warnings = report.issues.filter((i) => i.level === "warning");
+
+			process.stdout.write(`Entries: ${report.total}\n`);
+			process.stdout.write(`Errors: ${errors.length}\n`);
+			process.stdout.write(`Warnings: ${warnings.length}\n`);
+
+			for (const issue of report.issues) {
+				const prefix = issue.level.toUpperCase();
+				const keyInfo = issue.key ? ` [${issue.key}]` : "";
+				process.stdout.write(`${prefix}${keyInfo}: ${issue.message}\n`);
+			}
+
+			if (errors.length > 0) {
+				process.exit(1);
+			}
+		} catch (error) {
+			console.error("Error:", error instanceof Error ? error.message : error);
+			process.exit(1);
+		}
+	});
 
 program.parse();


### PR DESCRIPTION
🎯 **What:** Replaced all `console.log` occurrences in the `validate` CLI command action with `process.stdout.write(...\n)`.

💡 **Why:** This resolves a code health issue where console logging was used in production code. By standardizing output using `process.stdout.write`, it aligns with Node.js CLI best practices and avoids generic no-console linter rules without over-engineering an injectable logger.

✅ **Verification:** Automated formatter successfully applied sort changes and passed the format check. Tests within packages/bibtex all complete without issues.

✨ **Result:** Better code maintainability and output handling while retaining identical script capabilities.

---
*PR created automatically by Jules for task [13090969948998331892](https://jules.google.com/task/13090969948998331892) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`validate` CLI コマンド内の `console.log` を `process.stdout.write` へ置き換え、`process.exit(1)` を `process.exitCode = 1` に変更するリファクタリングPRです。出力の一貫性向上と no-console lintルール対応が目的で、機能的な変更はありません。

- `console.log` → `process.stdout.write(...\n)` への統一。`process.exitCode = 1` を使うことで、イベントループが自然に終了するまで待つようになり、stdout へのバッファリングされた書き込みが確実にフラッシュされる点では旧来の `process.exit(1)` より安全な変更です。
- エラー出力 (`catch` ブロック) は引き続き `console.error` が使われており、stderr への出力は正しく維持されています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はシンプルなリファクタリングのみで、機能的な動作は維持されている。

`console.log` → `process.stdout.write`、および `process.exit(1)` → `process.exitCode = 1` への置き換えは、いずれも既存の出力・終了ロジックを維持しており、回帰リスクは非常に低い。`process.exitCode = 1` の採用により、stdout バッファが自然にフラッシュされる点では旧来より堅牢になっている。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/index.ts | `validate` コマンドの `console.log` を `process.stdout.write` に、`process.exit(1)` を `process.exitCode = 1` に置き換えるリファクタリング。動作上の問題は見当たらない。 |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/hiroki-org/paper-tools/commit/81e2b17d4dcadbc5381a4c9f517d53f98f39128f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476652)</sub>

<!-- /greptile_comment -->