### PR TITLE
🧹 Refactor: Introduce logger to replace console logs in bibtex CLI

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -1,239 +1,291 @@
 #!/usr/bin/env node
 
 import "dotenv/config";
-import { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
 import { stdin as input } from "node:process";
-import { fetchBibtex } from "./bibtex-fetcher.js";
-import { deriveBibtexKey, formatBibtex, getValidationWarnings, parseBibtexEntry, splitBibtexEntries } from "./bibtex-formatter.js";
-import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 import { queryPapers } from "@paper-tools/recommender";
+import { Command } from "commander";
+import { fetchBibtex } from "./bibtex-fetcher.js";
+import {
+	deriveBibtexKey,
+	formatBibtex,
+	getValidationWarnings,
+	parseBibtexEntry,
+	splitBibtexEntries,
+} from "./bibtex-formatter.js";
+import { logger } from "./logger.js";
+import type { BibtexFormat, BibtexKeyFormat, ValidateIssue } from "./types.js";
 
 const program = new Command();
 
 function requireDatabaseId(): string {
-    const databaseId = process.env["NOTION_DATABASE_ID"];
-    if (!databaseId) {
-        throw new Error("NOTION_DATABASE_ID が未設定です");
-    }
-    return databaseId;
+	const databaseId = process.env["NOTION_DATABASE_ID"];
+	if (!databaseId) {
+		throw new Error("NOTION_DATABASE_ID が未設定です");
+	}
+	return databaseId;
 }
 
 function looksLikeDoi(inputValue: string): boolean {
-    const s = inputValue.trim();
-    return /^10\.[^\s/]+\/.+/i.test(s) || /^https?:\/\/doi\.org\//i.test(s) || /^doi:/i.test(s);
+	const s = inputValue.trim();
+	return (
+		/^10\.[^\s/]+\/.+/i.test(s) ||
+		/^https?:\/\/doi\.org\//i.test(s) ||
+		/^doi:/i.test(s)
+	);
 }
 
 function normalizeDoi(inputValue: string): string {
-    return inputValue.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	return inputValue
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
 function parseKeyFormat(value: string | undefined): BibtexKeyFormat {
-    if (value === "short" || value === "venue") return value;
-    return "default";
+	if (value === "short" || value === "venue") return value;
+	return "default";
 }
 
 function parseFormat(value: string | undefined): BibtexFormat {
-    if (value === "biblatex") return "biblatex";
-    return "bibtex";
+	if (value === "biblatex") return "biblatex";
+	return "bibtex";
 }
 
-function deriveCustomKey(rawBibtex: string, keyFormat: BibtexKeyFormat): string | undefined {
-    return deriveBibtexKey(rawBibtex, keyFormat);
+function deriveCustomKey(
+	rawBibtex: string,
+	keyFormat: BibtexKeyFormat,
+): string | undefined {
+	return deriveBibtexKey(rawBibtex, keyFormat);
 }
 
 async function readStdinText(): Promise<string> {
-    const chunks: Buffer[] = [];
-    for await (const chunk of input) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks).toString("utf8");
+	const chunks: Buffer[] = [];
+	for await (const chunk of input) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf8");
 }
 
-function buildValidateReport(entries: string[]): { issues: ValidateIssue[]; total: number } {
-    const issues: ValidateIssue[] = [];
-    const keySeen = new Map<string, number>();
-    const doiSeen = new Map<string, number>();
+function buildValidateReport(entries: string[]): {
+	issues: ValidateIssue[];
+	total: number;
+} {
+	const issues: ValidateIssue[] = [];
+	const keySeen = new Map<string, number>();
+	const doiSeen = new Map<string, number>();
 
-    entries.forEach((raw, index) => {
-        try {
-            const parsed = parseBibtexEntry(raw);
-            const key = parsed.key;
-            const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
+	entries.forEach((raw, index) => {
+		try {
+			const parsed = parseBibtexEntry(raw);
+			const key = parsed.key;
+			const doi = (parsed.fields.doi ?? "").trim().toLowerCase();
 
-            for (const warning of getValidationWarnings(parsed)) {
-                issues.push({ level: "warning", message: warning, key });
-            }
+			for (const warning of getValidationWarnings(parsed)) {
+				issues.push({ level: "warning", message: warning, key });
+			}
 
-            if (key) {
-                keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
-            }
-            if (doi) {
-                doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
-            }
-        } catch (error) {
-            issues.push({
-                level: "error",
-                message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
-            });
-        }
-    });
+			if (key) {
+				keySeen.set(key, (keySeen.get(key) ?? 0) + 1);
+			}
+			if (doi) {
+				doiSeen.set(doi, (doiSeen.get(doi) ?? 0) + 1);
+			}
+		} catch (error) {
+			issues.push({
+				level: "error",
+				message: `Entry ${index + 1} parse failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+	});
 
-    for (const [key, count] of keySeen) {
-        if (count > 1) {
-            issues.push({ level: "error", key, message: `Duplicate key detected: ${key} (${count})` });
-        }
-    }
-    for (const [doi, count] of doiSeen) {
-        if (count > 1) {
-            issues.push({ level: "error", message: `Duplicate DOI detected: ${doi} (${count})` });
-        }
-    }
+	for (const [key, count] of keySeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				key,
+				message: `Duplicate key detected: ${key} (${count})`,
+			});
+		}
+	}
+	for (const [doi, count] of doiSeen) {
+		if (count > 1) {
+			issues.push({
+				level: "error",
+				message: `Duplicate DOI detected: ${doi} (${count})`,
+			});
+		}
+	}
 
-    return { issues, total: entries.length };
+	return { issues, total: entries.length };
 }
 
 program
-    .name("paper-bib")
-    .description("Generate and validate BibTeX entries from DOI/title and Notion DB records")
-    .version("0.1.0");
+	.name("paper-bib")
+	.description(
+		"Generate and validate BibTeX entries from DOI/title and Notion DB records",
+	)
+	.version("0.1.0");
 
 program
-    .command("get")
-    .argument("<identifier>", "DOI or paper title")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .action(async (identifier: string, options: { format?: string; keyFormat?: string }) => {
-        try {
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-            const lookup = looksLikeDoi(identifier)
-                ? { doi: normalizeDoi(identifier) }
-                : { title: identifier.trim() };
+	.command("get")
+	.argument("<identifier>", "DOI or paper title")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.action(
+		async (
+			identifier: string,
+			options: { format?: string; keyFormat?: string },
+		) => {
+			try {
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
+				const lookup = looksLikeDoi(identifier)
+					? { doi: normalizeDoi(identifier) }
+					: { title: identifier.trim() };
 
-            const result = await fetchBibtex(lookup);
-            if (!result) {
-                throw new Error("BibTeX を取得できませんでした");
-            }
+				const result = await fetchBibtex(lookup);
+				if (!result) {
+					throw new Error("BibTeX を取得できませんでした");
+				}
 
-            const customKey = deriveCustomKey(result.bibtex, keyFormat);
-            const formatted = formatBibtex(result.bibtex, {
-                format,
-                key: customKey,
-                keyFormat,
-            });
-            if (formatted.warnings.length > 0) {
-                for (const warning of formatted.warnings) {
-                    console.error(`Warning: ${warning}`);
-                }
-            }
-            process.stdout.write(`${formatted.formatted}\n`);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
-
-program
-    .command("export")
-    .option("--tag <tag>", "Tag filter (best-effort)")
-    .option("--format <format>", "bibtex|biblatex", "bibtex")
-    .option("--key-format <keyFormat>", "default|short|venue", "default")
-    .option("--output <file>", "Output file path")
-    .action(async (options: { tag?: string; format?: string; keyFormat?: string; output?: string }) => {
-        try {
-            const databaseId = requireDatabaseId();
-            const format = parseFormat(options.format);
-            const keyFormat = parseKeyFormat(options.keyFormat);
-
-            const records = await queryPapers(databaseId);
-            let targets = records;
-
-            if (options.tag) {
-                // recommender notion-client currently does not expose tag fields.
-                // We keep this as a best-effort title filter to avoid blocking the export flow.
-                targets = records.filter((r) => r.title.toLowerCase().includes(options.tag!.toLowerCase()));
-                console.error(`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`);
-            }
-
-            const results: (string | null)[] = [];
-            const BATCH_SIZE = 10;
-            for (let i = 0; i < targets.length; i += BATCH_SIZE) {
-                const batch = targets.slice(i, i + BATCH_SIZE);
-                const batchResults = await Promise.all(
-                    batch.map(async (record) => {
-                        const fetched = await fetchBibtex({ doi: record.doi, title: record.title });
-                        if (!fetched) {
-                            console.error(`Warning: BibTeX取得失敗: ${record.title}`);
-                            return null;
-                        }
-
-                        const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
-                        const formatted = formatBibtex(fetched.bibtex, {
-                            format,
-                            key: customKey,
-                            keyFormat,
-                        });
-
-                        if (formatted.warnings.length > 0) {
-                            console.error(`Warning (${record.title}): ${formatted.warnings.join("; ")}`);
-                        }
-                        return formatted.formatted;
-                    })
-                );
-                results.push(...batchResults);
-            }
-            const chunks = results.filter((c): c is string => c !== null);
-
-            const outputText = chunks.join("\n\n");
-            if (options.output) {
-                await writeFile(options.output, outputText, "utf8");
-                console.error(`Wrote ${chunks.length} entries to ${options.output}`);
-            } else {
-                process.stdout.write(outputText + (outputText ? "\n" : ""));
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+				const customKey = deriveCustomKey(result.bibtex, keyFormat);
+				const formatted = formatBibtex(result.bibtex, {
+					format,
+					key: customKey,
+					keyFormat,
+				});
+				if (formatted.warnings.length > 0) {
+					for (const warning of formatted.warnings) {
+						logger.warn(`Warning: ${warning}`);
+					}
+				}
+				process.stdout.write(`${formatted.formatted}\n`);
+			} catch (error) {
+				logger.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("validate")
-    .argument("<input>", "BibTeX file path, or '-' to read stdin")
-    .action(async (inputArg: string) => {
-        try {
-            const text = inputArg === "-"
-                ? await readStdinText()
-                : await readFile(inputArg, "utf8");
+	.command("export")
+	.option("--tag <tag>", "Tag filter (best-effort)")
+	.option("--format <format>", "bibtex|biblatex", "bibtex")
+	.option("--key-format <keyFormat>", "default|short|venue", "default")
+	.option("--output <file>", "Output file path")
+	.action(
+		async (options: {
+			tag?: string;
+			format?: string;
+			keyFormat?: string;
+			output?: string;
+		}) => {
+			try {
+				const databaseId = requireDatabaseId();
+				const format = parseFormat(options.format);
+				const keyFormat = parseKeyFormat(options.keyFormat);
 
-            const entries = splitBibtexEntries(text);
-            if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
-                return;
-            }
+				const records = await queryPapers(databaseId);
+				let targets = records;
 
-            const report = buildValidateReport(entries);
-            const errors = report.issues.filter((i) => i.level === "error");
-            const warnings = report.issues.filter((i) => i.level === "warning");
+				if (options.tag) {
+					// recommender notion-client currently does not expose tag fields.
+					// We keep this as a best-effort title filter to avoid blocking the export flow.
+					targets = records.filter((r) =>
+						r.title.toLowerCase().includes(options.tag!.toLowerCase()),
+					);
+					logger.warn(
+						`Warning: --tag はタイトル文字列ベースの簡易フィルタです (${targets.length}/${records.length})`,
+					);
+				}
 
-            console.log(`Entries: ${report.total}`);
-            console.log(`Errors: ${errors.length}`);
-            console.log(`Warnings: ${warnings.length}`);
+				const results: (string | null)[] = [];
+				const BATCH_SIZE = 10;
+				for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+					const batch = targets.slice(i, i + BATCH_SIZE);
+					const batchResults = await Promise.all(
+						batch.map(async (record) => {
+							const fetched = await fetchBibtex({
+								doi: record.doi,
+								title: record.title,
+							});
+							if (!fetched) {
+								logger.warn(`Warning: BibTeX取得失敗: ${record.title}`);
+								return null;
+							}
 
-            for (const issue of report.issues) {
-                const prefix = issue.level.toUpperCase();
-                const keyInfo = issue.key ? ` [${issue.key}]` : "";
-                console.log(`${prefix}${keyInfo}: ${issue.message}`);
-            }
+							const customKey = deriveCustomKey(fetched.bibtex, keyFormat);
+							const formatted = formatBibtex(fetched.bibtex, {
+								format,
+								key: customKey,
+								keyFormat,
+							});
 
-            if (errors.length > 0) {
-                process.exit(1);
-            }
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+							if (formatted.warnings.length > 0) {
+								logger.error(
+									`Warning (${record.title}): ${formatted.warnings.join("; ")}`,
+								);
+							}
+							return formatted.formatted;
+						}),
+					);
+					results.push(...batchResults);
+				}
+				const chunks = results.filter((c): c is string => c !== null);
+
+				const outputText = chunks.join("\n\n");
+				if (options.output) {
+					await writeFile(options.output, outputText, "utf8");
+					logger.error(`Wrote ${chunks.length} entries to ${options.output}`);
+				} else {
+					process.stdout.write(outputText + (outputText ? "\n" : ""));
+				}
+			} catch (error) {
+				logger.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
+
+program
+	.command("validate")
+	.argument("<input>", "BibTeX file path, or '-' to read stdin")
+	.action(async (inputArg: string) => {
+		try {
+			const text =
+				inputArg === "-"
+					? await readStdinText()
+					: await readFile(inputArg, "utf8");
+
+			const entries = splitBibtexEntries(text);
+			if (entries.length === 0) {
+				logger.info("No BibTeX entries found.");
+				return;
+			}
+
+			const report = buildValidateReport(entries);
+			const errors = report.issues.filter((i) => i.level === "error");
+			const warnings = report.issues.filter((i) => i.level === "warning");
+
+			logger.info(`Entries: ${report.total}`);
+			logger.info(`Errors: ${errors.length}`);
+			logger.info(`Warnings: ${warnings.length}`);
+
+			for (const issue of report.issues) {
+				const prefix = issue.level.toUpperCase();
+				const keyInfo = issue.key ? ` [${issue.key}]` : "";
+				logger.info(`${prefix}${keyInfo}: ${issue.message}`);
+			}
+
+			if (errors.length > 0) {
+				process.exit(1);
+			}
+		} catch (error) {
+			logger.error("Error:", error instanceof Error ? error.message : error);
+			process.exit(1);
+		}
+	});
 
 program.parse();

--- a/packages/bibtex/src/logger.ts
+++ b/packages/bibtex/src/logger.ts
@@ -1,0 +1,32 @@
+export interface Logger {
+	// biome-ignore lint/suspicious/noExplicitAny: Standard logger arguments
+	info(message: string, ...args: any[]): void;
+	// biome-ignore lint/suspicious/noExplicitAny: Standard logger arguments
+	warn(message: string, ...args: any[]): void;
+	// biome-ignore lint/suspicious/noExplicitAny: Standard logger arguments
+	error(message: string | Error, ...args: any[]): void;
+}
+
+export const defaultLogger: Logger = {
+	info: (message, ...args) => console.log(message, ...args),
+	warn: (message, ...args) => console.error(message, ...args),
+	error: (message, ...args) => console.error(message, ...args),
+};
+
+let currentLogger: Logger = defaultLogger;
+
+export function setLogger(logger: Logger) {
+	currentLogger = logger;
+}
+
+export const logger = {
+	// biome-ignore lint/suspicious/noExplicitAny: Standard logger arguments
+	info: (message: string, ...args: any[]) =>
+		currentLogger.info(message, ...args),
+	// biome-ignore lint/suspicious/noExplicitAny: Standard logger arguments
+	warn: (message: string, ...args: any[]) =>
+		currentLogger.warn(message, ...args),
+	// biome-ignore lint/suspicious/noExplicitAny: Standard logger arguments
+	error: (message: string | Error, ...args: any[]) =>
+		currentLogger.error(message, ...args),
+};

--- a/packages/bibtex/tests/logger.test.ts
+++ b/packages/bibtex/tests/logger.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	defaultLogger,
+	type Logger,
+	logger,
+	setLogger,
+} from "../src/logger.js";
+
+describe("logger", () => {
+	beforeEach(() => {
+		setLogger(defaultLogger);
+	});
+
+	it("defaultLogger should map info to console.log", () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		defaultLogger.info("test message");
+		expect(logSpy).toHaveBeenCalledWith("test message");
+		logSpy.mockRestore();
+	});
+
+	it("defaultLogger should map warn to console.error", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		defaultLogger.warn("test warning");
+		expect(errorSpy).toHaveBeenCalledWith("test warning");
+		errorSpy.mockRestore();
+	});
+
+	it("defaultLogger should map error to console.error", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		defaultLogger.error("test error");
+		expect(errorSpy).toHaveBeenCalledWith("test error");
+		errorSpy.mockRestore();
+	});
+
+	it("should route messages to the currently set logger", () => {
+		const mockLogger: Logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+
+		setLogger(mockLogger);
+
+		logger.info("info msg", 1, 2);
+		logger.warn("warn msg", { a: 1 });
+		logger.error(new Error("error msg"));
+
+		expect(mockLogger.info).toHaveBeenCalledWith("info msg", 1, 2);
+		expect(mockLogger.warn).toHaveBeenCalledWith("warn msg", { a: 1 });
+		expect(mockLogger.error).toHaveBeenCalledWith(expect.any(Error));
+	});
+});


### PR DESCRIPTION
🎯 **What:** Replaced direct `console.log` and `console.error` usage in `packages/bibtex/src/index.ts` with a newly created injectable logger module (`packages/bibtex/src/logger.ts`).

💡 **Why:** To improve code maintainability and testability by removing hardcoded console interactions in production CLI code, allowing the logger behavior to be easily mocked in tests or adjusted per environment (e.g., verbosity controls).

✅ **Verification:**
1. Ran `pnpm build` in `packages/bibtex` to ensure the new logger module integrates without TypeScript errors.
2. Ran `pnpm test` in `packages/bibtex` to verify no regressions were introduced.
3. Verified the codebase with `@biomejs/biome` to ensure linting and formatting compliance, addressing `any` warnings via proper Biome suppression for standard rest args.

✨ **Result:** The codebase is cleaner and adheres to better software design principles by abstracting logging away from the direct `console` object, while preserving the exact runtime stdout/stderr behaviors.

---
*PR created automatically by Jules for task [14188194412138013998](https://jules.google.com/task/14188194412138013998) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`packages/bibtex/src/index.ts` の `console.log`/`console.error` 呼び出しを、新設の `packages/bibtex/src/logger.ts` が提供する注入可能なロガー抽象化に置き換えるリファクタリングです。インターフェース・デフォルト実装・プロキシオブジェクトで構成されるシンプルな設計ですが、ログレベルの変換に誤りが含まれています。

- `export` コマンド内で「ファイル書き込み完了」の成功メッセージと「フォーマット警告」の両方に `logger.error` が使われており、`logger.info` および `logger.warn` に修正が必要です。
- `defaultLogger.warn` が `console.warn` ではなく `console.error` にルーティングされており、`warn` と `error` が出力上で区別できません。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

ロガー導入の意図は明確で実装も概ね正しいが、`export` コマンド内でログレベルが誤って割り当てられているため、カスタムロガーを注入すると予期せぬ動作を引き起こす。

成功メッセージと警告メッセージが `logger.error` で出力されており、デフォルト動作では stdout/stderr への振り分けは変わらないが、`setLogger` を使う本来の目的（テスト・環境別ロガー注入）を実現しようとすると誤分類が顕在化する。また `defaultLogger.warn` が `console.warn` ではなく `console.error` を呼ぶため、`warn` と `error` を区別できない点も残っている。

`packages/bibtex/src/index.ts` の `export` コマンド内のログレベル割り当て（241行目・227–229行目）と、`packages/bibtex/src/logger.ts` の `defaultLogger.warn` の実装を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/logger.ts | 新規作成のロガーモジュール。`Logger` インターフェース・`defaultLogger`・`setLogger`・プロキシ `logger` を提供するが、`defaultLogger.warn` が `console.warn` ではなく `console.error` にルーティングされており、`warn` と `error` が区別できない問題がある。 |
| packages/bibtex/src/index.ts | `console.log`/`console.error` を `logger.*` に置き換えたが、`export` コマンド内で成功メッセージ（`Wrote … to …`）と警告メッセージ（`Warning (…)`）に誤って `logger.error` が使われている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as index.ts (CLI)
    participant P as logger proxy
    participant CL as currentLogger
    participant DL as defaultLogger

    Note over CLI,DL: 通常起動時（setLogger 未呼出し）
    CLI->>P: logger.info(msg)
    P->>CL: currentLogger.info(msg)
    CL->>DL: defaultLogger.info(msg)
    DL-->>CLI: console.log → stdout

    CLI->>P: logger.warn(msg)
    P->>CL: currentLogger.warn(msg)
    CL->>DL: defaultLogger.warn(msg)
    DL-->>CLI: console.error → stderr ⚠️ (console.warn ではない)

    CLI->>P: logger.error(msg)
    P->>CL: currentLogger.error(msg)
    CL->>DL: defaultLogger.error(msg)
    DL-->>CLI: console.error → stderr

    Note over CLI,DL: setLogger でカスタムロガー注入後
    CLI->>P: logger.error("Wrote N entries…") ❌ 成功メッセージ
    P->>CL: customLogger.error(msg)
    CL-->>CLI: エラーとして誤処理される可能性
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/bibtex/src/logger.ts:10-14
**`defaultLogger.warn` が `console.warn` ではなく `console.error` にルーティングされている**

`Logger` インターフェースで `warn` と `error` を明示的に区別しているにもかかわらず、`defaultLogger` では両方とも `console.error` に送られています。`console.warn` も同じく stderr に出力されるため、元の動作を維持しつつ、ログレベルを正しく区別できます。

```suggestion
export const defaultLogger: Logger = {
	info: (message, ...args) => console.log(message, ...args),
	warn: (message, ...args) => console.warn(message, ...args),
	error: (message, ...args) => console.error(message, ...args),
};
```

### Issue 2 of 3
packages/bibtex/src/index.ts:241
**ログレベルの誤用：成功メッセージに `logger.error` を使用**

ファイル書き込み完了後の成功メッセージに `logger.error` が呼ばれています。`setLogger` でカスタムロガー（エラーカウンターや Sentry 連携など）を注入した場合、正常完了したエクスポートがエラーとして扱われてしまいます。元の `console.error` は stderr に書くために使われていましたが、意味的には `logger.info` が適切です。

### Issue 3 of 3
packages/bibtex/src/index.ts:227-229
**ログレベルの誤用：警告メッセージに `logger.error` を使用**

`Warning (${record.title}):` というメッセージに対して `logger.error` が呼ばれています。元の `console.error`（stderr 書き込み用）を機械的に変換した結果ですが、意味的には `logger.warn` が正しいです。カスタムロガーを注入した際に、フォーマット警告がエラーとして誤って扱われます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Refactor: Introduce logger to replace..."](https://github.com/hiroki-org/paper-tools/commit/83ad346dc413484e1794c76d09c3245eb7b2ea0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32477323)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->