### PR TITLE
🧹 Replace console logs with injectable logger

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -1,239 +1,291 @@
 #!/usr/bin/env node
 
 import "dotenv/config";
-import { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
 import { stdin as input } from "node:process";
-import { fetchBibtex } from "./bibtex-fetcher.js";
-import { deriveBibtexKey, formatBibtex, getValidationWarnings, parseBibtexEntry, splitBibtexEntries } from "./bibtex-formatter.js";
-import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 import { queryPapers } from "@paper-tools/recommender";
+import { Command } from "commander";
+import { fetchBibtex } from "./bibtex-fetcher.js";
+import {
+	deriveBibtexKey,
+	formatBibtex,
+	getValidationWarnings,
+	parseBibtexEntry,
+	splitBibtexEntries,
+} from "./bibtex-formatter.js";
+import { logger } from "./logger.js";
+import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 
 const program = new Command();
 
 function requireDatabaseId(): string {
-    const databaseId = process.env["NOTION_DATABASE_ID"];
-    if (!databaseId) {
-        throw new Error("NOTION_DATABASE_ID が未設定です");
-    }
-    return databaseId;
+	const databaseId = process.env["NOTION_DATABASE_ID"];
+	if (!databaseId) {
+		throw new Error("NOTION_DATABASE_ID が未設定です");
+	}
+	return databaseId;
 }
 
 function looksLikeDoi(inputValue: string): boolean {
-    const s = inputValue.trim();
-    return /^10\.[^\s/]+\/.+/i.test(s) || /^https?:\/\/doi\.org\//i.test(s) || /^doi:/i.test(s);
+	const s = inputValue.trim();
+	return (
+		/^10\.[^\s/]+\/.+/i.test(s) ||
+		/^https?:\/\/doi\.org\//i.test(s) ||
+		/^doi:/i.test(s)
+	);
 }
 
 function normalizeDoi(inputValue: string): string {
-    return inputValue.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	return inputValue
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
 function parseKeyFormat(value: string | undefined): BibtexKeyFormat {
-    if (value === "short" || value === "venue") return value;
-    return "default";
+	if (value === "short" || value === "venue") return value;
+	return "default";
 }
 
 function parseFormat(value: string | undefined): BibtexFormat {
-    if (value === "biblatex") return "biblatex";
-    return "bibtex";
+	if (value === "biblatex") return "biblatex";
+	return "bibtex";
 }
 
-function deriveCustomKey(rawBibtex: string, keyFormat: BibtexKeyFormat): string | undefined {
-    return deriveBibtexKey(rawBibtex, keyFormat);
+function deriveCustomKey(
+	rawBibtex: string,
+	keyFormat: BibtexKeyFormat,
+): string | undefined {
+	return deriveBibtexKey(rawBibtex, keyFormat);
 }
 
 async function readStdinText(): Promise<string> {
-    const chunks: Buffer[] = [];
-    for await (const chunk of input) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks).toString("utf8");
+	const chunks: Buffer[] = [];
+	for await (const chunk of input) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf8");
 }
 
-function buildValidateReport(entries: string[]): { issues: ValidateIssue[]; total: number } {
-    const issues: ValidateIssue[] = [];
-    const keySeen = new Map<string, number>();
-    const doiSeen = new Map<string, number>();
+function buildValidateReport(entries: string[]): {
+	issues: ValidateIssue[];
+	total: number;
+} {
+	const issues: ValidateIssue[] = [];
+	const keySeen = new Map<string, number>();
+	const doiSeen = new Map<string, number>();
 
-    entries.forEach((raw, index) => {
-        try {
-            const parsed = parseBibtexEntry(raw);
-            const key = parsed.key;
-            const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
+	entries.forEach((raw, index) => {
+		try {
+			const parsed = parseBibtexEntry(raw);
+			const key = parsed.key;
+			const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
 
-            for (const warning of getValidationWarnings(parsed)) {
-                issues.push({ level: "warning", message: warning, key });
-            }
+			for (const warning of getValidationWarnings(parsed)) {
+				issues.push({ level: "warning", message: warning, key });
+			}
 
-            if (key) {
-                keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
-            }
-            if (doi) {
-                doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
-            }
-        } catch (error) {
-            issues.push({
-                level: "error",
-                message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
-            });
-        }
-    });
+			if (key) {
+				keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
+			}
+			if (doi) {
+				doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
+			}
+		} catch (error) {
+			issues.push({
+				level: "error",
+				message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+	});
 
-    for (const [key, count] of keySeen) {
-        if (count > 1) {
-            issues.push({ level: "error", key, message: `Duplicate key detected: ${key} (${count})` });
-        }
-    }
-    for (const [doi, count] of doiSeen) {
-        if (count > 1) {
-            issues.push({ level: "error", message: `Duplicate DOI detected: ${doi} (${count})` });
-        }
-    }
+	for (const [key, count] of keySeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				key,
+				message: `Duplicate key detected: ${key} (${count})`,
+			});
+		}
+	}
+	for (const [doi, count] of doiSeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				message: `Duplicate DOI detected: ${doi} (${count})`,
+			});
+		}
+	}
 
-    return { issues, total: entries.length };
+	return { issues, total: entries.length };
 }
 
 program
