### PR TITLE
🔒 Fix authentication bypass in API routes middleware

### DIFF
--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -1,90 +1,85 @@
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { ACCESS_TOKEN_COOKIE, DATABASE_ID_COOKIE } from "@/lib/auth-cookies";
 
 function isPublicPath(pathname: string) {
-    return pathname === "/privacy" || pathname === "/terms";
+	return pathname === "/privacy" || pathname === "/terms";
 }
 
 function decodeBase64Url(input: string) {
-    const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
-    const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
-    return atob(normalized + padding);
+	const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+	const padding =
+		normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+	return atob(normalized + padding);
 }
 
 function hasValidAccessTokenShape(rawCookieValue?: string) {
-    if (!rawCookieValue) return false;
-    const [payload, signature] = rawCookieValue.split(".");
-    if (!payload || !signature) return false;
-    try {
-        const parsed = JSON.parse(decodeBase64Url(payload)) as { token?: unknown };
-        return typeof parsed.token === "string" && parsed.token.length > 0;
-    } catch {
-        return false;
-    }
+	if (!rawCookieValue) return false;
+	const [payload, signature] = rawCookieValue.split(".");
+	if (!payload || !signature) return false;
+	try {
+		const parsed = JSON.parse(decodeBase64Url(payload)) as { token?: unknown };
+		return typeof parsed.token === "string" && parsed.token.length > 0;
+	} catch {
+		return false;
+	}
 }
 
 export function middleware(request: NextRequest) {
-    const { pathname } = request.nextUrl;
-    const isApiRoute = pathname.startsWith("/api/");
+	const { pathname } = request.nextUrl;
+	const isApiRoute = pathname.startsWith("/api/");
 
-    if (
-        pathname.startsWith("/_next") ||
-        pathname.startsWith("/favicon.ico") ||
-        pathname.startsWith("/api/auth")
-    ) {
-        return NextResponse.next();
-    }
+	if (
+		pathname.startsWith("/_next") ||
+		pathname.startsWith("/favicon.ico") ||
+		pathname.startsWith("/api/auth")
+	) {
+		return NextResponse.next();
+	}
 
-    if (
-        pathname.startsWith("/api/search") ||
-        pathname.startsWith("/api/graph") ||
-        pathname.startsWith("/api/recommend") ||
-        pathname.startsWith("/api/resolve")
-    ) {
-        return NextResponse.next();
-    }
+	if (isPublicPath(pathname)) {
+		return NextResponse.next();
+	}
 
-    if (isPublicPath(pathname)) {
-        return NextResponse.next();
-    }
+	const accessTokenRaw = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+	const databaseId = request.cookies.get(DATABASE_ID_COOKIE)?.value;
+	const hasAccessToken = hasValidAccessTokenShape(accessTokenRaw);
 
-    const accessTokenRaw = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
-    const databaseId = request.cookies.get(DATABASE_ID_COOKIE)?.value;
-    const hasAccessToken = hasValidAccessTokenShape(accessTokenRaw);
+	// Redirect authenticated users away from /login
+	if (pathname === "/login") {
+		if (hasAccessToken) {
+			if (databaseId) {
+				return NextResponse.redirect(new URL("/", request.url));
+			}
+			return NextResponse.redirect(new URL("/setup", request.url));
+		}
+		return NextResponse.next();
+	}
 
-    // Redirect authenticated users away from /login
-    if (pathname === "/login") {
-        if (hasAccessToken) {
-            if (databaseId) {
-                return NextResponse.redirect(new URL("/", request.url));
-            }
-            return NextResponse.redirect(new URL("/setup", request.url));
-        }
-        return NextResponse.next();
-    }
+	// Require authentication for all other routes
+	if (!hasAccessToken) {
+		if (isApiRoute) {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+		return NextResponse.redirect(new URL("/login", request.url));
+	}
 
-    // Require authentication for all other routes
-    if (!hasAccessToken) {
-        if (isApiRoute) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-        return NextResponse.redirect(new URL("/login", request.url));
-    }
+	if (!databaseId) {
+		if (pathname === "/setup" || pathname.startsWith("/api/databases")) {
+			return NextResponse.next();
+		}
+		if (isApiRoute) {
+			return NextResponse.json(
+				{ error: "Database is not selected" },
+				{ status: 400 },
+			);
+		}
+		return NextResponse.redirect(new URL("/setup", request.url));
+	}
 
-    if (!databaseId) {
-        if (pathname === "/setup" || pathname.startsWith("/api/databases")) {
-            return NextResponse.next();
-        }
-        if (isApiRoute) {
-            return NextResponse.json({ error: "Database is not selected" }, { status: 400 });
-        }
-        return NextResponse.redirect(new URL("/setup", request.url));
-    }
-
-    return NextResponse.next();
+	return NextResponse.next();
 }
 
 export const config = {
-    matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+	matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };


### PR DESCRIPTION
🎯 **What:**
The vulnerability was a hardcoded list of route prefixes (`/api/search`, `/api/graph`, `/api/recommend`, `/api/resolve`) in `packages/web/middleware.ts` that were allowed to bypass authentication checks without verifying if the endpoints handle their own authorization.

⚠️ **Risk:**
If left unfixed, an attacker could bypass authentication and access these API endpoints directly. This could lead to unauthorized data access, abuse of API resources (like search or graph generation), or other unintended actions since the middleware incorrectly assumed these routes were either public or handled their own authentication.

🛡️ **Solution:**
I removed the `if` block in the middleware that explicitly allowed these routes to bypass authentication. Now, requests to these routes will correctly fall through to the rest of the middleware logic, which verifies the presence of a valid access token and database ID, returning a `401 Unauthorized` or `400 Bad Request` if the required credentials are not present. Formatting was also cleaned up locally.

---
*PR created automatically by Jules for task [6107784142083515274](https://jules.google.com/task/6107784142083515274) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ミドルウェアの認証バイパスを修正するPRです。`/api/search`・`/api/graph`・`/api/recommend`・`/api/resolve` を無条件でスルーしていた `if` ブロックを削除し、これらのルートも通常の認証フロー（アクセストークン + データベースID チェック）に従うようにしています。インデントスタイルも全体的にタブに統一されています。

- バイパスブロックの削除によって認証のないリクエストが 401 で弾かれるようになった点は正しい修正ですが、これら4ルートは Notion データベースを使わない外部 API 呼び出しのみを行うため、`databaseId` 未設定の認証済みユーザーが 400 を受け取る機能退行が生じます。
- フォーマット変更（スペース→タブ）はロジックとは無関係の整理です。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

認証バイパスの除去自体は正しい方向だが、外部API専用ルートに対して不要な databaseId チェックが課されるため、認証済みだが DB 未設定のユーザーが機能を利用できなくなる退行が含まれており、そのまま本番マージするには追加修正が必要です。

セキュリティ修正の意図は正しく、バイパスブロックの削除は妥当です。ただし /api/search・/api/graph・/api/recommend・/api/resolve はいずれも Notion DB を使用しないにもかかわらず、修正後は databaseId 必須になってしまうため、OAuth 認証完了済みで DB 選択前のユーザーに不要な 400 エラーが発生します。この退行が解消されるまでは慎重な確認が必要です。

packages/web/middleware.ts — databaseId チェックの例外ルート一覧を見直す必要があります
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/middleware.ts | 認証バイパスの除去は正しいが、/api/search・graph・recommend・resolve が databaseId チェックの例外にもなっていないため、DB未設定の認証済みユーザーに不要な400エラーが返る機能退行がある |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web/middleware.ts:67-78
**認証済みだがDB未設定ユーザーへの意図しない 400 エラー**

今回の修正により `/api/search`・`/api/graph`・`/api/recommend`・`/api/resolve` は `databaseId` チェック（67〜78行目）も通過するようになりました。しかしこれら4ルートはいずれも Notion データベースを参照せず、外部 API（Semantic Scholar 等）を直接呼び出します。そのため、OAuth 認証は完了しているが DB 選択をまだ行っていないユーザーがこれらのエンドポイントを呼び出すと、ルートには何ら問題がないにもかかわらず `{"error":"Database is not selected"}` (400) が返されてしまいます。これはセキュリティ修正の副作用として生じる機能退行です。`/api/setup` や `/api/databases` と同様に、これらの外部検索系ルートも `databaseId` チェックの例外に含めることを検討してください。

### Issue 2 of 2
packages/web/middleware.ts:16-26
**トークン署名を検証していない**

`hasValidAccessTokenShape` はクッキーの先頭セグメントをデコードして `token` フィールドが文字列かどうかだけを確認しており、署名の検証は一切行っていません。`{"token":"x"}.anysignature` という形式のクッキーを任意に生成すれば、この関数は `true` を返します。この問題は今回の PR で新たに導入されたわけではありませんが、今回のPRによって認証チェックの重要性が増したため、ミドルウェアが実質的にトークン形状チェックしか行っていないことを把握した上で、`/api/auth/refresh` などのルートハンドラ側でサーバーサイドの署名検証が必ず行われているかを確認してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix authentication bypass in API rout..."](https://github.com/hiroki-org/paper-tools/commit/347b7474aa0139941aa125987d18c6ae07782870) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476804)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->