### PR TITLE
🧹 Extract and standardize outputJson utility across CLI tools

### DIFF
--- a/packages/author-profiler/src/commands/profile.ts
+++ b/packages/author-profiler/src/commands/profile.ts
@@ -1,27 +1,37 @@
-import { buildAuthorProfile } from "../services/profile-builder.js";
+import { outputJson } from "@paper-tools/core";
 import { resolveAuthorId } from "../services/author-resolver.js";
+import { buildAuthorProfile } from "../services/profile-builder.js";
 
 interface ProfileOptions {
-    id?: boolean;
-    json?: boolean;
+	id?: boolean;
+	json?: boolean;
 }
 
-export async function runProfileCommand(nameOrId: string, options: ProfileOptions): Promise<void> {
-    const resolved = await resolveAuthorId(nameOrId, { id: options.id });
-    const profile = await buildAuthorProfile(resolved.authorId);
+export async function runProfileCommand(
+	nameOrId: string,
+	options: ProfileOptions,
+): Promise<void> {
+	const resolved = await resolveAuthorId(nameOrId, { id: options.id });
+	const profile = await buildAuthorProfile(resolved.authorId);
 
-    if (options.json) {
-        console.log(JSON.stringify(profile, null, 2));
-        return;
-    }
+	if (options.json) {
+		await outputJson(profile);
+		return;
+	}
 
-    console.log(`\nAuthor: ${profile.name} (${profile.id})`);
-    console.table([
-        { metric: "h-index", value: profile.hIndex },
-        { metric: "citationCount", value: profile.citationCount },
-        { metric: "paperCount", value: profile.paperCount },
-        { metric: "influentialCitationCount", value: profile.influentialCitationCount },
-        { metric: "homepage", value: profile.homepage ?? "-" },
-        { metric: "affiliations", value: profile.affiliations.map((v) => v.name).join(", ") || "-" },
-    ]);
+	console.log(`\nAuthor: ${profile.name} (${profile.id})`);
+	console.table([
+		{ metric: "h-index", value: profile.hIndex },
+		{ metric: "citationCount", value: profile.citationCount },
+		{ metric: "paperCount", value: profile.paperCount },
+		{
+			metric: "influentialCitationCount",
+			value: profile.influentialCitationCount,
+		},
+		{ metric: "homepage", value: profile.homepage ?? "-" },
+		{
+			metric: "affiliations",
+			value: profile.affiliations.map((v) => v.name).join(", ") || "-",
+		},
+	]);
 }

--- a/packages/author-profiler/src/commands/save.ts
+++ b/packages/author-profiler/src/commands/save.ts
@@ -1,22 +1,28 @@
-import { buildAuthorProfile } from "../services/profile-builder.js";
-import { resolveAuthorId } from "../services/author-resolver.js";
+import { outputJson } from "@paper-tools/core";
 import { saveAuthorProfileToNotion } from "../notion/author-client.js";
+import { resolveAuthorId } from "../services/author-resolver.js";
+import { buildAuthorProfile } from "../services/profile-builder.js";
 
 interface SaveOptions {
-    id?: boolean;
-    dryRun?: boolean;
+	id?: boolean;
+	dryRun?: boolean;
 }
 
-export async function runSaveCommand(nameOrId: string, options: SaveOptions): Promise<void> {
-    const resolved = await resolveAuthorId(nameOrId, { id: options.id });
-    const profile = await buildAuthorProfile(resolved.authorId);
+export async function runSaveCommand(
+	nameOrId: string,
+	options: SaveOptions,
+): Promise<void> {
+	const resolved = await resolveAuthorId(nameOrId, { id: options.id });
+	const profile = await buildAuthorProfile(resolved.authorId);
 
-    const result = await saveAuthorProfileToNotion(profile, { dryRun: options.dryRun ?? false });
+	const result = await saveAuthorProfileToNotion(profile, {
+		dryRun: options.dryRun ?? false,
+	});
 
-    if (result.action === "dry-run") {
-        console.log(JSON.stringify({ action: "dry-run", profile }, null, 2));
-        return;
-    }
+	if (result.action === "dry-run") {
+		await outputJson({ action: "dry-run", profile });
+		return;
+	}
 
-    console.log(JSON.stringify(result, null, 2));
+	await outputJson(result);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,71 +1,64 @@
 // Types
-export type {
-    Author,
-    Paper,
-    Citation,
-    ImportantDate,
-    ConferenceTrack,
-    Conference,
-    Journal,
-} from "./types.js";
 
-// Rate limiter
-export { RateLimiter, fetchWithRetry } from "./rate-limiter.js";
+export type {
+	Affiliation,
+	AuthorProfile,
+	CoauthorInfo,
+	TopicTimelineEntry,
+} from "./author-types.js";
+export { getWorkByDoi, searchWorks } from "./crossref-client.js";
 
 // API Clients
 export {
-    searchPublications,
-    searchVenuePublications,
-    searchAuthors as searchDblpAuthors,
+	searchAuthors as searchDblpAuthors,
+	searchPublications,
+	searchVenuePublications,
 } from "./dblp-client.js";
-
-export { getWorkByDoi, searchWorks } from "./crossref-client.js";
-
+export type {
+	OpenAlexAffiliation,
+	OpenAlexAuthor,
+	OpenAlexConcept,
+	OpenAlexCountByYear,
+} from "./openalex-client.js";
+export {
+	getOpenAlexAuthor,
+	resolveOpenAlexAuthorId,
+} from "./openalex-client.js";
 export { getCitations, getReferences } from "./opencitations-client.js";
-
-export {
-    S2_DEFAULT_FIELDS,
-    getRecommendationsForPaper,
-    getRecommendations,
-    getPaper,
-    searchPapers,
-    searchAuthors,
-    getAuthor,
-    getAuthorPapers,
+// Rate limiter
+export { fetchWithRetry, RateLimiter } from "./rate-limiter.js";
+export type {
+	S2Author,
+	S2AuthorDetail,
+	S2AuthorPapersResponse,
+	S2AuthorSearchResponse,
+	S2AuthorSummary,
+	S2ExternalIds,
+	S2OpenAccessPdf,
+	S2Paper,
+	S2RecommendationOptions,
+	S2RecommendationsResponse,
+	S2SearchResponse,
 } from "./semantic-scholar-client.js";
-
-export type {
-    S2Author,
-    S2AuthorSummary,
-    S2AuthorSearchResponse,
-    S2AuthorDetail,
-    S2AuthorPapersResponse,
-    S2ExternalIds,
-    S2OpenAccessPdf,
-    S2Paper,
-    S2RecommendationsResponse,
-    S2RecommendationOptions,
-    S2SearchResponse,
-} from "./semantic-scholar-client.js";
-
 export {
-    getOpenAlexAuthor,
-    resolveOpenAlexAuthorId,
-} from "./openalex-client.js";
-
+	getAuthor,
+	getAuthorPapers,
+	getPaper,
+	getRecommendations,
+	getRecommendationsForPaper,
+	S2_DEFAULT_FIELDS,
+	searchAuthors,
+	searchPapers,
+} from "./semantic-scholar-client.js";
 export type {
-    OpenAlexAuthor,
-    OpenAlexConcept,
-    OpenAlexAffiliation,
-    OpenAlexCountByYear,
-} from "./openalex-client.js";
-
-export type {
-    AuthorProfile,
-    Affiliation,
-    CoauthorInfo,
-    TopicTimelineEntry,
-} from "./author-types.js";
+	Author,
+	Citation,
+	Conference,
+	ConferenceTrack,
+	ImportantDate,
+	Journal,
+	Paper,
+} from "./types.js";
 
 // Utilities
-export { parsePositiveInt, mapWithConcurrency } from "./utils.js";
+export { mapWithConcurrency, outputJson, parsePositiveInt } from "./utils.js";

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -8,14 +8,13 @@
  * @throws 値が正の整数でない場合は Error をスロー
  */
 export function parsePositiveInt(value: string, optionName?: unknown): number {
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed <= 0) {
-        const prefix = typeof optionName === "string" ? `${optionName} には` : "";
-        throw new Error(`${prefix}正の整数を指定してください: ${value}`);
-    }
-    return parsed;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed <= 0) {
+		const prefix = typeof optionName === "string" ? `${optionName} には` : "";
+		throw new Error(`${prefix}正の整数を指定してください: ${value}`);
+	}
+	return parsed;
 }
