### PR TITLE
🧹 Refactor CLI save command output

### DIFF
--- a/packages/author-profiler/src/commands/save.ts
+++ b/packages/author-profiler/src/commands/save.ts
@@ -1,22 +1,29 @@
-import { buildAuthorProfile } from "../services/profile-builder.js";
-import { resolveAuthorId } from "../services/author-resolver.js";
 import { saveAuthorProfileToNotion } from "../notion/author-client.js";
+import { resolveAuthorId } from "../services/author-resolver.js";
+import { buildAuthorProfile } from "../services/profile-builder.js";
 
 interface SaveOptions {
-    id?: boolean;
-    dryRun?: boolean;
+	id?: boolean;
+	dryRun?: boolean;
 }
 
-export async function runSaveCommand(nameOrId: string, options: SaveOptions): Promise<void> {
-    const resolved = await resolveAuthorId(nameOrId, { id: options.id });
-    const profile = await buildAuthorProfile(resolved.authorId);
+export async function runSaveCommand(
+	nameOrId: string,
+	options: SaveOptions,
+): Promise<void> {
+	const resolved = await resolveAuthorId(nameOrId, { id: options.id });
+	const profile = await buildAuthorProfile(resolved.authorId);
 
-    const result = await saveAuthorProfileToNotion(profile, { dryRun: options.dryRun ?? false });
+	const result = await saveAuthorProfileToNotion(profile, {
+		dryRun: options.dryRun ?? false,
+	});
 
-    if (result.action === "dry-run") {
-        console.log(JSON.stringify({ action: "dry-run", profile }, null, 2));
-        return;
-    }
+	if (result.action === "dry-run") {
+		process.stdout.write(
+			`${JSON.stringify({ action: "dry-run", profile }, null, 2)}\n`,
+		);
+		return;
+	}
 
-    console.log(JSON.stringify(result, null, 2));
+	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }

--- a/packages/author-profiler/src/tests/commands.test.ts
+++ b/packages/author-profiler/src/tests/commands.test.ts
@@ -1,198 +1,203 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { runProfileCommand } from "../commands/profile.js";
-import { runPapersCommand } from "../commands/papers.js";
 import { runCoauthorsCommand } from "../commands/coauthors.js";
+import { runPapersCommand } from "../commands/papers.js";
+import { runProfileCommand } from "../commands/profile.js";
 import { runSaveCommand } from "../commands/save.js";
-import { buildAuthorProfile } from "../services/profile-builder.js";
+import { saveAuthorProfileToNotion } from "../notion/author-client.js";
 import { resolveAuthorId } from "../services/author-resolver.js";
 import { buildCoauthorNetwork } from "../services/coauthor-network.js";
-import { saveAuthorProfileToNotion } from "../notion/author-client.js";
+import { buildAuthorProfile } from "../services/profile-builder.js";
 
 vi.mock("../services/profile-builder.js", () => ({
-    buildAuthorProfile: vi.fn(),
+	buildAuthorProfile: vi.fn(),
 }));
 
 vi.mock("../services/author-resolver.js", () => ({
-    resolveAuthorId: vi.fn(),
+	resolveAuthorId: vi.fn(),
 }));
 
 vi.mock("../services/coauthor-network.js", () => ({
-    buildCoauthorNetwork: vi.fn(),
+	buildCoauthorNetwork: vi.fn(),
 }));
 
 vi.mock("../notion/author-client.js", () => ({
-    saveAuthorProfileToNotion: vi.fn(),
+	saveAuthorProfileToNotion: vi.fn(),
 }));
 
 describe("author-profiler command handlers", () => {
-    const mockLog = vi.spyOn(console, "log").mockImplementation(() => {});
-    const mockTable = vi.spyOn(console, "table").mockImplementation(() => {});
+	const mockLog = vi.spyOn(console, "log").mockImplementation(() => {});
+	const mockStdout = vi
+		.spyOn(process.stdout, "write")
+		.mockImplementation(() => true);
+	const mockTable = vi.spyOn(console, "table").mockImplementation(() => {});
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.mocked(resolveAuthorId).mockResolvedValue({
-            authorId: "123",
-            name: "Alice",
-        });
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(resolveAuthorId).mockResolvedValue({
+			authorId: "123",
+			name: "Alice",
+		});
+	});
 
-    it("runProfileCommand prints JSON when --json is true", async () => {
-        vi.mocked(buildAuthorProfile).mockResolvedValue({
-            id: "123",
-            name: "Alice",
-            aliases: [],
-            affiliations: [{ name: "Example U" }],
-            homepage: "https://example.com",
-            hIndex: 10,
-            citationCount: 100,
-            paperCount: 5,
-            influentialCitationCount: 4,
-            topPapers: [],
-            coauthors: [],
-            topicTimeline: [],
-        });
+	it("runProfileCommand prints JSON when --json is true", async () => {
+		vi.mocked(buildAuthorProfile).mockResolvedValue({
+			id: "123",
+			name: "Alice",
+			aliases: [],
+			affiliations: [{ name: "Example U" }],
+			homepage: "https://example.com",
+			hIndex: 10,
+			citationCount: 100,
+			paperCount: 5,
+			influentialCitationCount: 4,
+			topPapers: [],
+			coauthors: [],
+			topicTimeline: [],
+		});
 
-        await runProfileCommand("Alice", { json: true });
+		await runProfileCommand("Alice", { json: true });
 
-        expect(resolveAuthorId).toHaveBeenCalledWith("Alice", { id: undefined });
-        expect(buildAuthorProfile).toHaveBeenCalledWith("123");
-        expect(mockLog).toHaveBeenCalledTimes(1);
-        expect(mockTable).not.toHaveBeenCalled();
-    });
+		expect(resolveAuthorId).toHaveBeenCalledWith("Alice", { id: undefined });
+		expect(buildAuthorProfile).toHaveBeenCalledWith("123");
+		expect(mockLog).toHaveBeenCalledTimes(1);
+		expect(mockTable).not.toHaveBeenCalled();
+	});
 
-    it("runProfileCommand prints table when --json is false", async () => {
-        vi.mocked(buildAuthorProfile).mockResolvedValue({
-            id: "123",
-            name: "Alice",
-            aliases: [],
-            affiliations: [{ name: "Example U" }],
-            homepage: undefined,
-            hIndex: 10,
-            citationCount: 100,
-            paperCount: 5,
-            influentialCitationCount: 4,
-            topPapers: [],
-            coauthors: [],
-            topicTimeline: [],
-        });
+	it("runProfileCommand prints table when --json is false", async () => {
+		vi.mocked(buildAuthorProfile).mockResolvedValue({
+			id: "123",
+			name: "Alice",
+			aliases: [],
+			affiliations: [{ name: "Example U" }],
+			homepage: undefined,
+			hIndex: 10,
+			citationCount: 100,
+			paperCount: 5,
+			influentialCitationCount: 4,
+			topPapers: [],
+			coauthors: [],
+			topicTimeline: [],
+		});
 
-        await runProfileCommand("Alice", {});
+		await runProfileCommand("Alice", {});
 
-        expect(mockLog).toHaveBeenCalled();
-        expect(mockTable).toHaveBeenCalledTimes(1);
-    });
+		expect(mockLog).toHaveBeenCalled();
+		expect(mockTable).toHaveBeenCalledTimes(1);
+	});
 
-    it("runPapersCommand validates --top and throws for invalid values", async () => {
-        await expect(runPapersCommand("Alice", { top: "0" })).rejects.toThrow(
-            "--top には正の整数を指定してください: 0",
-        );
-    });
+	it("runPapersCommand validates --top and throws for invalid values", async () => {
+		await expect(runPapersCommand("Alice", { top: "0" })).rejects.toThrow(
+			"--top には正の整数を指定してください: 0",
+		);
+	});
 
-    it("runPapersCommand renders top papers table", async () => {
-        vi.mocked(buildAuthorProfile).mockResolvedValue({
-            id: "123",
-            name: "Alice",
-            aliases: [],
-            affiliations: [],
-            homepage: undefined,
-            hIndex: 10,
-            citationCount: 100,
-            paperCount: 5,
-            influentialCitationCount: 4,
-            topPapers: [
-                {
-                    title: "Paper A",
-                    authors: [{ name: "Alice" }],
-                    year: 2024,
-                    venue: "ICSE",
-                    citationCount: 10,
-                },
-                {
-                    title: "Paper B",
-                    authors: [{ name: "Alice" }],
-                    year: 2023,
-                    venue: "ASE",
-                    citationCount: 8,
-                },
-            ],
-            coauthors: [],
-            topicTimeline: [],
-        });
+	it("runPapersCommand renders top papers table", async () => {
+		vi.mocked(buildAuthorProfile).mockResolvedValue({
+			id: "123",
+			name: "Alice",
+			aliases: [],
+			affiliations: [],
+			homepage: undefined,
+			hIndex: 10,
+			citationCount: 100,
+			paperCount: 5,
+			influentialCitationCount: 4,
+			topPapers: [
+				{
+					title: "Paper A",
+					authors: [{ name: "Alice" }],
+					year: 2024,
+					venue: "ICSE",
+					citationCount: 10,
+				},
+				{
+					title: "Paper B",
+					authors: [{ name: "Alice" }],
+					year: 2023,
+					venue: "ASE",
+					citationCount: 8,
+				},
+			],
+			coauthors: [],
+			topicTimeline: [],
+		});
 
-        await runPapersCommand("Alice", { top: "2" });
+		await runPapersCommand("Alice", { top: "2" });
 
-        expect(buildAuthorProfile).toHaveBeenCalledWith("123", { topPapers: 2 });
-        expect(mockTable).toHaveBeenCalledTimes(1);
-    });
+		expect(buildAuthorProfile).toHaveBeenCalledWith("123", { topPapers: 2 });
+		expect(mockTable).toHaveBeenCalledTimes(1);
+	});
 
-    it("runCoauthorsCommand validates depth and throws when depth is not 1", async () => {
-        await expect(runCoauthorsCommand("Alice", { depth: "2" })).rejects.toThrow(
-            "現在 --depth は 1 のみ対応しています",
-        );
-    });
+	it("runCoauthorsCommand validates depth and throws when depth is not 1", async () => {
+		await expect(runCoauthorsCommand("Alice", { depth: "2" })).rejects.toThrow(
+			"現在 --depth は 1 のみ対応しています",
+		);
+	});
 
-    it("runCoauthorsCommand renders coauthor network table", async () => {
-        vi.mocked(buildCoauthorNetwork).mockResolvedValue([
-            { authorId: "a1", name: "Bob", paperCount: 3 },
-            { authorId: "a2", name: "Carol", paperCount: 2 },
-        ]);
+	it("runCoauthorsCommand renders coauthor network table", async () => {
+		vi.mocked(buildCoauthorNetwork).mockResolvedValue([
+			{ authorId: "a1", name: "Bob", paperCount: 3 },
+			{ authorId: "a2", name: "Carol", paperCount: 2 },
+		]);
 
-        await runCoauthorsCommand("Alice", { depth: "1" });
+		await runCoauthorsCommand("Alice", { depth: "1" });
 
-        expect(buildCoauthorNetwork).toHaveBeenCalledWith("123", {
-            limit: 200,
-            sort: "citationCount:desc",
-        });
-        expect(mockTable).toHaveBeenCalledTimes(1);
-    });
+		expect(buildCoauthorNetwork).toHaveBeenCalledWith("123", {
+			limit: 200,
+			sort: "citationCount:desc",
+		});
+		expect(mockTable).toHaveBeenCalledTimes(1);
+	});
 
-    it("runSaveCommand prints dry-run payload for dry-run action", async () => {
-        vi.mocked(buildAuthorProfile).mockResolvedValue({
-            id: "123",
-            name: "Alice",
-            aliases: [],
-            affiliations: [],
-            homepage: undefined,
-            hIndex: 10,
-            citationCount: 100,
-            paperCount: 5,
-            influentialCitationCount: 4,
-            topPapers: [],
-            coauthors: [],
-            topicTimeline: [],
-        });
-        vi.mocked(saveAuthorProfileToNotion).mockResolvedValue({ action: "dry-run" });
+	it("runSaveCommand prints dry-run payload for dry-run action", async () => {
+		vi.mocked(buildAuthorProfile).mockResolvedValue({
+			id: "123",
+			name: "Alice",
+			aliases: [],
+			affiliations: [],
+			homepage: undefined,
+			hIndex: 10,
+			citationCount: 100,
+			paperCount: 5,
+			influentialCitationCount: 4,
+			topPapers: [],
+			coauthors: [],
+			topicTimeline: [],
+		});
+		vi.mocked(saveAuthorProfileToNotion).mockResolvedValue({
+			action: "dry-run",
+		});
 
-        await runSaveCommand("Alice", { dryRun: true });
+		await runSaveCommand("Alice", { dryRun: true });
 
-        expect(saveAuthorProfileToNotion).toHaveBeenCalledWith(expect.any(Object), {
-            dryRun: true,
-        });
-        expect(mockLog).toHaveBeenCalledTimes(1);
-    });
+		expect(saveAuthorProfileToNotion).toHaveBeenCalledWith(expect.any(Object), {
+			dryRun: true,
+		});
+		expect(mockStdout).toHaveBeenCalledTimes(1);
+	});
 
-    it("runSaveCommand prints persisted result for created/updated action", async () => {
-        vi.mocked(buildAuthorProfile).mockResolvedValue({
-            id: "123",
-            name: "Alice",
-            aliases: [],
-            affiliations: [],
-            homepage: undefined,
-            hIndex: 10,
-            citationCount: 100,
-            paperCount: 5,
-            influentialCitationCount: 4,
-            topPapers: [],
-            coauthors: [],
-            topicTimeline: [],
-        });
-        vi.mocked(saveAuthorProfileToNotion).mockResolvedValue({
-            action: "created",
-            pageId: "page-1",
-        });
+	it("runSaveCommand prints persisted result for created/updated action", async () => {
+		vi.mocked(buildAuthorProfile).mockResolvedValue({
+			id: "123",
+			name: "Alice",
+			aliases: [],
+			affiliations: [],
+			homepage: undefined,
+			hIndex: 10,
+			citationCount: 100,
+			paperCount: 5,
+			influentialCitationCount: 4,
+			topPapers: [],
+			coauthors: [],
+			topicTimeline: [],
+		});
+		vi.mocked(saveAuthorProfileToNotion).mockResolvedValue({
+			action: "created",
+			pageId: "page-1",
+		});
 
-        await runSaveCommand("Alice", {});
+		await runSaveCommand("Alice", {});
 
-        expect(mockLog).toHaveBeenCalledTimes(1);
-    });
+		expect(mockStdout).toHaveBeenCalledTimes(1);
+	});
 });

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,7 @@
+🎯 **What:** Replaced `console.log` with `process.stdout.write` in the `author-profiler` CLI `save` command, correctly formatting the JSON output and appending a newline. The relevant test was also updated to spy on `process.stdout.write` instead of `console.log`.
+
+💡 **Why:** To address the "Console Log in CLI Command" code health issue. Using `process.stdout.write` avoids the automatic formatting applied by `console.log` while bypassing the need to introduce a new external UI logger or UI framework dependency just for printing the result.
+
+✅ **Verification:** Ran the full test suite (`cd packages/author-profiler && pnpm test`) and ensured the updated test for `save` command passes and no other tests regressed.
+
+✨ **Result:** A cleaner CLI codebase that adheres to code health conventions by not using `console.log`, without inflating the package dependency tree.


