### PR TITLE
🧹 Extract console logging to injectable logger in bibtex package

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -1,239 +1,302 @@
 #!/usr/bin/env node
 
 import "dotenv/config";
-import { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
 import { stdin as input } from "node:process";
-import { fetchBibtex } from "./bibtex-fetcher.js";
-import { deriveBibtexKey, formatBibtex, getValidationWarnings, parseBibtexEntry, splitBibtexEntries } from "./bibtex-formatter.js";
-import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 import { queryPapers } from "@paper-tools/recommender";
+import { Command } from "commander";
+import { fetchBibtex } from "./bibtex-fetcher.js";
+import {
+	deriveBibtexKey,
+	formatBibtex,
+	getValidationWarnings,
+	parseBibtexEntry,
+	splitBibtexEntries,
+} from "./bibtex-formatter.js";
+import { defaultLogger } from "./logger.js";
+import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 
 const program = new Command();
 
 function requireDatabaseId(): string {
-    const databaseId = process.env["NOTION_DATABASE_ID"];
-    if (!databaseId) {
-        throw new Error("NOTION_DATABASE_ID が未設定です");
-    }
-    return databaseId;
+	const databaseId = process.env["NOTION_DATABASE_ID"];
+	if (!databaseId) {
+		throw new Error("NOTION_DATABASE_ID が未設定です");
+	}
+	return databaseId;
 }
 
 function looksLikeDoi(inputValue: string): boolean {
-    const s = inputValue.trim();
-    return /^10\.[^\s/]+\/.+/i.test(s) || /^https?:\/\/doi\.org\//i.test(s) || /^doi:/i.test(s);
+	const s = inputValue.trim();
+	return (
+		/^10\.[^\s/]+\/.+/i.test(s) ||
+		/^https?:\/\/doi\.org\//i.test(s) ||
+		/^doi:/i.test(s)
+	);
 }
 
 function normalizeDoi(inputValue: string): string {
-    return inputValue.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	return inputValue
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
 function parseKeyFormat(value: string | undefined): BibtexKeyFormat {
-    if (value === "short" || value === "venue") return value;
-    return "default";
+	if (value === "short" || value === "venue") return value;
+	return "default";
 }
 
 function parseFormat(value: string | undefined): BibtexFormat {
-    if (value === "biblatex") return "biblatex";
-    return "bibtex";
+	if (value === "biblatex") return "biblatex";
+	return "bibtex";
 }
 
-function deriveCustomKey(rawBibtex: string, keyFormat: BibtexKeyFormat): string | undefined {
-    return deriveBibtexKey(rawBibtex, keyFormat);
+function deriveCustomKey(
+	rawBibtex: string,
+	keyFormat: BibtexKeyFormat,
+): string | undefined {
+	return deriveBibtexKey(rawBibtex, keyFormat);
 }
 
 async function readStdinText(): Promise<string> {
-    const chunks: Buffer[] = [];
-    for await (const chunk of input) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks).toString("utf8");
+	const chunks: Buffer[] = [];
+	for await (const chunk of input) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf8");
 }
 
-function buildValidateReport(entries: string[]): { issues: ValidateIssue[]; total: number } {
-    const issues: ValidateIssue[] = [];
-    const keySeen = new Map<string, number>();
-    const doiSeen = new Map<string, number>();
+function buildValidateReport(entries: string[]): {
+	issues: ValidateIssue[];
+	total: number;
+} {
+	const issues: ValidateIssue[] = [];
+	const keySeen = new Map<string, number>();
+	const doiSeen = new Map<string, number>();
 
-    entries.forEach((raw, index) => {
-        try {
-            const parsed = parseBibtexEntry(raw);
-            const key = parsed.key;
-            const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
+	entries.forEach((raw, index) => {
+		try {
+			const parsed = parseBibtexEntry(raw);
+			const key = parsed.key;
+			const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
 
-            for (const warning of getValidationWarnings(parsed)) {
-                issues.push({ level: "warning", message: warning, key });
-            }
+			for (const warning of getValidationWarnings(parsed)) {
+				issues.push({ level: "warning", message: warning, key });
+			}
 
-            if (key) {
-                keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
-            }
-            if (doi) {
-                doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
-            }
-        } catch (error) {
-            issues.push({
-                level: "error",
-                message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
-            });
-        }
-    });
+			if (key) {
+				keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
+			}
+			if (doi) {
+				doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
+			}
+		} catch (error) {
+			issues.push({
+				level: "error",
+				message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+	});
 
-    for (const [key, count] of keySeen) {
-        if (count > 1) {
-            issues.push({ level: "error", key, message: `Duplicate key detected: ${key} (${count})` });
-        }
-    }
-    for (const [doi, count] of doiSeen) {
-        if (count > 1) {
-            issues.push({ level: "error", message: `Duplicate DOI detected: ${doi} (${count})` });
-        }
-    }
+	for (const [key, count] of keySeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				key,
+				message: `Duplicate key detected: ${key} (${count})`,
+			});
+		}
+	}
+	for (const [doi, count] of doiSeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				message: `Duplicate DOI detected: ${doi} (${count})`,
+			});
+		}
+	}
 
-    return { issues, total: entries.length };
+	return { issues, total: entries.length };
 }
 
 program
