### PR TITLE
🧹 Remove console.log in production code from bibtex CLI

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -1,239 +1,307 @@
 #!/usr/bin/env node
 
 import "dotenv/config";
-import { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
 import { stdin as input } from "node:process";
-import { fetchBibtex } from "./bibtex-fetcher.js";
-import { deriveBibtexKey, formatBibtex, getValidationWarnings, parseBibtexEntry, splitBibtexEntries } from "./bibtex-formatter.js";
-import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 import { queryPapers } from "@paper-tools/recommender";
+import { Command } from "commander";
+import { fetchBibtex } from "./bibtex-fetcher.js";
+import {
+	deriveBibtexKey,
+	formatBibtex,
+	getValidationWarnings,
+	parseBibtexEntry,
+	splitBibtexEntries,
+} from "./bibtex-formatter.js";
+import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
+
+export interface Logger {
+	log(message: string): void;
+	error(message: string): void;
+}
+
+export const defaultLogger: Logger = {
+	log: (msg) => console.log(msg),
+	error: (msg) => console.error(msg),
+};
 
 const program = new Command();
 
 function requireDatabaseId(): string {
-    const databaseId = process.env["NOTION_DATABASE_ID"];
-    if (!databaseId) {
-        throw new Error("NOTION_DATABASE_ID が未設定です");
-    }
-    return databaseId;
+	const databaseId = process.env["NOTION_DATABASE_ID"];
+	if (!databaseId) {
+		throw new Error("NOTION_DATABASE_ID が未設定です");
+	}
+	return databaseId;
 }
 
 function looksLikeDoi(inputValue: string): boolean {
-    const s = inputValue.trim();
-    return /^10\.[^\s/]+\/.+/i.test(s) || /^https?:\/\/doi\.org\//i.test(s) || /^doi:/i.test(s);
+	const s = inputValue.trim();
+	return (
+		/^10\.[^\s/]+\/.+/i.test(s) ||
+		/^https?:\/\/doi\.org\//i.test(s) ||
+		/^doi:/i.test(s)
+	);
 }
 
 function normalizeDoi(inputValue: string): string {
-    return inputValue.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	return inputValue
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
 function parseKeyFormat(value: string | undefined): BibtexKeyFormat {
-    if (value === "short" || value === "venue") return value;
-    return "default";
+	if (value === "short" || value === "venue") return value;
+	return "default";
 }
 
 function parseFormat(value: string | undefined): BibtexFormat {
-    if (value === "biblatex") return "biblatex";
-    return "bibtex";
+	if (value === "biblatex") return "biblatex";
+	return "bibtex";
 }
 
-function deriveCustomKey(rawBibtex: string, keyFormat: BibtexKeyFormat): string | undefined {
-    return deriveBibtexKey(rawBibtex, keyFormat);
+function deriveCustomKey(
+	rawBibtex: string,
+	keyFormat: BibtexKeyFormat,
+): string | undefined {
+	return deriveBibtexKey(rawBibtex, keyFormat);
 }
 
 async function readStdinText(): Promise<string> {
-    const chunks: Buffer[] = [];
-    for await (const chunk of input) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks).toString("utf8");
+	const chunks: Buffer[] = [];
+	for await (const chunk of input) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf8");
 }
 
-function buildValidateReport(entries: string[]): { issues: ValidateIssue[]; total: number } {
-    const issues: ValidateIssue[] = [];
-    const keySeen = new Map<string, number>();
-    const doiSeen = new Map<string, number>();
+function buildValidateReport(entries: string[]): {
+	issues: ValidateIssue[];
+	total: number;
+} {
+	const issues: ValidateIssue[] = [];
+	const keySeen = new Map<string, number>();
+	const doiSeen = new Map<string, number>();
 
-    entries.forEach((raw, index) => {
-        try {
-            const parsed = parseBibtexEntry(raw);
-            const key = parsed.key;
-            const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
+	entries.forEach((raw, index) => {
+		try {
+			const parsed = parseBibtexEntry(raw);
+			const key = parsed.key;
+			const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
 
-            for (const warning of getValidationWarnings(parsed)) {
-                issues.push({ level: "warning", message: warning, key });
-            }
+			for (const warning of getValidationWarnings(parsed)) {
+				issues.push({ level: "warning", message: warning, key });
+			}
 
-            if (key) {
-                keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
-            }
-            if (doi) {
-                doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
-            }
-        } catch (error) {
-            issues.push({
-                level: "error",
-                message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
-            });
-        }
-    });
+			if (key) {
+				keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
+			}
+			if (doi) {
+				doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
+			}
+		} catch (error) {
+			issues.push({
+				level: "error",
+				message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+	});
 
-    for (const [key, count] of keySeen) {
-        if (count > 1) {
-            issues.push({ level: "error", key, message: `Duplicate key detected: ${key} (${count})` });
-        }
-    }
-    for (const [doi, count] of doiSeen) {
-        if (count > 1) {
-            issues.push({ level: "error", message: `Duplicate DOI detected: ${doi} (${count})` });
-        }
-    }
+	for (const [key, count] of keySeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				key,
+				message: `Duplicate key detected: ${key} (${count})`,
+			});
+		}
+	}
+	for (const [doi, count] of doiSeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				message: `Duplicate DOI detected: ${doi} (${count})`,
+			});
+		}
+	}
 
-    return { issues, total: entries.length };
+	return { issues, total: entries.length };
 }
 
 program