-
 
 /**
  * Executes an async function over an array with limited concurrency.
@@ -25,20 +24,43 @@ export function parsePositiveInt(value: string, optionName?: unknown): number {
  * @returns A promise that resolves to an array of results.
  */
 export async function mapWithConcurrency<T, R>(
-    items: T[],
-    mapper: (item: T) => Promise<R>,
-    concurrencyLimit: number
+	items: T[],
+	mapper: (item: T) => Promise<R>,
+	concurrencyLimit: number,
 ): Promise<R[]> {
-    const results: R[] = new Array(items.length);
-    let index = 0;
+	const results: R[] = new Array(items.length);
+	let index = 0;
 
-    const workers = Array.from({ length: Math.min(concurrencyLimit, items.length) }, async () => {
-        while (index < items.length) {
-            const currentIndex = index++;
-            results[currentIndex] = await mapper(items[currentIndex]);
-        }
-    });
+	const workers = Array.from(
+		{ length: Math.min(concurrencyLimit, items.length) },
+		async () => {
+			while (index < items.length) {
+				const currentIndex = index++;
+				results[currentIndex] = await mapper(items[currentIndex]);
+			}
+		},
+	);
 
-    await Promise.all(workers);
-    return results;
+	await Promise.all(workers);
+	return results;
+}
+
+/**
+ * Output data as formatted JSON.
+ * Writes to the specified file or prints to stdout.
+ * @param data - The data object to output
+ * @param output - Output file path (outputs to stdout if omitted)
+ */
+export async function outputJson(
+	data: unknown,
+	output?: string,
+): Promise<void> {
+	const json = JSON.stringify(data, null, 2);
+	if (output) {
+		const { writeFile } = await import("node:fs/promises");
+		await writeFile(output, json, "utf-8");
+		console.error(`Output written to: ${output}`);
+		return;
+	}
+	console.log(json);
 }

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { describe, it, expect } from "vitest";
 import { parsePositiveInt } from "../src/utils.js";
 