### PR DESCRIPTION
🎯 **What:** Replaced `console.log` with `process.stdout.write` in the `author-profiler` CLI `save` command, correctly formatting the JSON output and appending a newline. The relevant test was also updated to spy on `process.stdout.write` instead of `console.log`.

💡 **Why:** To address the "Console Log in CLI Command" code health issue. Using `process.stdout.write` avoids the automatic formatting applied by `console.log` while bypassing the need to introduce a new external UI logger or UI framework dependency just for printing the result.

✅ **Verification:** Ran the full test suite (`cd packages/author-profiler && pnpm test`) and ensured the updated test for `save` command passes and no other tests regressed.

✨ **Result:** A cleaner CLI codebase that adheres to code health conventions by not using `console.log`, without inflating the package dependency tree.

---
*PR created automatically by Jules for task [5598637412851830777](https://jules.google.com/task/5598637412851830777) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`author-profiler` の `save` コマンドにおける `console.log` を `process.stdout.write` へ置き換えるリファクタリングです。JSON出力に末尾の `\n` を付与する形式に統一し、対応するテストも `mockStdout` スパイを使うよう更新しています。

- `save.ts`: `console.log` → `process.stdout.write` に変更。`JSON.stringify` の出力をテンプレートリテラルでラップして `\n` を追加する形式に統一。
- `commands.test.ts`: `process.stdout.write` へのスパイ (`mockStdout`) を追加し、save コマンドの2テストを `mockLog` から `mockStdout` のアサーションへ更新。
- `pr_description.md`: PR説明文がリポジトリにそのままコミットされており、削除が必要。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

`save.ts` 本体の変更は安全ですが、`pr_description.md` という不要なファイルがリポジトリに追加されており、マージ前に削除が必要です。

`save.ts` の変更はロジックを変えない単純な置き換えで問題ありません。一方、`pr_description.md` はPR説明文がそのままコミットされた不要なファイルであり、リポジトリに含めるべきでなく、このままマージするとコードベースが汚染されます。

`pr_description.md` を削除する必要があります。テストファイルの引数アサーションの補強も検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/author-profiler/src/commands/save.ts | `console.log` を `process.stdout.write` に置き換え。JSON文字列に `\n` を付与する形式も正しい。ロジック変更なし。 |
| packages/author-profiler/src/tests/commands.test.ts | `mockStdout` を追加して save コマンドのテストを更新。ただし出力引数の内容を `toHaveBeenCalledWith` で検証していないため、テストカバレッジが弱い。 |
| pr_description.md | PR説明文がリポジトリにコミットされた不要なファイル。削除が必要。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["runSaveCommand(nameOrId, options)"] --> B["resolveAuthorId()"]
    B --> C["buildAuthorProfile()"]
    C --> D["saveAuthorProfileToNotion(profile, {dryRun})"]
    D --> E{result.action}
    E -- "dry-run" --> F["process.stdout.write(JSON + newline)\n{ action: 'dry-run', profile }"]
    F --> G["return"]
    E -- "created / updated" --> H["process.stdout.write(JSON + newline)\n{ result }"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
pr_description.md:1-7
**不要なファイルがリポジトリに追加されています**

`pr_description.md` はPR本文の内容がそのままリポジトリにコミットされたファイルです。Jules（Google）が自動生成したPRでは PR説明をファイルとしてコミットしてしまうことがありますが、このファイルはコードベースには不要です。マージ前に削除してください。

### Issue 2 of 2
packages/author-profiler/src/tests/commands.test.ts:152-177
**出力内容の引数アサーションが欠如しています**

`expect(mockStdout).toHaveBeenCalledTimes(1)` だけでは、`process.stdout.write` に渡された文字列の内容（`action: "dry-run"` や `profile` データが正しくシリアライズされているか、末尾に `\n` が付いているか）が検証されません。`toHaveBeenCalledWith(...)` で具体的な引数を確認すると、リグレッションを確実に捕捉できます。同様に、`runSaveCommand prints persisted result` テスト（201行目）も同じ問題があります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: replace console.log with proce..."](https://github.com/hiroki-org/paper-tools/commit/7ab9ba1e0bfb2fb0620c4191888a75f2f4a45f65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32485016)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->