-    .name("paper-bib")
-    .description("Generate and validate BibTeX entries from DOI/title and Notion DB records")
-    .version("0.1.0");
+	.name("paper-bib")
+	.description(
+		"Generate and validate BibTeX entries from DOI/title and Notion DB records",
+	)
+	.version("0.1.0");
 
 program
-    .command("get")
-    .argument("<identifier>", "DOI or paper title")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .action(async (identifier: string, options: { format?: string; keyFormat?: string }) => {
-        try {
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-            const lookup = looksLikeDoi(identifier)
-                ? { doi: normalizeDoi(identifier) }
-                : { title: identifier.trim() };
+	.command("get")
+	.argument("<identifier>", "DOI or paper title")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.action(
+		async (
+			identifier: string,
+			options: { format?: string; keyFormat?: string },
+		) => {
+			try {
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
+				const lookup = looksLikeDoi(identifier)
+					? { doi: normalizeDoi(identifier) }
+					: { title: identifier.trim() };
 
-            const result = await fetchBibtex(lookup);
-            if (!result) {
-                throw new Error("BibTeX を取得できませんでした");
-            }
+				const result = await fetchBibtex(lookup);
+				if (!result) {
+					throw new Error("BibTeX を取得できませんでした");
+				}
 
-            const customKey = deriveCustomKey(result.bibtex, keyFormat);
-            const formatted = formatBibtex(result.bibtex, {
-                format,
-                key: customKey,
-                keyFormat,
-            });
-            if (formatted.warnings.length > 0) {
-                for (const warning of formatted.warnings) {
-                    console.error(`Warning: ${warning}`);
-                }
-            }
-            process.stdout.write(`${formatted.formatted}\n`);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
-
-program
-    .command("export")
-    .option("--tag <tag>", "Tag filter (best-effort)")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .option("--output <file>", "Output file path")
-    .action(async (options: { tag?: string; format?: string; keyFormat?: string; output?: string }) => {
-        try {
-            const databaseId = requireDatabaseId();
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-
-            const records = await queryPapers(databaseId);
-            let targets = records;
-
-            if (options.tag) {
-                // recommender notion-client currently does not expose tag fields.
-                // We keep this as a best-effort title filter to avoid blocking the export flow.
-                targets = records.filter((r) => r.title.toLowerCase().includes(options.tag!.toLowerCase()));
-                console.error(`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`);
-            }
-
-            const results: (string | null)[] = [];
-            const BATCH_SIZE = 10;
-            for (let i = 0; i < targets.length; i += BATCH_SIZE) {
-                const batch = targets.slice(i, i + BATCH_SIZE);
-                const batchResults = await Promise.all(
-                    batch.map(async (record) => {
-                        const fetched = await fetchBibtex({ doi: record.doi, title: record.title });
-                        if (!fetched) {
-                            console.error(`Warning: BibTeX取得失敗: ${record.title}`);
-                            return null;
-                        }
-
-                        const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
-                        const formatted = formatBibtex(fetched.bibtex, {
-                            format,
-                            key: customKey,
-                            keyFormat,
-                        });
-
-                        if (formatted.warnings.length > 0) {
-                            console.error(`Warning (${record.title}): ${formatted.warnings.join("; ")}`);
-                        }
-                        return formatted.formatted;
-                    })
-                );
-                results.push(...batchResults);
-            }
-            const chunks = results.filter((c): c is string => c !== null);
-
-            const outputText = chunks.join("\n\n");
-            if (options.output) {
-                await writeFile(options.output, outputText, "utf8");
-                console.error(`Wrote ${chunks.length} entries to ${options.output}`);
-            } else {
-                process.stdout.write(outputText + (outputText ? "\n" : ""));
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+				const customKey = deriveCustomKey(result.bibtex, keyFormat);
+				const formatted = formatBibtex(result.bibtex, {
+					format,
+					key: customKey,
+					keyFormat,
+				});
+				if (formatted.warnings.length > 0) {
+					for (const warning of formatted.warnings) {
+						defaultLogger.error(`Warning: ${warning}`);
+					}
+				}
+				process.stdout.write(`${formatted.formatted}\n`);
+			} catch (error) {
+				defaultLogger.error(
+					"Error:",
+					error instanceof Error ? error.message : error,
+				);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("validate")
-    .argument("<input>", "BibTeX file path, or '-' to read stdin")
-    .action(async (inputArg: string) => {
-        try {
-            const text = inputArg === "-"
-                ? await readStdinText()
-                : await readFile(inputArg, "utf8");
+	.command("export")
+	.option("--tag <tag>", "Tag filter (best-effort)")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.option("--output <file>", "Output file path")
+	.action(
+		async (options: {
+			tag?: string;
+			format?: string;
+			keyFormat?: string;
+			output?: string;
+		}) => {
+			try {
+				const databaseId = requireDatabaseId();
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
 
-            const entries = splitBibtexEntries(text);
-            if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
-                return;
-            }
+				const records = await queryPapers(databaseId);
+				let targets = records;
 
-            const report = buildValidateReport(entries);
-            const errors = report.issues.filter((i) => i.level === "error");
-            const warnings = report.issues.filter((i) => i.level === "warning");
+				if (options.tag) {
+					// recommender notion-client currently does not expose tag fields.
+					// We keep this as a best-effort title filter to avoid blocking the export flow.
+					targets = records.filter((r) =>
+						r.title.toLowerCase().includes(options.tag!.toLowerCase()),
+					);
+					defaultLogger.error(
+						`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`,
+					);
+				}
 
-            console.log(`Entries: ${report.total}`);
-            console.log(`Errors: ${errors.length}`);
-            console.log(`Warnings: ${warnings.length}`);
+				const results: (string | null)[] = [];
+				const BATCH_SIZE = 10;
+				for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+					const batch = targets.slice(i, i + BATCH_SIZE);
+					const batchResults = await Promise.all(
+						batch.map(async (record) => {
+							const fetched = await fetchBibtex({
+								doi: record.doi,
+								title: record.title,
+							});
+							if (!fetched) {
+								defaultLogger.error(`Warning: BibTeX取得失敗: ${record.title}`);
+								return null;
+							}
 
-            for (const issue of report.issues) {
-                const prefix = issue.level.toUpperCase();
-                const keyInfo = issue.key ? ` [${issue.key}]` : "";
-                console.log(`${prefix}${keyInfo}: ${issue.message}`);
-            }
+							const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
+							const formatted = formatBibtex(fetched.bibtex, {
+								format,
+								key: customKey,
+								keyFormat,
+							});
 
-            if (errors.length > 0) {
-                process.exit(1);
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+							if (formatted.warnings.length > 0) {
+								defaultLogger.error(
+									`Warning (${record.title}): ${formatted.warnings.join("; ")}`,
+								);
+							}
+							return formatted.formatted;
+						}),
+					);
+					results.push(...batchResults);
+				}
+				const chunks = results.filter((c): c is string => c !== null);
+
+				const outputText = chunks.join("\n\n");
+				if (options.output) {
+					await writeFile(options.output, outputText, "utf8");
+					defaultLogger.error(
+						`Wrote ${chunks.length} entries to ${options.output}`,
+					);
+				} else {
+					process.stdout.write(outputText + (outputText ? "\n" : ""));
+				}
+			} catch (error) {
+				defaultLogger.error(
+					"Error:",
+					error instanceof Error ? error.message : error,
+				);
+				process.exit(1);
+			}
+		},
+	);
+
+program
+	.command("validate")
+	.argument("<input>", "BibTeX file path, or '-' to read stdin")
+	.action(async (inputArg: string) => {
+		try {
+			const text =
+				inputArg === "-"
+					? await readStdinText()
+					: await readFile(inputArg, "utf8");
+
+			const entries = splitBibtexEntries(text);
+			if (entries.length === 0) {
+				defaultLogger.info("No BibTeX entries found.");
+				return;
+			}
+
+			const report = buildValidateReport(entries);
+			const errors = report.issues.filter((i) => i.level === "error");
+			const warnings = report.issues.filter((i) => i.level === "warning");
+
+			defaultLogger.info(`Entries: ${report.total}`);
+			defaultLogger.info(`Errors: ${errors.length}`);
+			defaultLogger.info(`Warnings: ${warnings.length}`);
+
+			for (const issue of report.issues) {
+				const prefix = issue.level.toUpperCase();
+				const keyInfo = issue.key ? ` [${issue.key}]` : "";
+				defaultLogger.info(`${prefix}${keyInfo}: ${issue.message}`);
+			}
+
+			if (errors.length > 0) {
+				process.exit(1);
+			}
+		} catch (error) {
+			defaultLogger.error(
+				"Error:",
+				error instanceof Error ? error.message : error,
+			);
+			process.exit(1);
+		}
+	});
 
 program.parse();

--- a/packages/bibtex/src/logger.ts
+++ b/packages/bibtex/src/logger.ts
@@ -1,0 +1,11 @@
+export interface Logger {
+    info(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+}
+
+export const defaultLogger: Logger = {
+    info: (...args: unknown[]) => console.info(...args),
+    warn: (...args: unknown[]) => console.warn(...args),
+    error: (...args: unknown[]) => console.error(...args),
+};

--- a/packages/bibtex/tests/logger.test.ts
+++ b/packages/bibtex/tests/logger.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultLogger } from "../src/logger.js";
+
+describe("defaultLogger", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should call console.info", () => {
+		const spy = vi.spyOn(console, "info").mockImplementation(() => {});
+		defaultLogger.info("test", 123);
+		expect(spy).toHaveBeenCalledWith("test", 123);
+	});
+
+	it("should call console.warn", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		defaultLogger.warn("test warning");
+		expect(spy).toHaveBeenCalledWith("test warning");
+	});
+
+	it("should call console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		defaultLogger.error("test error");
+		expect(spy).toHaveBeenCalledWith("test error");
+	});
+});


### PR DESCRIPTION
🎯 **What:** Replaced hardcoded `console.log` and `console.error` calls in `packages/bibtex/src/index.ts` with an injectable `defaultLogger` introduced in `packages/bibtex/src/logger.ts`.

💡 **Why:** Reduces reliance on direct global console methods in production CLI code, improving maintainability, consistency, and testability.

✅ **Verification:** Verified that `pnpm build` and `pnpm test` pass successfully across all workspace packages including `packages/bibtex`. Also requested automated code review and addressed findings.

✨ **Result:** A cleaner implementation that isolates side-effects associated with CLI diagnostic and reporting output generation.

---
*PR created automatically by Jules for task [3681756978428013735](https://jules.google.com/task/3681756978428013735) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`packages/bibtex` パッケージの `console.log` / `console.error` 直接呼び出しを、新規追加の `Logger` インターフェース（`logger.ts`）経由に置き換えるリファクタリングです。ロガーの差し替えを可能にすることでテスタビリティと保守性を向上させる意図は妥当です。

- `packages/bibtex/src/logger.ts` を新規追加し、`info` / `warn` / `error` を持つ `Logger` インターフェースと `defaultLogger` を定義。
- `index.ts` 内のすべての `console.log` を `defaultLogger.info`、`console.error` を `defaultLogger.error` に機械的に置き換え。ただし、警告メッセージに `.warn` ではなく `.error` が使われており、また成功通知メッセージにも `.error` が残っているため、インターフェースの `.warn` メソッドが一切使われない状態になっています。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

ログレベルの誤用（警告に `.error`、成功通知にも `.error`）が複数箇所に残っており、Logger 抽象化の恩恵が十分に得られていない状態です。

Logger 抽象化を導入したにもかかわらず、警告メッセージがすべて `.error` 経由で出力されており、`.warn` が一切使われていません。ロガーを差し替えた際にレベル別フィルタリングが正しく動作しないため、リファクタリングの目的が部分的にしか達成されていません。

`packages/bibtex/src/index.ts` — ログレベルの誤用が複数箇所に集中しているため、全体を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/logger.ts | Logger インターフェースと defaultLogger を新規追加。インターフェース設計は適切だが、インデントがプロジェクトのタブ規約と不一致（4スペース使用）。 |
| packages/bibtex/src/index.ts | console.log/error を defaultLogger に置き換え。ただし警告メッセージに .warn ではなく .error を使用しており、Logger インターフェースの .warn が一切使われていない。また成功メッセージに .error を使っている箇所も残存。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/bibtex/src/logger.ts:1-11
`logger.ts` はインターフェースとオブジェクトリテラルの内部を 4スペースでインデントしていますが、プロジェクト全体（`index.ts` 等）はタブを使用しています。スタイルを統一してください。

```suggestion
export interface Logger {
	info(...args: unknown[]): void;
	warn(...args: unknown[]): void;
	error(...args: unknown[]): void;
}

export const defaultLogger: Logger = {
	info: (...args: unknown[]) => console.info(...args),
	warn: (...args: unknown[]) => console.warn(...args),
	error: (...args: unknown[]) => console.error(...args),
};
```

### Issue 2 of 3
packages/bibtex/src/index.ts:159-163
**警告ログに `.error` を使用、`.warn` が未使用**

`Logger` インターフェースには `.warn` メソッドが用意されているにもかかわらず、コード全体で一度も使われていません。`"Warning: ..."` 形式のメッセージは `.warn` で出力すべきで、`.error` は例外・異常終了専用です。同じパターンが 202行目（`--tag` フィルタ警告）、218行目（BibTeX取得失敗）、230行目（フォーマット警告）にも存在します。`.warn` を使うことで、ロガーを差し替えたときにログレベルでのフィルタリングが正しく機能します。

### Issue 3 of 3
packages/bibtex/src/index.ts:244-246
**成功メッセージに `.error` を使用**

ファイル書き込み完了を伝えるメッセージ（`"Wrote N entries to ..."`）は情報ログであるにもかかわらず `defaultLogger.error` で出力しています。元の `console.error`（stderr への出力）をそのまま引き継いだ結果ですが、Logger 抽象化を導入した目的は意味的に適切なレベルを使うことにあるため、ここは `defaultLogger.info` が正しい選択です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Extract console logging to injectable..."](https://github.com/hiroki-org/paper-tools/commit/fcd33f9f63689c18b138fc53b960a1dd4c9bfff0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32477267)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->