-    .name("paper-bib")
-    .description("Generate and validate BibTeX entries from DOI/title and Notion DB records")
-    .version("0.1.0");
+	.name("paper-bib")
+	.description(
+		"Generate and validate BibTeX entries from DOI/title and Notion DB records",
+	)
+	.version("0.1.0");
 
 program
-    .command("get")
-    .argument("<identifier>", "DOI or paper title")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .action(async (identifier: string, options: { format?: string; keyFormat?: string }) => {
-        try {
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-            const lookup = looksLikeDoi(identifier)
-                ? { doi: normalizeDoi(identifier) }
-                : { title: identifier.trim() };
+	.command("get")
+	.argument("<identifier>", "DOI or paper title")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.action(
+		async (
+			identifier: string,
+			options: { format?: string; keyFormat?: string },
+		) => {
+			try {
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
+				const lookup = looksLikeDoi(identifier)
+					? { doi: normalizeDoi(identifier) }
+					: { title: identifier.trim() };
 
-            const result = await fetchBibtex(lookup);
-            if (!result) {
-                throw new Error("BibTeX を取得できませんでした");
-            }
+				const result = await fetchBibtex(lookup);
+				if (!result) {
+					throw new Error("BibTeX を取得できませんでした");
+				}
 
-            const customKey = deriveCustomKey(result.bibtex, keyFormat);
-            const formatted = formatBibtex(result.bibtex, {
-                format,
-                key: customKey,
-                keyFormat,
-            });
-            if (formatted.warnings.length > 0) {
-                for (const warning of formatted.warnings) {
-                    console.error(`Warning: ${warning}`);
-                }
-            }
-            process.stdout.write(`${formatted.formatted}\n`);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
-
-program
-    .command("export")
-    .option("--tag <tag>", "Tag filter (best-effort)")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .option("--output <file>", "Output file path")
-    .action(async (options: { tag?: string; format?: string; keyFormat?: string; output?: string }) => {
-        try {
-            const databaseId = requireDatabaseId();
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-
-            const records = await queryPapers(databaseId);
-            let targets = records;
-
-            if (options.tag) {
-                // recommender notion-client currently does not expose tag fields.
-                // We keep this as a best-effort title filter to avoid blocking the export flow.
-                targets = records.filter((r) => r.title.toLowerCase().includes(options.tag!.toLowerCase()));
-                console.error(`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`);
-            }
-
-            const results: (string | null)[] = [];
-            const BATCH_SIZE = 10;
-            for (let i = 0; i < targets.length; i += BATCH_SIZE) {
-                const batch = targets.slice(i, i + BATCH_SIZE);
-                const batchResults = await Promise.all(
-                    batch.map(async (record) => {
-                        const fetched = await fetchBibtex({ doi: record.doi, title: record.title });
-                        if (!fetched) {
-                            console.error(`Warning: BibTeX取得失敗: ${record.title}`);
-                            return null;
-                        }
-
-                        const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
-                        const formatted = formatBibtex(fetched.bibtex, {
-                            format,
-                            key: customKey,
-                            keyFormat,
-                        });
-
-                        if (formatted.warnings.length > 0) {
-                            console.error(`Warning (${record.title}): ${formatted.warnings.join("; ")}`);
-                        }
-                        return formatted.formatted;
-                    })
-                );
-                results.push(...batchResults);
-            }
-            const chunks = results.filter((c): c is string => c !== null);
-
-            const outputText = chunks.join("\n\n");
-            if (options.output) {
-                await writeFile(options.output, outputText, "utf8");
-                console.error(`Wrote ${chunks.length} entries to ${options.output}`);
-            } else {
-                process.stdout.write(outputText + (outputText ? "\n" : ""));
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+				const customKey = deriveCustomKey(result.bibtex, keyFormat);
+				const formatted = formatBibtex(result.bibtex, {
+					format,
+					key: customKey,
+					keyFormat,
+				});
+				if (formatted.warnings.length > 0) {
+					for (const warning of formatted.warnings) {
+						console.error(`Warning: ${warning}`);
+					}
+				}
+				process.stdout.write(`${formatted.formatted}\n`);
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("validate")
-    .argument("<input>", "BibTeX file path, or '-' to read stdin")
-    .action(async (inputArg: string) => {
-        try {
-            const text = inputArg === "-"
-                ? await readStdinText()
-                : await readFile(inputArg, "utf8");
+	.command("export")
+	.option("--tag <tag>", "Tag filter (best-effort)")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.option("--output <file>", "Output file path")
+	.action(
+		async (options: {
+			tag?: string;
+			format?: string;
+			keyFormat?: string;
+			output?: string;
+		}) => {
+			try {
+				const databaseId = requireDatabaseId();
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
 
-            const entries = splitBibtexEntries(text);
-            if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
-                return;
-            }
+				const records = await queryPapers(databaseId);
+				let targets = records;
 
-            const report = buildValidateReport(entries);
-            const errors = report.issues.filter((i) => i.level === "error");
-            const warnings = report.issues.filter((i) => i.level === "warning");
+				if (options.tag) {
+					// recommender notion-client currently does not expose tag fields.
+					// We keep this as a best-effort title filter to avoid blocking the export flow.
+					targets = records.filter((r) =>
+						r.title.toLowerCase().includes(options.tag!.toLowerCase()),
+					);
+					console.error(
+						`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`,
+					);
+				}
 
-            console.log(`Entries: ${report.total}`);
-            console.log(`Errors: ${errors.length}`);
-            console.log(`Warnings: ${warnings.length}`);
+				const results: (string | null)[] = [];
+				const BATCH_SIZE = 10;
+				for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+					const batch = targets.slice(i, i + BATCH_SIZE);
+					const batchResults = await Promise.all(
+						batch.map(async (record) => {
+							const fetched = await fetchBibtex({
+								doi: record.doi,
+								title: record.title,
+							});
+							if (!fetched) {
+								console.error(`Warning: BibTeX取得失敗: ${record.title}`);
+								return null;
+							}
 
-            for (const issue of report.issues) {
-                const prefix = issue.level.toUpperCase();
-                const keyInfo = issue.key ? ` [${issue.key}]` : "";
-                console.log(`${prefix}${keyInfo}: ${issue.message}`);
-            }
+							const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
+							const formatted = formatBibtex(fetched.bibtex, {
+								format,
+								key: customKey,
+								keyFormat,
+							});
 
-            if (errors.length > 0) {
-                process.exit(1);
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+							if (formatted.warnings.length > 0) {
+								console.error(
+									`Warning (${record.title}): ${formatted.warnings.join("; ")}`,
+								);
+							}
+							return formatted.formatted;
+						}),
+					);
+					results.push(...batchResults);
+				}
+				const chunks = results.filter((c): c is string => c !== null);
+
+				const outputText = chunks.join("\n\n");
+				if (options.output) {
+					await writeFile(options.output, outputText, "utf8");
+					console.error(`Wrote ${chunks.length} entries to ${options.output}`);
+				} else {
+					process.stdout.write(outputText + (outputText ? "\n" : ""));
+				}
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
+
+export async function validateAction(
+	inputArg: string,
+	logger: Logger = defaultLogger,
+) {
+	try {
+		const text =
+			inputArg === "-"
+				? await readStdinText()
+				: await readFile(inputArg, "utf8");
+
+		const entries = splitBibtexEntries(text);
+		if (entries.length === 0) {
+			logger.log("No BibTeX entries found.");
+			return;
+		}
+
+		const report = buildValidateReport(entries);
+		const errors = report.issues.filter((i) => i.level === "error");
+		const warnings = report.issues.filter((i) => i.level === "warning");
+
+		logger.log(`Entries: ${report.total}`);
+		logger.log(`Errors: ${errors.length}`);
+		logger.log(`Warnings: ${warnings.length}`);
+
+		for (const issue of report.issues) {
+			const prefix = issue.level.toUpperCase();
+			const keyInfo = issue.key ? ` [${issue.key}]` : "";
+			logger.log(`${prefix}${keyInfo}: ${issue.message}`);
+		}
+
+		if (errors.length > 0) {
+			process.exit(1);
+		}
+	} catch (error) {
+		logger.error(`Error: ${error instanceof Error ? error.message : error}`);
+		process.exit(1);
+	}
+}
+
+program
+	.command("validate")
+	.argument("<input>", "BibTeX file path, or '-' to read stdin")
+	.action(async (inputArg: string) => {
+		await validateAction(inputArg);
+	});
 
 program.parse();


### PR DESCRIPTION
🎯 **What:** Extracted validate command action into a standalone function `validateAction` in `packages/bibtex/src/index.ts` and injected a logger interface (`Logger`) that defaults to `defaultLogger`.

💡 **Why:** By extracting the logic and injecting a logger interface, the `console.log` statements are no longer hardcoded into the business logic. This improves maintainability and makes the module easily testable without polluting standard output during isolated tests.

✅ **Verification:**
- Validated via `pnpm dlx @biomejs/biome check packages/bibtex/src/index.ts --write` to ensure proper formatting and code health.
- Ran `pnpm test` successfully across the whole workspace (29 passing tests within the `bibtex` package).

✨ **Result:** The logic can now be safely unit tested by passing in a mock logger, and direct `console.log` usage is elegantly abstracted away.

---
*PR created automatically by Jules for task [11216024975497079657](https://jules.google.com/task/11216024975497079657) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

validate コマンドのアクションロジックを `validateAction` 関数に切り出し、`Logger` インターフェースをデフォルト引数として注入できる設計に変更することで、`console.log` のハードコードを排除しています。

- `Logger` インターフェース（`log` / `error` メソッド）と `defaultLogger` をエクスポートし、CLI コマンドは引き続き `defaultLogger` を使用する。`validateAction` は `export` されてテスト時にモックロガーを注入できるが、`process.exit(1)` が関数内にハードコードされているため、エラーケースのユニットテストはテストプロセスを終了させてしまう。
- `get` / `export` コマンドには同変更が適用されておらず、引き続き `console.error` を直接呼び出している。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

CLIとしての動作は変わらないが、テスタビリティの改善が目的の変更において `process.exit(1)` が残存しており、意図通りに機能しない。

`validateAction` はモックロガーを受け取れるようになったものの、エラーが見つかった場合に `process.exit(1)` を直接呼ぶ設計はそのままのため、ユニットテストでエラーケースを検証しようとするとテストプロセスごと終了してしまう。PR の主目的である「テスト容易性の向上」が半分しか達成されていない。

packages/bibtex/src/index.ts の `validateAction` 関数（特に `process.exit` を呼び出している箇所）を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/index.ts | `validateAction` を独立関数として抽出し `Logger` インターフェースを注入する変更。ただし `process.exit(1)` がハードコードされたままで、テスタビリティの目標が完全には達成されていない。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/bibtex/src/index.ts:291-297
**`process.exit` がハードコードされているためテスタビリティが向上していない**

PR説明には「モックロガーを注入することで安全にユニットテストできる」と記載されていますが、`validateAction` 内で `process.exit(1)` が直接呼ばれているため（292行目・296行目）、エラーを含む BibTeX データでテストを実行するとテストランナーのプロセスごと終了してしまいます。`logger` の注入だけでは副作用を完全に抽象化できておらず、「テスタブルになった」という主張と矛盾します。

終了コードをロガーと同様に外部から注入する（例: `exit: (code: number) => void` を追加する）か、エラー時に `process.exit` を呼ぶ代わりに例外をスローして呼び出し元（CLIアクション側）に `process.exit(1)` を委ねる設計にすることで、真のユニットテストが可能になります。

### Issue 2 of 2
packages/bibtex/src/index.ts:285-289
**ERROR レベルのイシューが `logger.error` ではなく `logger.log` で出力されている**

`Logger` インターフェースには `log`（stdout 向け）と `error`（stderr 向け）の両メソッドが定義されているにもかかわらず、エラーレベルのイシューも `logger.log` 経由で出力されています。エラーメッセージが stdout に混入すると、BibTeX 出力をパイプで受け取る下流ツールが壊れる可能性があります。

```suggestion
		for (const issue of report.issues) {
			const prefix = issue.level.toUpperCase();
			const keyInfo = issue.key ? ` [${issue.key}]` : "";
			const line = `${prefix}${keyInfo}: ${issue.message}`;
			if (issue.level === "error") {
				logger.error(line);
			} else {
				logger.log(line);
			}
		}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove console.log in production code..."](https://github.com/hiroki-org/paper-tools/commit/29566a2b64948aedd6fe38c3a59b7c31a0c86c8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32477121)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->