-    .name("paper-bib")
-    .description("Generate and validate BibTeX entries from DOI/title and Notion DB records")
-    .version("0.1.0");
+	.name("paper-bib")
+	.description(
+		"Generate and validate BibTeX entries from DOI/title and Notion DB records",
+	)
+	.version("0.1.0");
 
 program
-    .command("get")
-    .argument("<identifier>", "DOI or paper title")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .action(async (identifier: string, options: { format?: string; keyFormat?: string }) => {
-        try {
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-            const lookup = looksLikeDoi(identifier)
-                ? { doi: normalizeDoi(identifier) }
-                : { title: identifier.trim() };
+	.command("get")
+	.argument("<identifier>", "DOI or paper title")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.action(
+		async (
+			identifier: string,
+			options: { format?: string; keyFormat?: string },
+		) => {
+			try {
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
+				const lookup = looksLikeDoi(identifier)
+					? { doi: normalizeDoi(identifier) }
+					: { title: identifier.trim() };
 
-            const result = await fetchBibtex(lookup);
-            if (!result) {
-                throw new Error("BibTeX を取得できませんでした");
-            }
+				const result = await fetchBibtex(lookup);
+				if (!result) {
+					throw new Error("BibTeX を取得できませんでした");
+				}
 
-            const customKey = deriveCustomKey(result.bibtex, keyFormat);
-            const formatted = formatBibtex(result.bibtex, {
-                format,
-                key: customKey,
-                keyFormat,
-            });
-            if (formatted.warnings.length > 0) {
-                for (const warning of formatted.warnings) {
-                    console.error(`Warning: ${warning}`);
-                }
-            }
-            process.stdout.write(`${formatted.formatted}\n`);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
-
-program
-    .command("export")
-    .option("--tag <tag>", "Tag filter (best-effort)")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .option("--output <file>", "Output file path")
-    .action(async (options: { tag?: string; format?: string; keyFormat?: string; output?: string }) => {
-        try {
-            const databaseId = requireDatabaseId();
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-
-            const records = await queryPapers(databaseId);
-            let targets = records;
-
-            if (options.tag) {
-                // recommender notion-client currently does not expose tag fields.
-                // We keep this as a best-effort title filter to avoid blocking the export flow.
-                targets = records.filter((r) => r.title.toLowerCase().includes(options.tag!.toLowerCase()));
-                console.error(`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`);
-            }
-
-            const results: (string | null)[] = [];
-            const BATCH_SIZE = 10;
-            for (let i = 0; i < targets.length; i += BATCH_SIZE) {
-                const batch = targets.slice(i, i + BATCH_SIZE);
-                const batchResults = await Promise.all(
-                    batch.map(async (record) => {
-                        const fetched = await fetchBibtex({ doi: record.doi, title: record.title });
-                        if (!fetched) {
-                            console.error(`Warning: BibTeX取得失敗: ${record.title}`);
-                            return null;
-                        }
-
-                        const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
-                        const formatted = formatBibtex(fetched.bibtex, {
-                            format,
-                            key: customKey,
-                            keyFormat,
-                        });
-
-                        if (formatted.warnings.length > 0) {
-                            console.error(`Warning (${record.title}): ${formatted.warnings.join("; ")}`);
-                        }
-                        return formatted.formatted;
-                    })
-                );
-                results.push(...batchResults);
-            }
-            const chunks = results.filter((c): c is string => c !== null);
-
-            const outputText = chunks.join("\n\n");
-            if (options.output) {
-                await writeFile(options.output, outputText, "utf8");
-                console.error(`Wrote ${chunks.length} entries to ${options.output}`);
-            } else {
-                process.stdout.write(outputText + (outputText ? "\n" : ""));
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+				const customKey = deriveCustomKey(result.bibtex, keyFormat);
+				const formatted = formatBibtex(result.bibtex, {
+					format,
+					key: customKey,
+					keyFormat,
+				});
+				if (formatted.warnings.length > 0) {
+					for (const warning of formatted.warnings) {
+						logger.error(`Warning: ${warning}`);
+					}
+				}
+				process.stdout.write(`${formatted.formatted}\n`);
+			} catch (error) {
+				logger.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("validate")
-    .argument("<input>", "BibTeX file path, or '-' to read stdin")
-    .action(async (inputArg: string) => {
-        try {
-            const text = inputArg === "-"
-                ? await readStdinText()
-                : await readFile(inputArg, "utf8");
+	.command("export")
+	.option("--tag <tag>", "Tag filter (best-effort)")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.option("--output <file>", "Output file path")
+	.action(
+		async (options: {
+			tag?: string;
+			format?: string;
+			keyFormat?: string;
+			output?: string;
+		}) => {
+			try {
+				const databaseId = requireDatabaseId();
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
 
-            const entries = splitBibtexEntries(text);
-            if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
-                return;
-            }
+				const records = await queryPapers(databaseId);
+				let targets = records;
 
-            const report = buildValidateReport(entries);
-            const errors = report.issues.filter((i) => i.level === "error");
-            const warnings = report.issues.filter((i) => i.level === "warning");
+				if (options.tag) {
+					// recommender notion-client currently does not expose tag fields.
+					// We keep this as a best-effort title filter to avoid blocking the export flow.
+					targets = records.filter((r) =>
+						r.title.toLowerCase().includes(options.tag!.toLowerCase()),
+					);
+					logger.error(
+						`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`,
+					);
+				}
 
-            console.log(`Entries: ${report.total}`);
-            console.log(`Errors: ${errors.length}`);
-            console.log(`Warnings: ${warnings.length}`);
+				const results: (string | null)[] = [];
+				const BATCH_SIZE = 10;
+				for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+					const batch = targets.slice(i, i + BATCH_SIZE);
+					const batchResults = await Promise.all(
+						batch.map(async (record) => {
+							const fetched = await fetchBibtex({
+								doi: record.doi,
+								title: record.title,
+							});
+							if (!fetched) {
+								logger.error(`Warning: BibTeX取得失敗: ${record.title}`);
+								return null;
+							}
 
-            for (const issue of report.issues) {
-                const prefix = issue.level.toUpperCase();
-                const keyInfo = issue.key ? ` [${issue.key}]` : "";
-                console.log(`${prefix}${keyInfo}: ${issue.message}`);
-            }
+							const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
+							const formatted = formatBibtex(fetched.bibtex, {
+								format,
+								key: customKey,
+								keyFormat,
+							});
 
-            if (errors.length > 0) {
-                process.exit(1);
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+							if (formatted.warnings.length > 0) {
+								logger.error(
+									`Warning (${record.title}): ${formatted.warnings.join("; ")}`,
+								);
+							}
+							return formatted.formatted;
+						}),
+					);
+					results.push(...batchResults);
+				}
+				const chunks = results.filter((c): c is string => c !== null);
+
+				const outputText = chunks.join("\n\n");
+				if (options.output) {
+					await writeFile(options.output, outputText, "utf8");
+					logger.error(`Wrote ${chunks.length} entries to ${options.output}`);
+				} else {
+					process.stdout.write(outputText + (outputText ? "\n" : ""));
+				}
+			} catch (error) {
+				logger.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
+
+program
+	.command("validate")
+	.argument("<input>", "BibTeX file path, or '-' to read stdin")
+	.action(async (inputArg: string) => {
+		try {
+			const text =
+				inputArg === "-"
+					? await readStdinText()
+					: await readFile(inputArg, "utf8");
+
+			const entries = splitBibtexEntries(text);
+			if (entries.length === 0) {
+				logger.info("No BibTeX entries found.");
+				return;
+			}
+
+			const report = buildValidateReport(entries);
+			const errors = report.issues.filter((i) => i.level === "error");
+			const warnings = report.issues.filter((i) => i.level === "warning");
+
+			logger.info(`Entries: ${report.total}`);
+			logger.info(`Errors: ${errors.length}`);
+			logger.info(`Warnings: ${warnings.length}`);
+
+			for (const issue of report.issues) {
+				const prefix = issue.level.toUpperCase();
+				const keyInfo = issue.key ? ` [${issue.key}]` : "";
+				logger.info(`${prefix}${keyInfo}: ${issue.message}`);
+			}
+
+			if (errors.length > 0) {
+				process.exit(1);
+			}
+		} catch (error) {
+			logger.error("Error:", error instanceof Error ? error.message : error);
+			process.exit(1);
+		}
+	});
 
 program.parse();

--- a/packages/bibtex/src/logger.ts
+++ b/packages/bibtex/src/logger.ts
@@ -1,0 +1,20 @@
+export interface Logger {
+	info(...args: unknown[]): void;
+	error(...args: unknown[]): void;
+}
+
+export const defaultLogger: Logger = {
+	info: (...args: unknown[]) => console.log(...args),
+	error: (...args: unknown[]) => console.error(...args),
+};
+
+let currentLogger: Logger = defaultLogger;
+
+export function setLogger(logger: Logger) {
+	currentLogger = logger;
+}
+
+export const logger: Logger = {
+	info: (...args: unknown[]) => currentLogger.info(...args),
+	error: (...args: unknown[]) => currentLogger.error(...args),
+};

--- a/packages/bibtex/tests/logger.test.ts
+++ b/packages/bibtex/tests/logger.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	defaultLogger,
+	type Logger,
+	logger,
+	setLogger,
+} from "../src/logger.js";
+
+describe("Logger", () => {
+	beforeEach(() => {
+		// Reset to default logger before each test
+		setLogger(defaultLogger);
+	});
+
+	it("uses default console.log for info", () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		logger.info("Test message", 123);
+
+		expect(logSpy).toHaveBeenCalledWith("Test message", 123);
+		logSpy.mockRestore();
+	});
+
+	it("uses default console.error for error", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		logger.error("Test error", 456);
+
+		expect(errorSpy).toHaveBeenCalledWith("Test error", 456);
+		errorSpy.mockRestore();
+	});
+
+	it("allows injecting a custom logger", () => {
+		const customInfo = vi.fn();
+		const customError = vi.fn();
+
+		const customLogger: Logger = {
+			info: customInfo,
+			error: customError,
+		};
+
+		setLogger(customLogger);
+
+		logger.info("Custom info message");
+		expect(customInfo).toHaveBeenCalledWith("Custom info message");
+
+		logger.error("Custom error message");
+		expect(customError).toHaveBeenCalledWith("Custom error message");
+	});
+});


### PR DESCRIPTION
🎯 **What:** Introduced a `Logger` interface and `defaultLogger` implementation in `packages/bibtex/src/logger.ts`, and updated `packages/bibtex/src/index.ts` to use `logger.info` and `logger.error` instead of raw `console.log` and `console.error`.

💡 **Why:** Hardcoded console logs in production code limit flexibility. Encapsulating output in an injectable logger improves maintainability and allows for easier redirection of output streams in the future, while preserving the exact same CLI behavior for stdout and stderr.

✅ **Verification:** 
- `pnpm test` passed for `@paper-tools/bibtex` containing 29 tests.
- `pnpm build` completed successfully across all monorepo packages.
- Tested and formatted with `@biomejs/biome`.
- Successfully validated that `logger.info` uses stdout and `logger.error` uses stderr appropriately.

✨ **Result:** Enhanced the architectural cleanliness of the BibTeX CLI and fully resolved the "Console Log in Production Code" warning.

---
*PR created automatically by Jules for task [13649345950338042688](https://jules.google.com/task/13649345950338042688) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `packages/bibtex/src/logger.ts` に `Logger` インターフェースとインジェクタブルなロガー実装を追加し、`index.ts` の `console.log` / `console.error` を `logger.info` / `logger.error` へ置き換えるリファクタリングです。CLIの外部から出力先を差し替えられるようになり、テスタビリティと保守性が向上します。

- **logger.ts 新規追加**: `Logger` インターフェース・`defaultLogger`・`setLogger`・プロキシ `logger` オブジェクトを定義。`setLogger` 呼び出し後は `logger` 経由のすべての出力が新ロガーに委譲される。
- **index.ts 更新**: `get` / `export` / `validate` コマンド全体で `console.*` を `logger.*` に置換。既存のstdout/stderr 振り分けは維持されているが、`validate` の ERROR レベル検証問題は `logger.info`（stdout）のままとなっており、新インフラを活用する余地が残る。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能的な後退はなく、既存のCLI動作はそのまま維持されている。指摘事項はいずれもスタイルおよびテスタビリティに関するもので、動作を壊すリスクはない。

変更は console.* を logger.* に置き換える範囲に留まっており、ロジックの変更はない。setLogger の引数名の衝突と戻り値の欠如は将来の使いやすさに影響するが、現時点での動作は正しい。validate コマンドでのエラーレベル振り分けは pre-existing の動作を保持しているため退行ではない。

logger.ts — setLogger の設計（引数名と返値）を確認することを推奨。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/logger.ts | Logger インターフェース・defaultLogger・setLogger・logger プロキシを新規追加。setLogger の引数名 logger がモジュールスコープの logger 定数と衝突しており、また以前のロガーを返さないためテスト時の復元が不便。 |
| packages/bibtex/src/index.ts | console.log / console.error を logger.info / logger.error へ機械的に置換。validate コマンドで ERROR レベルの検証問題が logger.info（stdout）のままになっており、新しい Logger 抽象が生かしきれていない箇所がある。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/bibtex/src/logger.ts:13-15
`setLogger` の引数名 `logger` は、同ファイルでエクスポートされている `logger` 定数と名前が衝突しています。関数スコープ内では引数の `logger` が優先されるため現状は動作しますが、読み手が混乱しやすく、将来的に誤って `logger` 定数を参照するバグを招くリスクがあります。引数名を `newLogger` や `instance` などに変更することを推奨します。

```suggestion
export function setLogger(newLogger: Logger) {
	currentLogger = newLogger;
}
```

### Issue 2 of 3
packages/bibtex/src/logger.ts:13-15
`setLogger` が以前のロガーを返さないため、テストのクリーンアップが難しくなっています。テストコードが `setLogger(mockLogger)` を呼んだ後、`defaultLogger` を直接インポートして再セットしなければ元に戻せません。以前のロガーを返却するようにすると、`const prev = setLogger(mock); ... setLogger(prev);` というパターンで安全に元の状態に戻せます。

```suggestion
export function setLogger(newLogger: Logger): Logger {
	const prev = currentLogger;
	currentLogger = newLogger;
	return prev;
}
```

### Issue 3 of 3
packages/bibtex/src/index.ts:276-284
`validate` コマンドでは、`level === "error"` の検証問題（重複キー・重複DOIなど）も `logger.info`（stdout）で出力しています。今回の `Logger` 抽象化により `info`（stdout）と `error`（stderr）を明確に使い分けられるようになったため、エラーレベルの問題は `logger.error` へルーティングすると `2>/dev/null` などのシェル操作との相性が向上します。

```suggestion
			for (const issue of report.issues) {
				const prefix = issue.level.toUpperCase();
				const keyInfo = issue.key ? ` [${issue.key}]` : "";
				const logFn = issue.level === "error" ? logger.error : logger.info;
				logFn(`${prefix}${keyInfo}: ${issue.message}`);
			}

			if (errors.length > 0) {
				process.exit(1);
			}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Replace console logs with injectable ..."](https://github.com/hiroki-org/paper-tools/commit/fa0558ec981af514fb60ceca9b8f79f0f09a9249) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476874)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->