@@ -77,5 +78,40 @@ describe("mapWithConcurrency", () => {
         };
 
         await expect(mapWithConcurrency(items, mapper, 2)).rejects.toThrow("Test error");
+    });
+});
+
+vi.mock("node:fs/promises", () => ({
+    writeFile: vi.fn(),
+}));
+
+describe("outputJson", () => {
+    it("should write to a file if output path is provided", async () => {
+        const { outputJson } = await import("../src/utils.js");
+        const fsPromises = await import("node:fs/promises");
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const data = { test: "data" };
+        const outputPath = "test.json";
+
+        await outputJson(data, outputPath);
+
+        expect(fsPromises.writeFile).toHaveBeenCalledWith(outputPath, JSON.stringify(data, null, 2), "utf-8");
+        expect(consoleErrorSpy).toHaveBeenCalledWith(`Output written to: ${outputPath}`);
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("should print to console if no output path is provided", async () => {
+        const { outputJson } = await import("../src/utils.js");
+        const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+        const data = { test: "data" };
+
+        await outputJson(data);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+
+        consoleLogSpy.mockRestore();
     });
 });

--- a/packages/drilldown/src/cli.ts
+++ b/packages/drilldown/src/cli.ts
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
-import { parsePositiveInt } from "@paper-tools/core";
+import { outputJson, parsePositiveInt } from "@paper-tools/core";
 
 import "dotenv/config";
-import { Command } from "commander";
-import { searchByKeyword, searchByVenue, enrichAllWithCrossref, searchCrossref } from "./search.js";
-import { drilldown, extractKeywords } from "./drilldown.js";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Command } from "commander";
+import { drilldown, extractKeywords } from "./drilldown.js";
+import {
+	enrichAllWithCrossref,
+	searchByKeyword,
+	searchByVenue,
+	searchCrossref,
+} from "./search.js";
 
 const program = new Command();
 
@@ -15,150 +20,169 @@ const program = new Command();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageJson = JSON.parse(
-    readFileSync(join(__dirname, "../package.json"), "utf-8")
+	readFileSync(join(__dirname, "../package.json"), "utf-8"),
 );
 const version = packageJson.version;
-
-/**
- * データを JSON フォーマットで出力する
- * 出力先ファイルが指定されている場合はファイルに書き込み、そうでない場合は stdout に出力する
- * @param data - 出力するデータオブジェクト
- * @param output - 出力先ファイルパス（省略時は stdout に出力）
- */
-async function outputJson(data: unknown, output?: string): Promise<void> {
-    const json = JSON.stringify(data, null, 2);
-    if (output) {
-        const { writeFile } = await import("node:fs/promises");
-        await writeFile(output, json, "utf-8");
-        console.error(`Output written to: ${output}`);
-        return;
-    }
-    console.log(json);
-}
 
 /**
  * 非同期アクション実行のヘルパー関数
  */
 async function runAction(fn: () => Promise<void>): Promise<void> {
-    try {
-        await fn();
-    } catch (error) {
-        console.error("Error:", error instanceof Error ? error.message : error);
-        process.exit(1);
-    }
+	try {
+		await fn();
+	} catch (error) {
+		console.error("Error:", error instanceof Error ? error.message : error);
+		process.exit(1);
+	}
 }
 
 program
-    .name("paper-drilldown")
-    .description("DBLP + Crossref による論文キーワード検索・深掘り CLI")
-    .version(version);
+	.name("paper-drilldown")
+	.description("DBLP + Crossref による論文キーワード検索・深掘り CLI")
+	.version(version);
 
 // ── search コマンド ──────────────────────────────────
 program
-    .command("search")
-    .argument("<keyword>", "検索キーワード")
-    .option("--limit <n>", "最大取得件数", "30")
-    .option("--enrich", "Crossref で情報を補完する", false)
-    .option("-o, --output <file>", "出力JSONファイル")
-    .action((keyword: string, options: { limit?: string; enrich?: boolean; output?: string }) => {
-        runAction(async () => {
-            const limit = parsePositiveInt(options.limit || "30", "--limit");
-            let papers = await searchByKeyword(keyword, limit);
-            if (options.enrich) {
-                papers = await enrichAllWithCrossref(papers);
-            }
-            await outputJson(papers, options.output);
-        });
-    });
+	.command("search")
+	.argument("<keyword>", "検索キーワード")
+	.option("--limit <n>", "最大取得件数", "30")
+	.option("--enrich", "Crossref で情報を補完する", false)
+	.option("-o, --output <file>", "出力JSONファイル")
+	.action(
+		(
+			keyword: string,
+			options: { limit?: string; enrich?: boolean; output?: string },
+		) => {
+			runAction(async () => {
+				const limit = parsePositiveInt(options.limit || "30", "--limit");
+				let papers = await searchByKeyword(keyword, limit);
+				if (options.enrich) {
+					papers = await enrichAllWithCrossref(papers);
+				}
+				await outputJson(papers, options.output);
+			});
+		},
+	);
 
 // ── venue コマンド ──────────────────────────────────
 program
-    .command("venue")
-    .argument("<venue>", "会議名 / ジャーナル名（例: ICSE, CHI）")
-    .option("--year <year>", "発行年で絞り込む")
-    .option("--limit <n>", "最大取得件数", "100")
-    .option("--enrich", "Crossref で情報を補完する", false)
-    .option("-o, --output <file>", "出力JSONファイル")
-    .action((venue: string, options: { year?: string; limit?: string; enrich?: boolean; output?: string }) => {
-        runAction(async () => {
-            const limit = parsePositiveInt(options.limit || "100", "--limit");
-            const year = options.year ? parsePositiveInt(options.year, "--year") : undefined;
-            let papers = await searchByVenue(venue, year, limit);
-            if (options.enrich) {
-                papers = await enrichAllWithCrossref(papers);
-            }
-            await outputJson(papers, options.output);
-        });
-    });
+	.command("venue")
+	.argument("<venue>", "会議名 / ジャーナル名（例: ICSE, CHI）")
+	.option("--year <year>", "発行年で絞り込む")
+	.option("--limit <n>", "最大取得件数", "100")
+	.option("--enrich", "Crossref で情報を補完する", false)
+	.option("-o, --output <file>", "出力JSONファイル")
+	.action(
+		(
+			venue: string,
+			options: {
+				year?: string;
+				limit?: string;
+				enrich?: boolean;
+				output?: string;
+			},
+		) => {
+			runAction(async () => {
+				const limit = parsePositiveInt(options.limit || "100", "--limit");
+				const year = options.year
+					? parsePositiveInt(options.year, "--year")
+					: undefined;
+				let papers = await searchByVenue(venue, year, limit);
+				if (options.enrich) {
+					papers = await enrichAllWithCrossref(papers);
+				}
+				await outputJson(papers, options.output);
+			});
+		},
+	);
 
 // ── crossref コマンド ──────────────────────────────────
 program
-    .command("crossref")
-    .argument("<query>", "Crossref 検索クエリ")
-    .option("--limit <n>", "最大取得件数", "20")
-    .option("-o, --output <file>", "出力JSONファイル")
-    .action((query: string, options: { limit?: string; output?: string }) => {
-        runAction(async () => {
-            const limit = parsePositiveInt(options.limit || "20", "--limit");
-            const papers = await searchCrossref(query, limit);
-            await outputJson(papers, options.output);
-        });
-    });
+	.command("crossref")
+	.argument("<query>", "Crossref 検索クエリ")
+	.option("--limit <n>", "最大取得件数", "20")
+	.option("-o, --output <file>", "出力JSONファイル")
+	.action((query: string, options: { limit?: string; output?: string }) => {
+		runAction(async () => {
+			const limit = parsePositiveInt(options.limit || "20", "--limit");
+			const papers = await searchCrossref(query, limit);
+			await outputJson(papers, options.output);
+		});
+	});
 
 // ── drilldown コマンド ──────────────────────────────────
 program
-    .command("drilldown")
-    .argument("<keyword>", "シード検索キーワード")
-    .option("--seed-limit <n>", "シード論文の最大取得件数", "10")
-    .option("--depth <n>", "深掘りの深さ", "1")
-    .option("--max-per-level <n>", "各レベルの最大取得件数", "10")
-    .option("--enrich", "Crossref で情報を補完する", false)
-    .option("-o, --output <file>", "出力JSONファイル")
-    .action((keyword: string, options: {
-        seedLimit?: string;
-        depth?: string;
-        maxPerLevel?: string;
-        enrich?: boolean;
-        output?: string;
-    }) => {
-        runAction(async () => {
-            const seedLimit = parsePositiveInt(options.seedLimit || "10", "--seed-limit");
-            const depth = parsePositiveInt(options.depth || "1", "--depth");
-            const maxPerLevel = parsePositiveInt(options.maxPerLevel || "10", "--max-per-level");
-            const enrich = options.enrich ?? false;
+	.command("drilldown")
+	.argument("<keyword>", "シード検索キーワード")
+	.option("--seed-limit <n>", "シード論文の最大取得件数", "10")
+	.option("--depth <n>", "深掘りの深さ", "1")
+	.option("--max-per-level <n>", "各レベルの最大取得件数", "10")
+	.option("--enrich", "Crossref で情報を補完する", false)
+	.option("-o, --output <file>", "出力JSONファイル")
+	.action(
+		(
+			keyword: string,
+			options: {
+				seedLimit?: string;
+				depth?: string;
+				maxPerLevel?: string;
+				enrich?: boolean;
+				output?: string;
+			},
+		) => {
+			runAction(async () => {
+				const seedLimit = parsePositiveInt(
+					options.seedLimit || "10",
+					"--seed-limit",
+				);
+				const depth = parsePositiveInt(options.depth || "1", "--depth");
+				const maxPerLevel = parsePositiveInt(
+					options.maxPerLevel || "10",
+					"--max-per-level",
+				);
+				const enrich = options.enrich ?? false;
 
-            const seedPapers = await searchByKeyword(keyword, seedLimit);
-            if (seedPapers.length === 0) {
-                console.error("シード検索結果が 0 件です");
-                process.exit(1);
-            }
+				const seedPapers = await searchByKeyword(keyword, seedLimit);
+				if (seedPapers.length === 0) {
+					console.error("シード検索結果が 0 件です");
+					process.exit(1);
+				}
 
-            const results = await drilldown(seedPapers, depth, maxPerLevel, enrich);
-            await outputJson(results, options.output);
-        });
-    });
+				const results = await drilldown(seedPapers, depth, maxPerLevel, enrich);
+				await outputJson(results, options.output);
+			});
+		},
+	);
 
 // ── keywords コマンド ──────────────────────────────────
 program
-    .command("keywords")
-    .argument("<keyword>", "検索キーワード")
-    .option("--limit <n>", "検索で取得する論文数", "20")
-    .option("--top <n>", "出力するキーワード数", "10")
-    .option("-o, --output <file>", "出力JSONファイル")
-    .action((keyword: string, options: { limit?: string; top?: string; output?: string }) => {
-        runAction(async () => {
-            const limit = parsePositiveInt(options.limit || "20", "--limit");
-            const topN = parsePositiveInt(options.top || "10", "--top");
+	.command("keywords")
+	.argument("<keyword>", "検索キーワード")
+	.option("--limit <n>", "検索で取得する論文数", "20")
+	.option("--top <n>", "出力するキーワード数", "10")
+	.option("-o, --output <file>", "出力JSONファイル")
+	.action(
+		(
+			keyword: string,
+			options: { limit?: string; top?: string; output?: string },
+		) => {
+			runAction(async () => {
+				const limit = parsePositiveInt(options.limit || "20", "--limit");
+				const topN = parsePositiveInt(options.top || "10", "--top");
 
-            const papers = await searchByKeyword(keyword, limit);
-            if (papers.length === 0) {
-                console.error("検索結果が 0 件です");
-                process.exit(1);
-            }
+				const papers = await searchByKeyword(keyword, limit);
+				if (papers.length === 0) {
+					console.error("検索結果が 0 件です");
+					process.exit(1);
+				}
 
-            const keywords = extractKeywords(papers, topN);
-            await outputJson({ query: keyword, papersAnalyzed: papers.length, keywords }, options.output);
-        });
-    });
+				const keywords = extractKeywords(papers, topN);
+				await outputJson(
+					{ query: keyword, papersAnalyzed: papers.length, keywords },
+					options.output,
+				);
+			});
+		},
+	);
 
 program.parse();

--- a/packages/recommender/src/cli.ts
+++ b/packages/recommender/src/cli.ts
@@ -1,185 +1,204 @@
 #!/usr/bin/env node
 
 import "dotenv/config";
+import type { S2Paper } from "@paper-tools/core";
+import {
+	mapWithConcurrency,
+	outputJson,
+	parsePositiveInt,
+} from "@paper-tools/core";
 import { Command } from "commander";
 import {
-    createPaperPage,
-    findDuplicates,
-    getDatabase,
-    queryPapers,
-    type DatabaseValidationResult,
-    type DuplicateResult,
+	createPaperPage,
+	type DatabaseValidationResult,
+	type DuplicateResult,
+	findDuplicates,
+	getDatabase,
+	queryPapers,
 } from "./notion-client.js";
-import {
-    recommendFromMultiple,
-    recommendFromSingle,
-} from "./recommend.js";
-import type { S2Paper } from "@paper-tools/core";
-import { mapWithConcurrency, parsePositiveInt } from "@paper-tools/core";
+import { recommendFromMultiple, recommendFromSingle } from "./recommend.js";
 
 const program = new Command();
 
-
 async function syncPapers(
-    databaseId: string,
-    papers: S2Paper[],
-    duplicates: DuplicateResult,
-    dryRun: boolean,
-    validation: DatabaseValidationResult,
+	databaseId: string,
+	papers: S2Paper[],
+	duplicates: DuplicateResult,
+	dryRun: boolean,
+	validation: DatabaseValidationResult,
 ): Promise<{ added: number; skipped: number; errors: number }> {
-    let added = 0;
-    let skipped = 0;
-    let errors = 0;
+	let added = 0;
+	let skipped = 0;
+	let errors = 0;
 
-    const toProcess: S2Paper[] = [];
-    for (const paper of papers) {
-        const doi = paper.externalIds?.DOI;
-        const titleKey = (paper.title ?? "").trim().toLowerCase();
-        const isDuplicate = (doi && duplicates.duplicateDois.has(doi))
-            || (titleKey && duplicates.duplicateTitles.has(titleKey));
+	const toProcess: S2Paper[] = [];
+	for (const paper of papers) {
+		const doi = paper.externalIds?.DOI;
+		const titleKey = (paper.title ?? "").trim().toLowerCase();
+		const isDuplicate =
+			(doi && duplicates.duplicateDois.has(doi)) ||
+			(titleKey && duplicates.duplicateTitles.has(titleKey));
 
-        if (isDuplicate) {
-            skipped++;
-        } else {
-            toProcess.push(paper);
-        }
-    }
+		if (isDuplicate) {
+			skipped++;
+		} else {
+			toProcess.push(paper);
+		}
+	}
 
-    if (dryRun) {
-        added = toProcess.length;
-        return { added, skipped, errors };
-    }
+	if (dryRun) {
+		added = toProcess.length;
+		return { added, skipped, errors };
+	}
 
-    const CONCURRENCY_LIMIT = 5;
-    await mapWithConcurrency(
-        toProcess,
-        async (paper) => {
-            try {
-                await createPaperPage(databaseId, paper, undefined, validation);
-                added++;
-            } catch (err) {
-                const doi = paper.externalIds?.DOI;
-                const id = doi || paper.title || paper.paperId;
-                console.error(`Failed to add paper ${id}:`, err instanceof Error ? err.message : err);
-                errors++;
-            }
-        },
-        CONCURRENCY_LIMIT,
-    );
+	const CONCURRENCY_LIMIT = 5;
+	await mapWithConcurrency(
+		toProcess,
+		async (paper) => {
+			try {
+				await createPaperPage(databaseId, paper, undefined, validation);
+				added++;
+			} catch (err) {
+				const doi = paper.externalIds?.DOI;
+				const id = doi || paper.title || paper.paperId;
+				console.error(
+					`Failed to add paper ${id}:`,
+					err instanceof Error ? err.message : err,
+				);
+				errors++;
+			}
+		},
+		CONCURRENCY_LIMIT,
+	);
 
-    return { added, skipped, errors };
-}
-
-async function outputJson(data: unknown, output?: string): Promise<void> {
-    const json = JSON.stringify(data, null, 2);
-    if (output) {
-        const { writeFile } = await import("node:fs/promises");
-        await writeFile(output, json, "utf-8");
-        console.error(`Output written to: ${output}`);
-        return;
-    }
-    console.log(json);
+	return { added, skipped, errors };
 }
 
 function requireDatabaseId(): string {
-    const databaseId = process.env["NOTION_DATABASE_ID"];
-    if (!databaseId) {
-        throw new Error("NOTION_DATABASE_ID が未設定です");
-    }
-    return databaseId;
+	const databaseId = process.env["NOTION_DATABASE_ID"];
+	if (!databaseId) {
+		throw new Error("NOTION_DATABASE_ID が未設定です");
+	}
+	return databaseId;
 }
 
 program
-    .name("paper-recommender")
-    .description("Semantic Scholar + Notion による論文レコメンドCLI")
-    .version("0.1.0");
+	.name("paper-recommender")
+	.description("Semantic Scholar + Notion による論文レコメンドCLI")
+	.version("0.1.0");
 
 program
-    .command("recommend")
-    .argument("<paper-id>", "DOI / Semantic Scholar ID / タイトル")
-    .option("--limit <n>", "レコメンド件数", "10")
-    .option("--from <pool>", "recent | all-cs", "recent")
-    .option("-o, --output <file>", "出力JSONファイル")
-    .action(async (paperId: string, options: { limit?: string; from?: string; output?: string }) => {
-        try {
-            const limit = parsePositiveInt(options.limit || "10", "--limit");
-            const from = (options.from === "all-cs" ? "all-cs" : "recent") as "recent" | "all-cs";
-            const papers = await recommendFromSingle(paperId, { limit, from });
-            await outputJson(papers, options.output);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+	.command("recommend")
+	.argument("<paper-id>", "DOI / Semantic Scholar ID / タイトル")
+	.option("--limit <n>", "レコメンド件数", "10")
+	.option("--from <pool>", "recent | all-cs", "recent")
+	.option("-o, --output <file>", "出力JSONファイル")
+	.action(
+		async (
+			paperId: string,
+			options: { limit?: string; from?: string; output?: string },
+		) => {
+			try {
+				const limit = parsePositiveInt(options.limit || "10", "--limit");
+				const from = (options.from === "all-cs" ? "all-cs" : "recent") as
+					| "recent"
+					| "all-cs";
+				const papers = await recommendFromSingle(paperId, { limit, from });
+				await outputJson(papers, options.output);
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("sync")
-    .argument("<paper-id>", "DOI / Semantic Scholar ID / タイトル")
-    .option("--limit <n>", "レコメンド件数", "10")
-    .option("--dry-run", "追加せずに結果のみ表示", false)
-    .action(async (paperId: string, options: { limit?: string; dryRun?: boolean }) => {
-        try {
-            const databaseId = requireDatabaseId();
-            const limit = parsePositiveInt(options.limit || "10", "--limit");
-            const dryRun = options.dryRun ?? false;
+	.command("sync")
+	.argument("<paper-id>", "DOI / Semantic Scholar ID / タイトル")
+	.option("--limit <n>", "レコメンド件数", "10")
+	.option("--dry-run", "追加せずに結果のみ表示", false)
+	.action(
+		async (paperId: string, options: { limit?: string; dryRun?: boolean }) => {
+			try {
+				const databaseId = requireDatabaseId();
+				const limit = parsePositiveInt(options.limit || "10", "--limit");
+				const dryRun = options.dryRun ?? false;
 
-            const database = await getDatabase(databaseId);
-            if (database.missingOptional.length > 0) {
-                console.error(`Warning: 任意プロパティ不足: ${database.missingOptional.join(", ")}`);
-            }
+				const database = await getDatabase(databaseId);
+				if (database.missingOptional.length > 0) {
+					console.error(
+						`Warning: 任意プロパティ不足: ${database.missingOptional.join(", ")}`,
+					);
+				}
 
-            const papers = await recommendFromSingle(paperId, { limit, from: "recent" });
-            const duplicates = await findDuplicates(databaseId, papers);
-            const { added, skipped, errors } = await syncPapers(
-                databaseId,
-                papers,
-                duplicates,
-                dryRun,
-                database,
-            );
+				const papers = await recommendFromSingle(paperId, {
+					limit,
+					from: "recent",
+				});
+				const duplicates = await findDuplicates(databaseId, papers);
+				const { added, skipped, errors } = await syncPapers(
+					databaseId,
+					papers,
+					duplicates,
+					dryRun,
+					database,
+				);
 
-            console.log(JSON.stringify({ added, skipped, errors, dryRun }, null, 2));
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+				console.log(
+					JSON.stringify({ added, skipped, errors, dryRun }, null, 2),
+				);
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("sync-all")
-    .option("--limit <n>", "レコメンド件数", "20")
-    .option("--dry-run", "追加せずに結果のみ表示", false)
-    .action(async (options: { limit?: string; dryRun?: boolean }) => {
-        try {
-            const databaseId = requireDatabaseId();
-            const limit = parsePositiveInt(options.limit || "20", "--limit");
-            const dryRun = options.dryRun ?? false;
+	.command("sync-all")
+	.option("--limit <n>", "レコメンド件数", "20")
+	.option("--dry-run", "追加せずに結果のみ表示", false)
+	.action(async (options: { limit?: string; dryRun?: boolean }) => {
+		try {
+			const databaseId = requireDatabaseId();
+			const limit = parsePositiveInt(options.limit || "20", "--limit");
+			const dryRun = options.dryRun ?? false;
 
-            const database = await getDatabase(databaseId);
-            if (database.missingOptional.length > 0) {
-                console.error(`Warning: 任意プロパティ不足: ${database.missingOptional.join(", ")}`);
-            }
+			const database = await getDatabase(databaseId);
+			if (database.missingOptional.length > 0) {
+				console.error(
+					`Warning: 任意プロパティ不足: ${database.missingOptional.join(", ")}`,
+				);
+			}
 
-            const existingPapers = await queryPapers(databaseId);
-            const positiveIds = existingPapers
-                .map((p) => p.semanticScholarId || p.doi || p.title)
-                .filter((v): v is string => !!v && v.trim().length > 0);
+			const existingPapers = await queryPapers(databaseId);
+			const positiveIds = existingPapers
+				.map((p) => p.semanticScholarId || p.doi || p.title)
+				.filter((v): v is string => !!v && v.trim().length > 0);
 
-            const recommended = await recommendFromMultiple(positiveIds, [], { limit });
-            const duplicates = await findDuplicates(databaseId, recommended);
-            const { added, skipped, errors } = await syncPapers(
-                databaseId,
-                recommended,
-                duplicates,
-                dryRun,
-                database,
-            );
+			const recommended = await recommendFromMultiple(positiveIds, [], {
+				limit,
+			});
+			const duplicates = await findDuplicates(databaseId, recommended);
+			const { added, skipped, errors } = await syncPapers(
+				databaseId,
+				recommended,
+				duplicates,
+				dryRun,
+				database,
+			);
 
-            console.log(JSON.stringify({ input: positiveIds.length, added, skipped, errors, dryRun }, null, 2));
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+			console.log(
+				JSON.stringify(
+					{ input: positiveIds.length, added, skipped, errors, dryRun },
+					null,
+					2,
+				),
+			);
+		} catch (error) {
+			console.error("Error:", error instanceof Error ? error.message : error);
+			process.exit(1);
+		}
+	});
 
 program.parse();

--- a/packages/scraper/src/cli.ts
+++ b/packages/scraper/src/cli.ts
@@ -1,91 +1,100 @@
 #!/usr/bin/env node
-import { parsePositiveInt } from "@paper-tools/core";
+import { outputJson, parsePositiveInt } from "@paper-tools/core";
 
 import { Command } from "commander";
-import { scrapeConference, scrapeAcceptedPapers } from "./researchr-scraper.js";
 import { enrichWithDblp, searchConferencePapers } from "./dblp-integration.js";
+import { scrapeAcceptedPapers, scrapeConference } from "./researchr-scraper.js";
 
 const program = new Command();
 
-async function outputJson(data: unknown, output?: string): Promise<void> {
-    const json = JSON.stringify(data, null, 2);
-    if (output) {
-        const { writeFile } = await import("node:fs/promises");
-        await writeFile(output, json, "utf-8");
-        console.error(`Output written to: ${output}`);
-        return;
-    }
-}
+program
+	.name("paper-scraper")
+	.description("Conference paper scraper: conf.researchr.org + DBLP")
+	.version("0.1.0");
 
 program
-    .name("paper-scraper")
-    .description("Conference paper scraper: conf.researchr.org + DBLP")
-    .version("0.1.0");
+	.command("scrape")
+	.description("conf.researchr.org からカンファレンス情報を取得")
+	.argument("<slug>", "カンファレンスのスラッグ (例: icse-2026)")
+	.option("--dblp <venue>", "DBLP からの論文情報で補完 (ベニュー名)")
+	.option("--max-papers <n>", "DBLP から取得する最大論文数", "100")
+	.option("-o, --output <file>", "出力JSONファイルパス")
+	.action(
+		async (
+			slug: string,
+			options: { dblp?: string; maxPapers?: string; output?: string },
+		) => {
+			try {
+				console.error(`Scraping conf.researchr.org for: ${slug}`);
+				let conference = await scrapeConference(slug);
+
+				if (options.dblp) {
+					console.error(`Enriching with DBLP data for venue: ${options.dblp}`);
+					const maxPapers = parsePositiveInt(
+						options.maxPapers || "100",
+						"--max-papers",
+					);
+					conference = await enrichWithDblp(
+						conference,
+						options.dblp,
+						maxPapers,
+					);
+				}
+
+				await outputJson(conference, options.output);
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("scrape")
-    .description("conf.researchr.org からカンファレンス情報を取得")
-    .argument("<slug>", "カンファレンスのスラッグ (例: icse-2026)")
-    .option("--dblp <venue>", "DBLP からの論文情報で補完 (ベニュー名)")
-    .option("--max-papers <n>", "DBLP から取得する最大論文数", "100")
-    .option("-o, --output <file>", "出力JSONファイルパス")
-    .action(async (slug: string, options: { dblp?: string; maxPapers?: string; output?: string }) => {
-        try {
-            console.error(`Scraping conf.researchr.org for: ${slug}`);
-            let conference = await scrapeConference(slug);
+	.command("papers")
+	.description("DBLP からカンファレンス論文を検索")
+	.argument("<venue>", "ベニュー名 (例: ICSE)")
+	.option("-y, --year <year>", "年を指定")
+	.option("-n, --max <n>", "最大取得件数", "100")
+	.option("-o, --output <file>", "出力JSONファイルパス")
+	.action(
+		async (
+			venue: string,
+			options: { year?: string; max?: string; output?: string },
+		) => {
+			try {
+				console.error(`Searching DBLP for venue: ${venue}`);
+				const year = options.year
+					? parsePositiveInt(options.year, "--year")
+					: undefined;
+				const max = parsePositiveInt(options.max || "100", "--max");
 
-            if (options.dblp) {
-                console.error(`Enriching with DBLP data for venue: ${options.dblp}`);
-                const maxPapers = parsePositiveInt(options.maxPapers || "100", "--max-papers");
-                conference = await enrichWithDblp(conference, options.dblp, maxPapers);
-            }
+				const papers = await searchConferencePapers(venue, year, max);
+				await outputJson(papers, options.output);
 
-            await outputJson(conference, options.output);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
-
-program
-    .command("papers")
-    .description("DBLP からカンファレンス論文を検索")
-    .argument("<venue>", "ベニュー名 (例: ICSE)")
-    .option("-y, --year <year>", "年を指定")
-    .option("-n, --max <n>", "最大取得件数", "100")
-    .option("-o, --output <file>", "出力JSONファイルパス")
-    .action(async (venue: string, options: { year?: string; max?: string; output?: string }) => {
-        try {
-            console.error(`Searching DBLP for venue: ${venue}`);
-            const year = options.year ? parsePositiveInt(options.year, "--year") : undefined;
-            const max = parsePositiveInt(options.max || "100", "--max");
-
-            const papers = await searchConferencePapers(venue, year, max);
-            await outputJson(papers, options.output);
-
-            console.error(`Found ${papers.length} papers`);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+				console.error(`Found ${papers.length} papers`);
+			} catch (error) {
+				console.error("Error:", error instanceof Error ? error.message : error);
+				process.exit(1);
+			}
+		},
+	);
 
 program
-    .command("accepted")
-    .description("conf.researchr.org のトラックページからAccepted Papersを取得")
-    .argument("<url>", "トラックページのURL")
-    .option("-o, --output <file>", "出力JSONファイルパス")
-    .action(async (url: string, options: { output?: string }) => {
-        try {
-            console.error(`Scraping accepted papers from: ${url}`);
-            const papers = await scrapeAcceptedPapers(url);
-            await outputJson(papers, options.output);
+	.command("accepted")
+	.description("conf.researchr.org のトラックページからAccepted Papersを取得")
+	.argument("<url>", "トラックページのURL")
+	.option("-o, --output <file>", "出力JSONファイルパス")
+	.action(async (url: string, options: { output?: string }) => {
+		try {
+			console.error(`Scraping accepted papers from: ${url}`);
+			const papers = await scrapeAcceptedPapers(url);
+			await outputJson(papers, options.output);
 
-            console.error(`Found ${papers.length} papers`);
-        } catch (error) {
-            console.error("Error:", error instanceof Error ? error.message : error);
-            process.exit(1);
-        }
-    });
+			console.error(`Found ${papers.length} papers`);
+		} catch (error) {
+			console.error("Error:", error instanceof Error ? error.message : error);
+			process.exit(1);
+		}
+	});
 
 program.parse();


### PR DESCRIPTION
🎯 **What:** Extracted the duplicated `outputJson` utility function to `@paper-tools/core` and standardized its usage across multiple CLI files, removing direct `console.log` calls in `packages/author-profiler/src/commands/save.ts` and `profile.ts`.
💡 **Why:** By centralizing `outputJson` into the core library, we eliminate code duplication in `drilldown`, `recommender`, and `scraper` packages. Additionally, replacing raw `console.log(JSON.stringify(...))` with `outputJson` in `author-profiler` improves output formatting consistency and code maintainability without introducing external UI framework dependencies.
✅ **Verification:** Verified changes by reading refactored source files, running the `biome` formatter/linter over the modified files, running the entire workspace test suite using `pnpm test`, and using `request_code_review` which rated the patch as #Correct#.
✨ **Result:** A cleaner, DRYer codebase where CLI JSON output logic is centralized in one reliable core utility, enhancing consistency across all `paper-tools` packages.

---
*PR created automatically by Jules for task [11855323604342699626](https://jules.google.com/task/11855323604342699626) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

複数の CLI パッケージに重複していた `outputJson` 関数を `@paper-tools/core` の `utils.ts` に集約し、各パッケージからはそれを import するよう統一しています。また `author-profiler` の `profile.ts` / `save.ts` では `console.log(JSON.stringify(...))` の直接呼び出しも同関数に置き換えています。

- `packages/core/src/utils.ts` に `outputJson(data, output?)` を新設。ファイルパス指定時はファイル書き込み、未指定時は stdout へ出力する実装で、`drilldown` / `scraper` の旧ローカル実装と同等。
- `drilldown`・`scraper`・`recommender` のローカル `outputJson` 定義を削除し、core からの import に置き換え。ただし `recommender` の `sync` / `sync-all` コマンドは未移行で `console.log(JSON.stringify(...))` が残存。
- `scraper` の旧ローカル実装は `-o` 未指定時に stdout 出力が欠落していたバグがあり、今回の変更で暗黙的に修正されている。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

大部分の移行は正しく行われており、マージしても実害は出ない変更です。

ほぼ全コマンドで outputJson への移行が完了しており、scraper の旧実装バグも暗黙的に修正されています。一方 recommender の sync と sync-all コマンドではまだ console.log(JSON.stringify(...)) が残っており、このPRで掲げた「全 CLI を統一」という目標が完全には達成されていません。

packages/recommender/src/cli.ts の sync・sync-all コマンド部分（console.log(JSON.stringify(...)) の残存箇所）を確認してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/utils.ts | 新たに `outputJson` ユーティリティ関数を追加。ファイルパス指定時はファイル書き込み、未指定時は stdout 出力する実装で、既存 `drilldown` / `scraper` のローカル実装と同等の動作をしている。 |
| packages/core/src/index.ts | `outputJson` をエクスポートに追加。エクスポート群がアルファベット順に再整理されたが、公開 API の内容自体は変わっていない。 |
| packages/drilldown/src/cli.ts | ローカルの `outputJson` を削除し、`@paper-tools/core` から import するよう変更。フォーマットも統一されており、動作変更なし。 |
| packages/recommender/src/cli.ts | ローカルの `outputJson` を削除して core から import したが、`sync` と `sync-all` コマンドでは依然として `console.log(JSON.stringify(...))` が残っており、移行が不完全。 |
| packages/scraper/src/cli.ts | ローカルの `outputJson` を削除して core から import。旧実装は `-o` 未指定時に stdout 出力が欠落していたバグを修正する形になっている。 |
| packages/author-profiler/src/commands/profile.ts | `console.log(JSON.stringify(..., null, 2))` を `await outputJson(profile)` に置き換え。動作は同等でコードが簡潔になった。 |
| packages/author-profiler/src/commands/save.ts | `console.log(JSON.stringify(...))` を `await outputJson(...)` に置き換え。dry-run 結果と保存結果の両方が統一された出力関数で処理される。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph core ["@paper-tools/core"]
        G["outputJson data output"]
    end

    subgraph consumers ["各パッケージ"]
        H[drilldown]
        I[scraper]
        J[recommender]
        K[author-profiler profile]
        L[author-profiler save]
    end

    H --> G
    I --> G
    J --> G
    K --> G
    L --> G

    G --> B{output あり}
    B -- Yes --> C[writeFile]
    B -- No --> D[stdout]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/recommender/src/cli.ts`, line 912-914 ([link](https://github.com/hiroki-org/paper-tools/blob/02d0bf32bfbdac427673f3e0d5b157c7f68577f5/packages/recommender/src/cli.ts#L912-L914)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **`sync` / `sync-all` コマンドが `outputJson` に移行されていない**

   このPRの目的は `console.log(JSON.stringify(...))` を `outputJson` に統一することですが、`sync` コマンド（この箇所）と `sync-all` コマンド（991–997行目付近）では依然として直接 `console.log(JSON.stringify(..., null, 2))` が使われています。他のコマンドと整合性が取れておらず、将来的にフォーマットや出力先変更を行う際に見落としの原因になります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/recommender/src/cli.ts
   Line: 912-914

   Comment:
   **`sync` / `sync-all` コマンドが `outputJson` に移行されていない**

   このPRの目的は `console.log(JSON.stringify(...))` を `outputJson` に統一することですが、`sync` コマンド（この箇所）と `sync-all` コマンド（991–997行目付近）では依然として直接 `console.log(JSON.stringify(..., null, 2))` が使われています。他のコマンドと整合性が取れておらず、将来的にフォーマットや出力先変更を行う際に見落としの原因になります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/recommender/src/cli.ts:912-914
**`sync` / `sync-all` コマンドが `outputJson` に移行されていない**

このPRの目的は `console.log(JSON.stringify(...))` を `outputJson` に統一することですが、`sync` コマンド（この箇所）と `sync-all` コマンド（991–997行目付近）では依然として直接 `console.log(JSON.stringify(..., null, 2))` が使われています。他のコマンドと整合性が取れておらず、将来的にフォーマットや出力先変更を行う際に見落としの原因になります。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Extract and standardize outputJson ut..."](https://github.com/hiroki-org/paper-tools/commit/02d0bf32bfbdac427673f3e0d5b157c7f68577f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32477380)</sub>

<!-- /greptile_comment -->