### PR TITLE
🧹 Extract API route utilities

### DIFF
--- a/packages/web/src/app/api/archive/route.test.ts
+++ b/packages/web/src/app/api/archive/route.test.ts
@@ -1,15 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth", () => ({
-    getAccessToken: vi.fn(),
-    getSelectedDatabaseId: vi.fn(),
-    getUserInfo: vi.fn(),
-    getNotionClient: vi.fn(),
+	getAccessToken: vi.fn(),
+	getSelectedDatabaseId: vi.fn(),
+	getUserInfo: vi.fn(),
+	getNotionClient: vi.fn(),
 }));
 
 vi.mock("@/lib/notion-data-source", () => ({
-    resolveNotionDataSource: vi.fn(),
+	resolveNotionDataSource: vi.fn(),
 }));
 
 const auth = await import("@/lib/auth");
@@ -17,252 +17,267 @@ const notionDataSource = await import("@/lib/notion-data-source");
 const { GET, POST } = await import("./route");
 
 describe("/api/archive", () => {
-    let mockQuery: ReturnType<typeof vi.fn>;
-    let mockCreate: ReturnType<typeof vi.fn>;
+	let mockQuery: ReturnType<typeof vi.fn>;
+	let mockCreate: ReturnType<typeof vi.fn>;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
+	beforeEach(() => {
+		vi.clearAllMocks();
 
-        mockQuery = vi.fn().mockResolvedValue({ results: [] });
-        mockCreate = vi.fn().mockResolvedValue({});
+		mockQuery = vi.fn().mockResolvedValue({ results: [] });
+		mockCreate = vi.fn().mockResolvedValue({});
 
-        vi.mocked(auth.getAccessToken).mockReturnValue("fake-token");
-        vi.mocked(auth.getSelectedDatabaseId).mockReturnValue("fake-db-id");
-        vi.mocked(auth.getUserInfo).mockReturnValue({ workspaceName: "Fake Workspace" });
-        vi.mocked(auth.getNotionClient).mockReturnValue({
-            dataSources: { query: mockQuery },
-            pages: { create: mockCreate },
-        } as unknown as ReturnType<typeof auth.getNotionClient>);
+		vi.mocked(auth.getAccessToken).mockReturnValue("fake-token");
+		vi.mocked(auth.getSelectedDatabaseId).mockReturnValue("fake-db-id");
+		vi.mocked(auth.getUserInfo).mockReturnValue({
+			workspaceName: "Fake Workspace",
+		});
+		vi.mocked(auth.getNotionClient).mockReturnValue({
+			dataSources: { query: mockQuery },
+			pages: { create: mockCreate },
+		} as unknown as ReturnType<typeof auth.getNotionClient>);
 
-        vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValue({
-            object: "data_source",
-            id: "fake-ds-id",
-            title: [{ plain_text: "Fake Database" }],
-            properties: {
-                "Name": { type: "title", title: {} },
-                "DOI": { type: "rich_text", rich_text: {} },
-                "Semantic Scholar": { type: "rich_text", rich_text: {} },
-            },
-        });
-    });
+		vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValue({
+			object: "data_source",
+			id: "fake-ds-id",
+			title: [{ plain_text: "Fake Database" }],
+			properties: {
+				Name: { type: "title", title: {} },
+				DOI: { type: "rich_text", rich_text: {} },
+				"Semantic Scholar": { type: "rich_text", rich_text: {} },
+			},
+		});
+	});
 
-    describe("GET", () => {
-        it("returns 401 if access token is missing", async () => {
-            vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(401);
-            const data = await res.json();
-            expect(data.error).toBe("Not authenticated");
-        });
+	describe("GET", () => {
+		it("returns 401 if access token is missing", async () => {
+			vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(401);
+			const data = await res.json();
+			expect(data.error).toBe("Not authenticated");
+		});
 
-        it("returns 400 if database id is missing", async () => {
-            vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toBe("Database is not selected");
-        });
+		it("returns 400 if database id is missing", async () => {
+			vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(400);
+			const data = await res.json();
+			expect(data.error).toBe("Database is not selected");
+		});
 
-        it("returns empty records if no pages found", async () => {
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(200);
-            const data = await res.json();
-            expect(data.records).toHaveLength(0);
-            expect(data.total).toBe(0);
-            expect(data.database).toEqual({
-                databaseId: "fake-ds-id",
-                databaseName: "Fake Database",
-                workspaceName: "Fake Workspace",
-            });
-            expect(mockQuery).toHaveBeenCalledWith({ data_source_id: "fake-ds-id", page_size: 100 });
-        });
+		it("returns empty records if no pages found", async () => {
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data.records).toHaveLength(0);
+			expect(data.total).toBe(0);
+			expect(data.database).toEqual({
+				databaseId: "fake-ds-id",
+				databaseName: "Fake Database",
+				workspaceName: "Fake Workspace",
+			});
+			expect(mockQuery).toHaveBeenCalledWith({
+				data_source_id: "fake-ds-id",
+				page_size: 100,
+			});
+		});
 
-        it("maps page records correctly", async () => {
-            mockQuery.mockResolvedValueOnce({
-                results: [
-                    {
-                        object: "page",
-                        id: "page-1",
-                        properties: {
-                            "Name": { type: "title", title: [{ plain_text: "Test Paper" }] },
-                            "DOI": { type: "rich_text", rich_text: [{ plain_text: "10.1234/test" }] },
-                            "Semantic Scholar": { type: "rich_text", rich_text: [{ plain_text: "s2-123" }] },
-                        },
-                    },
-                    {
-                        object: "page",
-                        id: "page-2",
-                        properties: {
-                            "Name": { type: "title", title: [] }, // untitled
-                        },
-                    },
-                    {
-                        object: "not-a-page",
-                        id: "page-3",
-                    }
-                ],
-            });
+		it("maps page records correctly", async () => {
+			mockQuery.mockResolvedValueOnce({
+				results: [
+					{
+						object: "page",
+						id: "page-1",
+						properties: {
+							Name: { type: "title", title: [{ plain_text: "Test Paper" }] },
+							DOI: {
+								type: "rich_text",
+								rich_text: [{ plain_text: "10.1234/test" }],
+							},
+							"Semantic Scholar": {
+								type: "rich_text",
+								rich_text: [{ plain_text: "s2-123" }],
+							},
+						},
+					},
+					{
+						object: "page",
+						id: "page-2",
+						properties: {
+							Name: { type: "title", title: [] }, // untitled
+						},
+					},
+					{
+						object: "not-a-page",
+						id: "page-3",
+					},
+				],
+			});
 
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(200);
-            const data = await res.json();
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(200);
+			const data = await res.json();
 
-            expect(data.records).toHaveLength(2); // filters out not-a-page
-            expect(data.records[0]).toEqual({
-                pageId: "page-1",
-                title: "Test Paper",
-                doi: "10.1234/test",
-                semanticScholarId: "s2-123",
-            });
-            expect(data.records[1]).toEqual({
-                pageId: "page-2",
-                title: "(untitled)",
-            });
-            expect(data.total).toBe(2);
-        });
+			expect(data.records).toHaveLength(2); // filters out not-a-page
+			expect(data.records[0]).toEqual({
+				pageId: "page-1",
+				title: "Test Paper",
+				doi: "10.1234/test",
+				semanticScholarId: "s2-123",
+			});
+			expect(data.records[1]).toEqual({
+				pageId: "page-2",
+				title: "(untitled)",
+			});
+			expect(data.total).toBe(2);
+		});
 
-        it("returns 500 on error", async () => {
-            mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Notion API Error");
-        });
+		it("returns 500 on error", async () => {
+			mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Notion API Error");
+		});
 
-        it("returns 500 on non-Error error", async () => {
-            mockQuery.mockRejectedValueOnce("Unknown Error String");
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Unknown error");
-        });
-    });
+		it("returns 500 on non-Error error", async () => {
+			mockQuery.mockRejectedValueOnce("Unknown Error String");
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Unknown error");
+		});
+	});
 
-    describe("POST", () => {
-        const mockPaper = {
-            paperId: "s2-456",
-            title: "New Test Paper",
-            externalIds: { DOI: "10.5678/new" },
-        };
+	describe("POST", () => {
+		const mockPaper = {
+			paperId: "s2-456",
+			title: "New Test Paper",
+			externalIds: { DOI: "10.5678/new" },
+		};
 
-        it("returns 401 if access token is missing", async () => {
-            vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(401);
-        });
+		it("returns 401 if access token is missing", async () => {
+			vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(401);
+		});
 
-        it("returns 400 if database id is missing", async () => {
-            vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(400);
-        });
+		it("returns 400 if database id is missing", async () => {
+			vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(400);
+		});
 
-        it("returns 400 if paper is missing from body", async () => {
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({}),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toBe("paper is required");
-        });
+		it("returns 400 if paper is missing from body", async () => {
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(400);
+			const data = await res.json();
+			expect(data.error).toBe("paper is required");
+		});
 
-        it("creates a page in notion successfully", async () => {
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(200);
-            const data = await res.json();
-            expect(data.success).toBe(true);
+		it("creates a page in notion successfully", async () => {
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data.success).toBe(true);
 
-            expect(mockCreate).toHaveBeenCalledWith({
-                parent: { data_source_id: "fake-ds-id" },
-                properties: {
-                    "Name": { title: [{ text: { content: "New Test Paper" } }] },
-                    "DOI": { rich_text: [{ text: { content: "10.5678/new" } }] },
-                    "Semantic Scholar": { rich_text: [{ text: { content: "s2-456" } }] },
-                },
-            });
-        });
+			expect(mockCreate).toHaveBeenCalledWith({
+				parent: { data_source_id: "fake-ds-id" },
+				properties: {
+					Name: { title: [{ text: { content: "New Test Paper" } }] },
+					DOI: { rich_text: [{ text: { content: "10.5678/new" } }] },
+					"Semantic Scholar": { rich_text: [{ text: { content: "s2-456" } }] },
+				},
+			});
+		});
 
-        it("handles url type for DOI", async () => {
-             vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValueOnce({
-                object: "data_source",
-                id: "fake-ds-id",
-                properties: {
-                    "Name": { type: "title", title: {} },
-                    "DOI": { type: "url", url: "" },
-                },
-            });
+		it("handles url type for DOI", async () => {
+			vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValueOnce(
+				{
+					object: "data_source",
+					id: "fake-ds-id",
+					properties: {
+						Name: { type: "title", title: {} },
+						DOI: { type: "url", url: "" },
+					},
+				},
+			);
 
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            await POST(req);
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			await POST(req);
 
-            expect(mockCreate).toHaveBeenCalledWith({
-                parent: { data_source_id: "fake-ds-id" },
-                properties: {
-                    "Name": { title: [{ text: { content: "New Test Paper" } }] },
-                    "DOI": { url: "https://doi.org/10.5678/new" },
-                },
-            });
-        });
+			expect(mockCreate).toHaveBeenCalledWith({
+				parent: { data_source_id: "fake-ds-id" },
+				properties: {
+					Name: { title: [{ text: { content: "New Test Paper" } }] },
+					DOI: { url: "https://doi.org/10.5678/new" },
+				},
+			});
+		});
 
-        it("handles missing title in paper gracefully", async () => {
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: { paperId: "123" } }),
-            });
-            await POST(req);
+		it("handles missing title in paper gracefully", async () => {
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: { paperId: "123" } }),
+			});
+			await POST(req);
 
-            expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
-                properties: expect.objectContaining({
-                    "Name": { title: [{ text: { content: "Untitled" } }] },
-                }),
-            }));
-        });
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					properties: expect.objectContaining({
+						Name: { title: [{ text: { content: "Untitled" } }] },
+					}),
+				}),
+			);
+		});
 
-        it("returns 500 on error", async () => {
-            mockCreate.mockRejectedValueOnce(new Error("Create Error"));
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Create Error");
-        });
+		it("returns 500 on error", async () => {
+			mockCreate.mockRejectedValueOnce(new Error("Create Error"));
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Create Error");
+		});
 
-        it("returns 500 on non-Error error in POST", async () => {
-            mockCreate.mockRejectedValueOnce("Unknown Create Error");
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Unknown error");
-        });
-    });
+		it("returns 500 on non-Error error in POST", async () => {
+			mockCreate.mockRejectedValueOnce("Unknown Create Error");
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Unknown error");
+		});
+	});
 });

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -1,188 +1,220 @@
-import { NextRequest, NextResponse } from "next/server";
 import type { S2Paper } from "@paper-tools/core";
-import { getAccessToken, getNotionClient, getSelectedDatabaseId, getUserInfo } from "@/lib/auth";
-import { resolveNotionDataSource, type NotionDataSource } from "@/lib/notion-data-source";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	getAccessToken,
+	getNotionClient,
+	getSelectedDatabaseId,
+	getUserInfo,
+} from "@/lib/auth";
+import {
+	type NotionDataSource,
+	resolveNotionDataSource,
+} from "@/lib/notion-data-source";
 
 type NotionProperty = {
-    type?: string;
-    title?: Array<{ plain_text?: string }>;
-    rich_text?: Array<{ plain_text?: string }>;
-    url?: string | null;
-    multi_select?: Array<{ name?: string }>;
+	type?: string;
+	title?: Array<{ plain_text?: string }>;
+	rich_text?: Array<{ plain_text?: string }>;
+	url?: string | null;
+	multi_select?: Array<{ name?: string }>;
 };
 
 type ArchiveNotionDataSource = NotionDataSource<NotionProperty>;
 
 type NotionClient = ReturnType<typeof getNotionClient>;
-type NotionPageCreateProperties = Parameters<NotionClient["pages"]["create"]>[0]["properties"];
+type NotionPageCreateProperties = Parameters<
+	NotionClient["pages"]["create"]
+>[0]["properties"];
 
 function getPlainText(items: Array<{ plain_text?: string }> | undefined) {
-    return (items ?? []).map((item) => item.plain_text ?? "").join("").trim();
+	return (items ?? [])
+		.map((item) => item.plain_text ?? "")
+		.join("")
+		.trim();
 }
 
 function findTitleProperty(properties: Record<string, NotionProperty>) {
-    const entry = Object.entries(properties).find(([, prop]) => prop.type === "title");
-    return entry?.[0] ?? "Name";
+	const entry = Object.entries(properties).find(
+		([, prop]) => prop.type === "title",
+	);
+	return entry?.[0] ?? "Name";
 }
 
-function findPropertyByKeyword(properties: Record<string, NotionProperty>, keyword: string) {
-    const lower = keyword.toLowerCase();
-    let partialMatch: string | null = null;
+function findPropertyByKeyword(
+	properties: Record<string, NotionProperty>,
+	keyword: string,
+) {
+	const lower = keyword.toLowerCase();
+	let partialMatch: string | null = null;
 
-    for (const name of Object.keys(properties)) {
-        const nameLower = name.toLowerCase();
-        if (nameLower === lower) {
-            return name;
-        }
-        if (!partialMatch && nameLower.includes(lower)) {
-            partialMatch = name;
-        }
-    }
+	for (const name of Object.keys(properties)) {
+		const nameLower = name.toLowerCase();
+		if (nameLower === lower) {
+			return name;
+		}
+		if (!partialMatch && nameLower.includes(lower)) {
+			partialMatch = name;
+		}
+	}
 
-    return partialMatch;
+	return partialMatch;
 }
 
 function mapPageRecord(page: {
-    id: string;
-    properties: Record<string, NotionProperty>;
+	id: string;
+	properties: Record<string, NotionProperty>;
 }) {
-    const props = page.properties;
-    const titleKey = findTitleProperty(props);
-    const doiKey = findPropertyByKeyword(props, "doi");
-    const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
+	const props = page.properties;
+	const titleKey = findTitleProperty(props);
+	const doiKey = findPropertyByKeyword(props, "doi");
+	const s2Key =
+		findPropertyByKeyword(props, "semantic scholar") ??
+		findPropertyByKeyword(props, "s2");
 
-    const titleProp = props[titleKey];
-    const doiProp = doiKey ? props[doiKey] : undefined;
-    const s2Prop = s2Key ? props[s2Key] : undefined;
+	const titleProp = props[titleKey];
+	const doiProp = doiKey ? props[doiKey] : undefined;
+	const s2Prop = s2Key ? props[s2Key] : undefined;
 
-    return {
-        pageId: page.id,
-        title: getPlainText(titleProp?.title) || "(untitled)",
-        doi: getPlainText(doiProp?.rich_text) || doiProp?.url || undefined,
-        semanticScholarId: getPlainText(s2Prop?.rich_text) || undefined,
-    };
+	return {
+		pageId: page.id,
+		title: getPlainText(titleProp?.title) || "(untitled)",
+		doi: getPlainText(doiProp?.rich_text) || doiProp?.url || undefined,
+		semanticScholarId: getPlainText(s2Prop?.rich_text) || undefined,
+	};
 }
 
 function parseAuth(request: NextRequest) {
-    const accessToken = getAccessToken(request.cookies);
-    const dataSourceId = getSelectedDatabaseId(request.cookies);
-    if (!accessToken) {
-        return { ok: false as const, status: 401, error: "Not authenticated" };
-    }
-    if (!dataSourceId) {
-        return { ok: false as const, status: 400, error: "Database is not selected" };
-    }
-    return { ok: true as const, accessToken, dataSourceId };
+	const accessToken = getAccessToken(request.cookies);
+	const dataSourceId = getSelectedDatabaseId(request.cookies);
+	if (!accessToken) {
+		return { ok: false as const, status: 401, error: "Not authenticated" };
+	}
+	if (!dataSourceId) {
+		return {
+			ok: false as const,
+			status: 400,
+			error: "Database is not selected",
+		};
+	}
+	return { ok: true as const, accessToken, dataSourceId };
 }
 
 export async function GET(request: NextRequest) {
-    const auth = parseAuth(request);
-    if (!auth.ok) {
-        return NextResponse.json({ error: auth.error }, { status: auth.status });
-    }
+	const auth = parseAuth(request);
+	if (!auth.ok) {
+		return NextResponse.json({ error: auth.error }, { status: auth.status });
+	}
 
-    try {
-        const notion = getNotionClient(auth.accessToken);
-        const dataSource: ArchiveNotionDataSource = await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
-        const recordsRes = await notion.dataSources.query({
-            data_source_id: dataSource.id,
-            page_size: 100,
-        });
+	try {
+		const notion = getNotionClient(auth.accessToken);
+		const dataSource: ArchiveNotionDataSource =
+			await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
+		const recordsRes = await notion.dataSources.query({
+			data_source_id: dataSource.id,
+			page_size: 100,
+		});
 
-        const records = recordsRes.results
-            .filter((r) => r.object === "page")
-            .map((page) => mapPageRecord(page as { id: string; properties: Record<string, NotionProperty> }));
+		const records = recordsRes.results
+			.filter((r) => r.object === "page")
+			.map((page) =>
+				mapPageRecord(
+					page as { id: string; properties: Record<string, NotionProperty> },
+				),
+			);
 
-        const userInfo = getUserInfo(request.cookies);
-        const databaseTitle = dataSource.title ?? [];
-        const databaseName = getPlainText(databaseTitle) || "(untitled database)";
+		const userInfo = getUserInfo(request.cookies);
+		const databaseTitle = dataSource.title ?? [];
+		const databaseName = getPlainText(databaseTitle) || "(untitled database)";
 
-        return NextResponse.json({
-            records,
-            total: records.length,
-            database: {
-                databaseId: dataSource.id,
-                databaseName,
-                workspaceName: userInfo?.workspaceName ?? "Notion Workspace",
-            },
-        });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		return NextResponse.json({
+			records,
+			total: records.length,
+			database: {
+				databaseId: dataSource.id,
+				databaseName,
+				workspaceName: userInfo?.workspaceName ?? "Notion Workspace",
+			},
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }
 
 export async function POST(request: NextRequest) {
-    const auth = parseAuth(request);
-    if (!auth.ok) {
-        return NextResponse.json({ error: auth.error }, { status: auth.status });
-    }
+	const auth = parseAuth(request);
+	if (!auth.ok) {
+		return NextResponse.json({ error: auth.error }, { status: auth.status });
+	}
 
-    try {
-        const body = (await request.json()) as { paper: S2Paper; tags?: string[] };
-        const { paper } = body;
+	try {
+		const body = (await request.json()) as { paper: S2Paper; tags?: string[] };
+		const { paper } = body;
 
-        if (!paper) {
-            return NextResponse.json({ error: "paper is required" }, { status: 400 });
-        }
+		if (!paper) {
+			return NextResponse.json({ error: "paper is required" }, { status: 400 });
+		}
 
-        const notion = getNotionClient(auth.accessToken);
-        const dataSource: ArchiveNotionDataSource = await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
-        const props = dataSource.properties;
-        const titleKey = findTitleProperty(props);
-        const doiKey = findPropertyByKeyword(props, "doi");
-        const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
-        const tagsKey = findPropertyByKeyword(props, "tag");
+		const notion = getNotionClient(auth.accessToken);
+		const dataSource: ArchiveNotionDataSource =
+			await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
+		const props = dataSource.properties;
+		const titleKey = findTitleProperty(props);
+		const doiKey = findPropertyByKeyword(props, "doi");
+		const s2Key =
+			findPropertyByKeyword(props, "semantic scholar") ??
+			findPropertyByKeyword(props, "s2");
+		const tagsKey = findPropertyByKeyword(props, "tag");
 
-        const properties: NotionPageCreateProperties = {
-            [titleKey]: {
-                title: [{ text: { content: paper.title ?? "Untitled" } }],
-            },
-        };
+		const properties: NotionPageCreateProperties = {
+			[titleKey]: {
+				title: [{ text: { content: paper.title ?? "Untitled" } }],
+			},
+		};
 
-        const doi = paper.externalIds?.DOI?.trim();
-        if (doiKey && doi) {
-            const doiType = props[doiKey]?.type;
-            if (doiType === "url") {
-                properties[doiKey] = { url: `https://doi.org/${doi}` };
-            } else {
-                properties[doiKey] = { rich_text: [{ text: { content: doi } }] };
-            }
-        }
+		const doi = paper.externalIds?.DOI?.trim();
+		if (doiKey && doi) {
+			const doiType = props[doiKey]?.type;
+			if (doiType === "url") {
+				properties[doiKey] = { url: `https://doi.org/${doi}` };
+			} else {
+				properties[doiKey] = { rich_text: [{ text: { content: doi } }] };
+			}
+		}
 
-        if (s2Key && paper.paperId) {
-            properties[s2Key] = {
-                rich_text: [{ text: { content: paper.paperId } }],
-            };
-        }
+		if (s2Key && paper.paperId) {
+			properties[s2Key] = {
+				rich_text: [{ text: { content: paper.paperId } }],
+			};
+		}
 
-        if (tagsKey && Array.isArray(body.tags) && body.tags.length > 0) {
-            const tagsType = props[tagsKey]?.type;
-            if (tagsType === "multi_select") {
-                const tagMap = new Map<string, string>();
-                for (const rawTag of body.tags) {
-                    const normalized = rawTag.trim();
-                    if (!normalized) continue;
-                    const dedupeKey = normalized.toLowerCase();
-                    if (!tagMap.has(dedupeKey)) {
-                        tagMap.set(dedupeKey, normalized);
-                    }
-                }
-                const tags = Array.from(tagMap.values()).map((name) => ({ name }));
-                if (tags.length > 0) {
-                    properties[tagsKey] = { multi_select: tags };
-                }
-            }
-        }
+		if (tagsKey && Array.isArray(body.tags) && body.tags.length > 0) {
+			const tagsType = props[tagsKey]?.type;
+			if (tagsType === "multi_select") {
+				const tagMap = new Map<string, string>();
+				for (const rawTag of body.tags) {
+					const normalized = rawTag.trim();
+					if (!normalized) continue;
+					const dedupeKey = normalized.toLowerCase();
+					if (!tagMap.has(dedupeKey)) {
+						tagMap.set(dedupeKey, normalized);
+					}
+				}
+				const tags = Array.from(tagMap.values()).map((name) => ({ name }));
+				if (tags.length > 0) {
+					properties[tagsKey] = { multi_select: tags };
+				}
+			}
+		}
 
-        await notion.pages.create({
-            parent: { data_source_id: dataSource.id },
-            properties,
-        });
+		await notion.pages.create({
+			parent: { data_source_id: dataSource.id },
+			properties,
+		});
 
-        return NextResponse.json({ success: true });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -1,66 +1,78 @@
 import { Client } from "@notionhq/client";
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import {
-    OAUTH_STATE_COOKIE,
-    buildNotionRedirectUri,
-    setAuthCookies,
+	buildNotionRedirectUri,
+	OAUTH_STATE_COOKIE,
+	setAuthCookies,
 } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
-    const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
-    const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
-    if (!clientId || !clientSecret) {
-        return NextResponse.redirect(new URL("/login?error=missing_oauth_config", request.url));
-    }
+	const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
+	const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
+	if (!clientId || !clientSecret) {
+		return NextResponse.redirect(
+			new URL("/login?error=missing_oauth_config", request.url),
+		);
+	}
 
-    const url = new URL(request.url);
-    const code = url.searchParams.get("code");
-    const state = url.searchParams.get("state");
-    const stateInCookie = request.cookies.get(OAUTH_STATE_COOKIE)?.value;
+	const url = new URL(request.url);
+	const code = url.searchParams.get("code");
+	const state = url.searchParams.get("state");
+	const stateInCookie = request.cookies.get(OAUTH_STATE_COOKIE)?.value;
 
-    if (!code || !state || !stateInCookie || state !== stateInCookie) {
-        return NextResponse.redirect(new URL("/login?error=invalid_state", request.url));
-    }
+	if (!code || !state || !stateInCookie || state !== stateInCookie) {
+		return NextResponse.redirect(
+			new URL("/login?error=invalid_state", request.url),
+		);
+	}
 
-    try {
-        const notion = new Client();
-        const tokenResponse = await notion.oauth.token({
-            client_id: clientId,
-            client_secret: clientSecret,
-            grant_type: "authorization_code",
-            code,
-            redirect_uri: buildNotionRedirectUri(request),
-        });
+	try {
+		const notion = new Client();
+		const tokenResponse = await notion.oauth.token({
+			client_id: clientId,
+			client_secret: clientSecret,
+			grant_type: "authorization_code",
+			code,
+			redirect_uri: buildNotionRedirectUri(request),
+		});
 
-        const owner = tokenResponse.owner;
-        const userName = owner.type === "user" ? (owner.user as any)?.name : undefined;
+		const owner = tokenResponse.owner;
+		const userName =
+			owner.type === "user" ? (owner.user as any)?.name : undefined;
 
-        const response = NextResponse.redirect(new URL("/setup", request.url));
-        const refreshToken = (tokenResponse as any).refresh_token as string | undefined;
-        if (!refreshToken) {
-            return NextResponse.redirect(new URL("/login?error=missing_refresh_token", request.url));
-        }
+		const response = NextResponse.redirect(new URL("/setup", request.url));
+		const refreshToken = (tokenResponse as any).refresh_token as
+			| string
+			| undefined;
+		if (!refreshToken) {
+			return NextResponse.redirect(
+				new URL("/login?error=missing_refresh_token", request.url),
+			);
+		}
 
-        setAuthCookies(response, {
-            accessToken: tokenResponse.access_token,
-            refreshToken,
-            userInfo: {
-                name: userName,
-                workspaceName: tokenResponse.workspace_name ?? undefined,
-                workspaceIcon: tokenResponse.workspace_icon,
-            },
-            request,
-        });
-        response.cookies.set(OAUTH_STATE_COOKIE, "", {
-            path: "/",
-            maxAge: 0,
-            httpOnly: true,
-            secure: process.env.NODE_ENV === "production",
-            sameSite: "lax",
-        });
-        return response;
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "OAuth callback failed";
-        return NextResponse.redirect(new URL(`/login?error=${encodeURIComponent(message)}`, request.url));
-    }
+		setAuthCookies(response, {
+			accessToken: tokenResponse.access_token,
+			refreshToken,
+			userInfo: {
+				name: userName,
+				workspaceName: tokenResponse.workspace_name ?? undefined,
+				workspaceIcon: tokenResponse.workspace_icon,
+			},
+			request,
+		});
+		response.cookies.set(OAUTH_STATE_COOKIE, "", {
+			path: "/",
+			maxAge: 0,
+			httpOnly: true,
+			secure: process.env.NODE_ENV === "production",
+			sameSite: "lax",
+		});
+		return response;
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "OAuth callback failed";
+		return NextResponse.redirect(
+			new URL(`/login?error=${encodeURIComponent(message)}`, request.url),
+		);
+	}
 }

--- a/packages/web/src/app/api/auth/logout/route.ts
+++ b/packages/web/src/app/api/auth/logout/route.ts
@@ -1,9 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { clearAuthCookies } from "@/lib/auth";
 
 // Only POST is allowed to prevent CSRF attacks
 export async function POST(request: NextRequest) {
-    const response = NextResponse.redirect(new URL("/login", request.url), { status: 303 });
-    clearAuthCookies(response);
-    return response;
+	const response = NextResponse.redirect(new URL("/login", request.url), {
+		status: 303,
+	});
+	clearAuthCookies(response);
+	return response;
 }

--- a/packages/web/src/app/api/auth/notion/route.ts
+++ b/packages/web/src/app/api/auth/notion/route.ts
@@ -1,23 +1,30 @@
-import { NextRequest, NextResponse } from "next/server";
-import { buildNotionRedirectUri, createStateToken, setOauthStateCookie } from "@/lib/auth";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	buildNotionRedirectUri,
+	createStateToken,
+	setOauthStateCookie,
+} from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
-    const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
-    if (!clientId) {
-        return NextResponse.json({ error: "NOTION_OAUTH_CLIENT_ID is not set" }, { status: 500 });
-    }
+	const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
+	if (!clientId) {
+		return NextResponse.json(
+			{ error: "NOTION_OAUTH_CLIENT_ID is not set" },
+			{ status: 500 },
+		);
+	}
 
-    const state = createStateToken();
-    const redirectUri = buildNotionRedirectUri(request);
+	const state = createStateToken();
+	const redirectUri = buildNotionRedirectUri(request);
 
-    const url = new URL("https://api.notion.com/v1/oauth/authorize");
-    url.searchParams.set("client_id", clientId);
-    url.searchParams.set("redirect_uri", redirectUri);
-    url.searchParams.set("response_type", "code");
-    url.searchParams.set("owner", "user");
-    url.searchParams.set("state", state);
+	const url = new URL("https://api.notion.com/v1/oauth/authorize");
+	url.searchParams.set("client_id", clientId);
+	url.searchParams.set("redirect_uri", redirectUri);
+	url.searchParams.set("response_type", "code");
+	url.searchParams.set("owner", "user");
+	url.searchParams.set("state", state);
 
-    const response = NextResponse.redirect(url);
-    setOauthStateCookie(response, state, request);
-    return response;
+	const response = NextResponse.redirect(url);
+	setOauthStateCookie(response, state, request);
+	return response;
 }

--- a/packages/web/src/app/api/auth/refresh/route.test.ts
+++ b/packages/web/src/app/api/auth/refresh/route.test.ts
@@ -1,138 +1,156 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { NextRequest } from "next/server";
-import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE, USER_INFO_COOKIE } from "@/lib/auth-cookies";
 
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Instead of mocking the whole auth module, we'll spy on the getters to simulate incoming cookies
 // and allow setAuthCookies to operate normally on the NextResponse object.
 import * as auth from "@/lib/auth";
+import {
+	ACCESS_TOKEN_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
+} from "@/lib/auth-cookies";
 
 const { POST } = await import("./route");
 
 describe("/api/auth/refresh POST", () => {
-    let mockFetch: any;
+	let mockFetch: any;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "test-client-id");
-        vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "test-client-secret");
-        vi.stubEnv("COOKIE_SECRET", "test-secret");
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "test-client-id");
+		vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "test-client-secret");
+		vi.stubEnv("COOKIE_SECRET", "test-secret");
 
-        mockFetch = vi.fn();
-        vi.stubGlobal("fetch", mockFetch);
+		mockFetch = vi.fn();
+		vi.stubGlobal("fetch", mockFetch);
 
-        vi.spyOn(auth, "getRefreshToken").mockReturnValue("old-refresh-token");
-        vi.spyOn(auth, "getUserInfo").mockReturnValue(null);
-    });
+		vi.spyOn(auth, "getRefreshToken").mockReturnValue("old-refresh-token");
+		vi.spyOn(auth, "getUserInfo").mockReturnValue(null);
+	});
 
-    afterEach(() => {
-        vi.unstubAllEnvs();
-        vi.unstubAllGlobals();
-        vi.restoreAllMocks();
-    });
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
 
-    it("should return 500 if OAuth config is missing", async () => {
-        vi.unstubAllEnvs();
-        vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "");
-        vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "");
+	it("should return 500 if OAuth config is missing", async () => {
+		vi.unstubAllEnvs();
+		vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "");
+		vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "");
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(500);
-        const data = await res.json();
-        expect(data.error).toBe("OAuth config is missing");
-    });
+		expect(res.status).toBe(500);
+		const data = await res.json();
+		expect(data.error).toBe("OAuth config is missing");
+	});
 
-    it("should return 401 if refresh token is not found in cookies", async () => {
-        vi.spyOn(auth, "getRefreshToken").mockReturnValue(null);
+	it("should return 401 if refresh token is not found in cookies", async () => {
+		vi.spyOn(auth, "getRefreshToken").mockReturnValue(null);
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(401);
-        const data = await res.json();
-        expect(data.error).toBe("refresh_token not found");
-    });
+		expect(res.status).toBe(401);
+		const data = await res.json();
+		expect(data.error).toBe("refresh_token not found");
+	});
 
-    it("should return 401 if Notion API request fails", async () => {
-        mockFetch.mockResolvedValue({
-            ok: false,
-            status: 400,
-            json: async () => ({ error: "invalid_grant" }),
-        });
+	it("should return 401 if Notion API request fails", async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 400,
+			json: async () => ({ error: "invalid_grant" }),
+		});
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(400);
-        const data = await res.json();
-        expect(data.error).toBe("invalid_grant");
-    });
+		expect(res.status).toBe(400);
+		const data = await res.json();
+		expect(data.error).toBe("invalid_grant");
+	});
 
-    it("should return 502 if Notion response is missing refresh_token", async () => {
-        mockFetch.mockResolvedValue({
-            ok: true,
-            status: 200,
-            json: async () => ({ access_token: "new-access-token" }), // Missing refresh_token
-        });
+	it("should return 502 if Notion response is missing refresh_token", async () => {
+		mockFetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ access_token: "new-access-token" }), // Missing refresh_token
+		});
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(502);
-        const data = await res.json();
-        expect(data.error).toBe("refresh_token missing in response");
-    });
+		expect(res.status).toBe(502);
+		const data = await res.json();
+		expect(data.error).toBe("refresh_token missing in response");
+	});
 
-    it("should return 200, call fetch correctly, and set cookies on success", async () => {
-        mockFetch.mockResolvedValue({
-            ok: true,
-            status: 200,
-            json: async () => ({
-                access_token: "new-access-token",
-                refresh_token: "new-refresh-token",
-                workspace_name: "Test Workspace",
-            }),
-        });
+	it("should return 200, call fetch correctly, and set cookies on success", async () => {
+		mockFetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				workspace_name: "Test Workspace",
+			}),
+		});
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(200);
-        const data = await res.json();
-        expect(data.success).toBe(true);
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.success).toBe(true);
 
-        // Assert fetch was called correctly
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        const [url, options] = mockFetch.mock.calls[0];
-        expect(url).toBe("https://api.notion.com/v1/oauth/token");
-        expect(options.method).toBe("POST");
-        const basic = Buffer.from("test-client-id:test-client-secret").toString("base64");
-        expect(options.headers).toMatchObject({
-            "Content-Type": "application/json",
-            "Notion-Version": "2025-09-03",
-            "Authorization": `Basic ${basic}`
-        });
-        expect(JSON.parse(options.body)).toEqual({
-            grant_type: "refresh_token",
-            refresh_token: "old-refresh-token"
-        });
+		// Assert fetch was called correctly
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		const [url, options] = mockFetch.mock.calls[0];
+		expect(url).toBe("https://api.notion.com/v1/oauth/token");
+		expect(options.method).toBe("POST");
+		const basic = Buffer.from("test-client-id:test-client-secret").toString(
+			"base64",
+		);
+		expect(options.headers).toMatchObject({
+			"Content-Type": "application/json",
+			"Notion-Version": "2025-09-03",
+			Authorization: `Basic ${basic}`,
+		});
+		expect(JSON.parse(options.body)).toEqual({
+			grant_type: "refresh_token",
+			refresh_token: "old-refresh-token",
+		});
 
-        // Assert cookies were set properly
-        expect(res.cookies.get(ACCESS_TOKEN_COOKIE)).toBeDefined();
-        expect(res.cookies.get(REFRESH_TOKEN_COOKIE)).toBeDefined();
-        expect(res.cookies.get(USER_INFO_COOKIE)).toBeDefined();
-    });
+		// Assert cookies were set properly
+		expect(res.cookies.get(ACCESS_TOKEN_COOKIE)).toBeDefined();
+		expect(res.cookies.get(REFRESH_TOKEN_COOKIE)).toBeDefined();
+		expect(res.cookies.get(USER_INFO_COOKIE)).toBeDefined();
+	});
 
-    it("should return 401 if fetch throws an error", async () => {
-        mockFetch.mockRejectedValue(new Error("Network failure"));
+	it("should return 401 if fetch throws an error", async () => {
+		mockFetch.mockRejectedValue(new Error("Network failure"));
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(401);
-        const data = await res.json();
-        expect(data.error).toBe("Network failure");
-    });
+		expect(res.status).toBe(401);
+		const data = await res.json();
+		expect(data.error).toBe("Network failure");
+	});
 });

--- a/packages/web/src/app/api/auth/refresh/route.ts
+++ b/packages/web/src/app/api/auth/refresh/route.ts
@@ -1,65 +1,76 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getRefreshToken, getUserInfo, setAuthCookies } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
-    const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
-    const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
-    if (!clientId || !clientSecret) {
-        return NextResponse.json({ error: "OAuth config is missing" }, { status: 500 });
-    }
+	const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
+	const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
+	if (!clientId || !clientSecret) {
+		return NextResponse.json(
+			{ error: "OAuth config is missing" },
+			{ status: 500 },
+		);
+	}
 
-    const refreshToken = getRefreshToken(request.cookies);
-    if (!refreshToken) {
-        return NextResponse.json({ error: "refresh_token not found" }, { status: 401 });
-    }
+	const refreshToken = getRefreshToken(request.cookies);
+	if (!refreshToken) {
+		return NextResponse.json(
+			{ error: "refresh_token not found" },
+			{ status: 401 },
+		);
+	}
 
-    try {
-        const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
-        const tokenRes = await fetch("https://api.notion.com/v1/oauth/token", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Notion-Version": "2025-09-03",
-                Authorization: `Basic ${basic}`,
-            },
-            body: JSON.stringify({
-                grant_type: "refresh_token",
-                refresh_token: refreshToken,
-            }),
-        });
-        const tokenResponse = (await tokenRes.json()) as {
-            access_token?: string;
-            refresh_token?: string;
-            workspace_name?: string | null;
-            workspace_icon?: string | null;
-            error?: string;
-        };
-        if (!tokenRes.ok || !tokenResponse.access_token) {
-            return NextResponse.json(
-                { error: tokenResponse.error ?? "Refresh failed" },
-                { status: tokenRes.status || 401 },
-            );
-        }
-        const nextRefreshToken = (tokenResponse as any).refresh_token as string | undefined;
-        if (!nextRefreshToken) {
-            return NextResponse.json({ error: "refresh_token missing in response" }, { status: 502 });
-        }
+	try {
+		const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+		const tokenRes = await fetch("https://api.notion.com/v1/oauth/token", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Notion-Version": "2025-09-03",
+				Authorization: `Basic ${basic}`,
+			},
+			body: JSON.stringify({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+			}),
+		});
+		const tokenResponse = (await tokenRes.json()) as {
+			access_token?: string;
+			refresh_token?: string;
+			workspace_name?: string | null;
+			workspace_icon?: string | null;
+			error?: string;
+		};
+		if (!tokenRes.ok || !tokenResponse.access_token) {
+			return NextResponse.json(
+				{ error: tokenResponse.error ?? "Refresh failed" },
+				{ status: tokenRes.status || 401 },
+			);
+		}
+		const nextRefreshToken = (tokenResponse as any).refresh_token as
+			| string
+			| undefined;
+		if (!nextRefreshToken) {
+			return NextResponse.json(
+				{ error: "refresh_token missing in response" },
+				{ status: 502 },
+			);
+		}
 
-        const userInfo = getUserInfo(request.cookies) ?? {
-            workspaceName: tokenResponse.workspace_name ?? undefined,
-            workspaceIcon: tokenResponse.workspace_icon,
-        };
+		const userInfo = getUserInfo(request.cookies) ?? {
+			workspaceName: tokenResponse.workspace_name ?? undefined,
+			workspaceIcon: tokenResponse.workspace_icon,
+		};
 
-        const response = NextResponse.json({ success: true });
-        setAuthCookies(response, {
-            accessToken: tokenResponse.access_token,
-            refreshToken: nextRefreshToken,
-            userInfo,
-            request,
-        });
-        return response;
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Refresh failed";
-        return NextResponse.json({ error: message }, { status: 401 });
-    }
+		const response = NextResponse.json({ success: true });
+		setAuthCookies(response, {
+			accessToken: tokenResponse.access_token,
+			refreshToken: nextRefreshToken,
+			userInfo,
+			request,
+		});
+		return response;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Refresh failed";
+		return NextResponse.json({ error: message }, { status: 401 });
+	}
 }

--- a/packages/web/src/app/api/authors/[authorId]/route.test.ts
+++ b/packages/web/src/app/api/authors/[authorId]/route.test.ts
@@ -1,64 +1,64 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthorProfile } from "@paper-tools/core";
 import { NextRequest } from "next/server";
-import { type AuthorProfile } from "@paper-tools/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/author-profiler", () => ({
-    buildAuthorProfile: vi.fn(),
+	buildAuthorProfile: vi.fn(),
 }));
 
 const profiler = await import("@paper-tools/author-profiler");
 const { GET } = await import("./route");
 
 describe("/api/authors/[authorId] GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("returns author profile", async () => {
-        vi.mocked(profiler.buildAuthorProfile).mockResolvedValueOnce({
-            id: "123",
-            name: "Alice",
-            affiliations: [{ name: "Example U" }],
-            hIndex: 10,
-            citationCount: 200,
-            paperCount: 30,
-            influentialCitationCount: 50,
-            topPapers: [],
-            coauthors: [],
-            topicTimeline: [],
-        } as Partial<AuthorProfile> as AuthorProfile);
+	it("returns author profile", async () => {
+		vi.mocked(profiler.buildAuthorProfile).mockResolvedValueOnce({
+			id: "123",
+			name: "Alice",
+			affiliations: [{ name: "Example U" }],
+			hIndex: 10,
+			citationCount: 200,
+			paperCount: 30,
+			influentialCitationCount: 50,
+			topPapers: [],
+			coauthors: [],
+			topicTimeline: [],
+		} as Partial<AuthorProfile> as AuthorProfile);
 
-        const req = new NextRequest("http://localhost/api/authors/123");
-        const res = await GET(req, { params: { authorId: "123" } });
-        const data = await res.json();
+		const req = new NextRequest("http://localhost/api/authors/123");
+		const res = await GET(req, { params: { authorId: "123" } });
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(data.id).toBe("123");
-    });
+		expect(res.status).toBe(200);
+		expect(data.id).toBe("123");
+	});
 
-    it("returns 400 when authorId is empty", async () => {
-        const req = new NextRequest("http://localhost/api/authors/");
-        const res = await GET(req, { params: { authorId: "" } });
-        expect(res.status).toBe(400);
-    });
+	it("returns 400 when authorId is empty", async () => {
+		const req = new NextRequest("http://localhost/api/authors/");
+		const res = await GET(req, { params: { authorId: "" } });
+		expect(res.status).toBe(400);
+	});
 
-    it("returns 404 only for Semantic Scholar 404 error format", async () => {
-        vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
-            new Error("Semantic Scholar API error: 404 Not Found - missing"),
-        );
+	it("returns 404 only for Semantic Scholar 404 error format", async () => {
+		vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
+			new Error("Semantic Scholar API error: 404 Not Found - missing"),
+		);
 
-        const req = new NextRequest("http://localhost/api/authors/unknown");
-        const res = await GET(req, { params: { authorId: "unknown" } });
-        expect(res.status).toBe(404);
-    });
+		const req = new NextRequest("http://localhost/api/authors/unknown");
+		const res = await GET(req, { params: { authorId: "unknown" } });
+		expect(res.status).toBe(404);
+	});
 
-    it("returns 502 when message incidentally includes 404", async () => {
-        vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
-            new Error("Topic score 0.404 failed validation"),
-        );
+	it("returns 502 when message incidentally includes 404", async () => {
+		vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
+			new Error("Topic score 0.404 failed validation"),
+		);
 
-        const req = new NextRequest("http://localhost/api/authors/unknown");
-        const res = await GET(req, { params: { authorId: "unknown" } });
-        expect(res.status).toBe(502);
-    });
+		const req = new NextRequest("http://localhost/api/authors/unknown");
+		const res = await GET(req, { params: { authorId: "unknown" } });
+		expect(res.status).toBe(502);
+	});
 });

--- a/packages/web/src/app/api/authors/[authorId]/route.ts
+++ b/packages/web/src/app/api/authors/[authorId]/route.ts
@@ -1,25 +1,30 @@
-import { NextRequest, NextResponse } from "next/server";
 import { buildAuthorProfile } from "@paper-tools/author-profiler";
+import { type NextRequest, NextResponse } from "next/server";
 
 export const runtime = "nodejs";
 
 type RouteContext = {
-    params: Promise<{ authorId: string }>;
+	params: Promise<{ authorId: string }>;
 };
 
 export async function GET(_request: NextRequest, context: RouteContext) {
-    const { authorId: rawAuthorId } = await context.params;
-    const authorId = rawAuthorId?.trim();
-    if (!authorId) {
-        return NextResponse.json({ error: "authorId is required" }, { status: 400 });
-    }
+	const { authorId: rawAuthorId } = await context.params;
+	const authorId = rawAuthorId?.trim();
+	if (!authorId) {
+		return NextResponse.json(
+			{ error: "authorId is required" },
+			{ status: 400 },
+		);
+	}
 
-    try {
-        const profile = await buildAuthorProfile(authorId);
-        return NextResponse.json(profile);
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        const status = /Semantic Scholar API error:\s*404\b/.test(message) ? 404 : 502;
-        return NextResponse.json({ error: message }, { status });
-    }
+	try {
+		const profile = await buildAuthorProfile(authorId);
+		return NextResponse.json(profile);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		const status = /Semantic Scholar API error:\s*404\b/.test(message)
+			? 404
+			: 502;
+		return NextResponse.json({ error: message }, { status });
+	}
 }

--- a/packages/web/src/app/api/authors/search/route.test.ts
+++ b/packages/web/src/app/api/authors/search/route.test.ts
@@ -1,45 +1,47 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/core", () => ({
-    searchAuthors: vi.fn(),
+	searchAuthors: vi.fn(),
 }));
 
 const core = await import("@paper-tools/core");
 const { GET } = await import("./route");
 
 describe("/api/authors/search GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("returns author candidates", async () => {
-        vi.mocked(core.searchAuthors).mockResolvedValueOnce({
-            total: 1,
-            offset: 0,
-            data: [
-                {
-                    authorId: "123",
-                    name: "Alice",
-                    affiliations: ["Example University"],
-                    paperCount: 10,
-                    citationCount: 100,
-                    hIndex: 8,
-                },
-            ],
-        });
+	it("returns author candidates", async () => {
+		vi.mocked(core.searchAuthors).mockResolvedValueOnce({
+			total: 1,
+			offset: 0,
+			data: [
+				{
+					authorId: "123",
+					name: "Alice",
+					affiliations: ["Example University"],
+					paperCount: 10,
+					citationCount: 100,
+					hIndex: 8,
+				},
+			],
+		});
 
-        const req = new NextRequest("http://localhost/api/authors/search?q=alice&limit=10");
-        const res = await GET(req);
-        const data = await res.json();
+		const req = new NextRequest(
+			"http://localhost/api/authors/search?q=alice&limit=10",
+		);
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(data.candidates[0].authorId).toBe("123");
-    });
+		expect(res.status).toBe(200);
+		expect(data.candidates[0].authorId).toBe("123");
+	});
 
-    it("returns 400 when q is missing", async () => {
-        const req = new NextRequest("http://localhost/api/authors/search");
-        const res = await GET(req);
-        expect(res.status).toBe(400);
-    });
+	it("returns 400 when q is missing", async () => {
+		const req = new NextRequest("http://localhost/api/authors/search");
+		const res = await GET(req);
+		expect(res.status).toBe(400);
+	});
 });

--- a/packages/web/src/app/api/authors/search/route.ts
+++ b/packages/web/src/app/api/authors/search/route.ts
@@ -1,33 +1,36 @@
-import { NextRequest, NextResponse } from "next/server";
 import { searchAuthors } from "@paper-tools/core";
+import { type NextRequest, NextResponse } from "next/server";
+import { parseLimitParam, parseSearchParams } from "../../utils";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
-    const { searchParams } = new URL(request.url);
-    const q = searchParams.get("q")?.trim() ?? "";
-    const rawLimit = Number(searchParams.get("limit") ?? "10");
-    const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(20, rawLimit)) : 10;
+	const searchParams = parseSearchParams(request);
+	const q = searchParams.get("q")?.trim() ?? "";
+	const limit = parseLimitParam(searchParams);
 
-    if (!q) {
-        return NextResponse.json({ error: "q parameter is required" }, { status: 400 });
-    }
+	if (!q) {
+		return NextResponse.json(
+			{ error: "q parameter is required" },
+			{ status: 400 },
+		);
+	}
 
-    try {
-        const res = await searchAuthors(q, { limit });
-        return NextResponse.json({
-            total: res.total,
-            candidates: (res.data ?? []).map((c) => ({
-                authorId: c.authorId,
-                name: c.name,
-                affiliations: c.affiliations ?? [],
-                paperCount: c.paperCount ?? 0,
-                citationCount: c.citationCount ?? 0,
-                hIndex: c.hIndex ?? 0,
-            })),
-        });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 502 });
-    }
+	try {
+		const res = await searchAuthors(q, { limit });
+		return NextResponse.json({
+			total: res.total,
+			candidates: (res.data ?? []).map((c) => ({
+				authorId: c.authorId,
+				name: c.name,
+				affiliations: c.affiliations ?? [],
+				paperCount: c.paperCount ?? 0,
+				citationCount: c.citationCount ?? 0,
+				hIndex: c.hIndex ?? 0,
+			})),
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 502 });
+	}
 }

--- a/packages/web/src/app/api/bibtex/bulk/route.test.ts
+++ b/packages/web/src/app/api/bibtex/bulk/route.test.ts
@@ -1,94 +1,108 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/core", () => ({
-    RateLimiter: class {
-        async acquire() {
-            return;
-        }
-    },
+	RateLimiter: class {
+		async acquire() {
+			return;
+		}
+	},
 }));
 
 vi.mock("@paper-tools/bibtex/lib", () => ({
-    fetchBibtex: vi.fn(),
-    formatBibtex: vi.fn(),
-    deriveBibtexKey: vi.fn(),
+	fetchBibtex: vi.fn(),
+	formatBibtex: vi.fn(),
+	deriveBibtexKey: vi.fn(),
 }));
 
 const bibtex = await import("@paper-tools/bibtex/lib");
 const { POST } = await import("./route");
 
 function makeRequest(body: unknown) {
-    return new NextRequest("http://localhost/api/bibtex/bulk", {
-        method: "POST",
-        body: JSON.stringify(body),
-        headers: { "content-type": "application/json" },
-    });
+	return new NextRequest("http://localhost/api/bibtex/bulk", {
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "content-type": "application/json" },
+	});
 }
 
 describe("/api/bibtex/bulk POST", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("サーバーエラー時に500エラーを返す", async () => {
-        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-        try {
-            const req = new NextRequest("http://localhost/api/bibtex/bulk", {
-                method: "POST",
-                body: "invalid json",
-            });
-            const res = await POST(req);
-            const data = await res.json();
+	it("サーバーエラー時に500エラーを返す", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const req = new NextRequest("http://localhost/api/bibtex/bulk", {
+				method: "POST",
+				body: "invalid json",
+			});
+			const res = await POST(req);
+			const data = await res.json();
 
-            expect(res.status).toBe(500);
-            expect(data.error).toBe("Internal Server Error");
-            expect(consoleSpy).toHaveBeenCalled();
-        } finally {
-            consoleSpy.mockRestore();
-        }
-    });
+			expect(res.status).toBe(500);
+			expect(data.error).toBe("Internal Server Error");
+			expect(consoleSpy).toHaveBeenCalled();
+		} finally {
+			consoleSpy.mockRestore();
+		}
+	});
 
-    it("複数論文の BibTeX を結合して返す", async () => {
-        vi.mocked(bibtex.fetchBibtex)
-            .mockResolvedValueOnce({ bibtex: "@article{a,title={A}}", source: "crossref" } as any)
-            .mockResolvedValueOnce({ bibtex: "@article{b,title={B}}", source: "dblp" } as any);
-        vi.mocked(bibtex.deriveBibtexKey)
-            .mockReturnValueOnce("a2024")
-            .mockReturnValueOnce("b2024");
-        vi.mocked(bibtex.formatBibtex)
-            .mockReturnValueOnce({ formatted: "@article{a2024,title={A}}", warnings: [] } as any)
-            .mockReturnValueOnce({ formatted: "@article{b2024,title={B}}", warnings: [] } as any);
+	it("複数論文の BibTeX を結合して返す", async () => {
+		vi.mocked(bibtex.fetchBibtex)
+			.mockResolvedValueOnce({
+				bibtex: "@article{a,title={A}}",
+				source: "crossref",
+			} as any)
+			.mockResolvedValueOnce({
+				bibtex: "@article{b,title={B}}",
+				source: "dblp",
+			} as any);
+		vi.mocked(bibtex.deriveBibtexKey)
+			.mockReturnValueOnce("a2024")
+			.mockReturnValueOnce("b2024");
+		vi.mocked(bibtex.formatBibtex)
+			.mockReturnValueOnce({
+				formatted: "@article{a2024,title={A}}",
+				warnings: [],
+			} as any)
+			.mockReturnValueOnce({
+				formatted: "@article{b2024,title={B}}",
+				warnings: [],
+			} as any);
 
-        const req = makeRequest({ papers: [{ doi: "10.1/a", title: "A" }, { title: "B" }] });
-        const res = await POST(req);
-        const data = await res.json();
+		const req = makeRequest({
+			papers: [{ doi: "10.1/a", title: "A" }, { title: "B" }],
+		});
+		const res = await POST(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(data.count).toBe(2);
-        expect(data.bibtex).toContain("@article{a2024");
-        expect(data.bibtex).toContain("@article{b2024");
-        expect(data.errors).toHaveLength(0);
-    });
+		expect(res.status).toBe(200);
+		expect(data.count).toBe(2);
+		expect(data.bibtex).toContain("@article{a2024");
+		expect(data.bibtex).toContain("@article{b2024");
+		expect(data.errors).toHaveLength(0);
+	});
 
-    it("papers が空なら 400", async () => {
-        const req = makeRequest({ papers: [] });
-        const res = await POST(req);
-        const data = await res.json();
+	it("papers が空なら 400", async () => {
+		const req = makeRequest({ papers: [] });
+		const res = await POST(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(400);
-        expect(data.error).toContain("papers");
-    });
+		expect(res.status).toBe(400);
+		expect(data.error).toContain("papers");
+	});
 
-    it("個別失敗は errors に集約する", async () => {
-        vi.mocked(bibtex.fetchBibtex).mockResolvedValueOnce(null as any);
+	it("個別失敗は errors に集約する", async () => {
+		vi.mocked(bibtex.fetchBibtex).mockResolvedValueOnce(null as any);
 
-        const req = makeRequest({ papers: [{ title: "Missing" }] });
-        const res = await POST(req);
-        const data = await res.json();
+		const req = makeRequest({ papers: [{ title: "Missing" }] });
+		const res = await POST(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(data.count).toBe(0);
-        expect(data.errors).toHaveLength(1);
-    });
+		expect(res.status).toBe(200);
+		expect(data.count).toBe(0);
+		expect(data.errors).toHaveLength(1);
+	});
 });

--- a/packages/web/src/app/api/bibtex/bulk/route.ts
+++ b/packages/web/src/app/api/bibtex/bulk/route.ts
@@ -1,93 +1,123 @@
-import { NextRequest, NextResponse } from "next/server";
+import {
+	deriveBibtexKey,
+	fetchBibtex,
+	formatBibtex,
+} from "@paper-tools/bibtex/lib";
 import { RateLimiter } from "@paper-tools/core";
-import { deriveBibtexKey, fetchBibtex, formatBibtex } from "@paper-tools/bibtex/lib";
+import { type NextRequest, NextResponse } from "next/server";
 
 type BulkPaper = { doi?: string; title?: string };
 
 type BulkBody = {
-    papers?: BulkPaper[];
-    format?: "bibtex" | "biblatex";
-    keyFormat?: "default" | "short" | "venue";
+	papers?: BulkPaper[];
+	format?: "bibtex" | "biblatex";
+	keyFormat?: "default" | "short" | "venue";
 };
 
 function parseFormat(value: string | undefined): "bibtex" | "biblatex" {
-    return value === "biblatex" ? "biblatex" : "bibtex";
+	return value === "biblatex" ? "biblatex" : "bibtex";
 }
 
-function parseKeyFormat(value: string | undefined): "default" | "short" | "venue" {
-    if (value === "short" || value === "venue") return value;
-    return "default";
+function parseKeyFormat(
+	value: string | undefined,
+): "default" | "short" | "venue" {
+	if (value === "short" || value === "venue") return value;
+	return "default";
 }
 
 function normalizeDoi(value?: string): string | undefined {
-    if (!value?.trim()) return undefined;
-    return value.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	if (!value?.trim()) return undefined;
+	return value
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = (await request.json()) as BulkBody;
-        const papers = Array.isArray(body.papers) ? body.papers : [];
-        if (papers.length === 0) {
-            return NextResponse.json({ error: "papers は1件以上必要です" }, { status: 400 });
-        }
+	try {
+		const body = (await request.json()) as BulkBody;
+		const papers = Array.isArray(body.papers) ? body.papers : [];
+		if (papers.length === 0) {
+			return NextResponse.json(
+				{ error: "papers は1件以上必要です" },
+				{ status: 400 },
+			);
+		}
 
-        const format = parseFormat(body.format);
-        const keyFormat = parseKeyFormat(body.keyFormat);
-        const limiter = new RateLimiter(3, 1000);
+		const format = parseFormat(body.format);
+		const keyFormat = parseKeyFormat(body.keyFormat);
+		const limiter = new RateLimiter(3, 1000);
 
-        const results: Array<{ index: number; bibtex: string }> = [];
-        const errors: Array<{ title?: string; doi?: string; message: string }> = [];
+		const results: Array<{ index: number; bibtex: string }> = [];
+		const errors: Array<{ title?: string; doi?: string; message: string }> = [];
 
-        let cursor = 0;
-        const workers = Array.from({ length: 3 }, () => (async () => {
-            while (true) {
-                const current = cursor;
-                cursor += 1;
-                if (current >= papers.length) return;
+		let cursor = 0;
+		const workers = Array.from({ length: 3 }, () =>
+			(async () => {
+				while (true) {
+					const current = cursor;
+					cursor += 1;
+					if (current >= papers.length) return;
 
-                const paper = papers[current];
-                const doi = normalizeDoi(paper.doi);
-                const title = paper.title?.trim() || undefined;
+					const paper = papers[current];
+					const doi = normalizeDoi(paper.doi);
+					const title = paper.title?.trim() || undefined;
 
-                if (!doi && !title) {
-                    errors.push({ title: paper.title, doi: paper.doi, message: "doi または title が必要です" });
-                    continue;
-                }
+					if (!doi && !title) {
+						errors.push({
+							title: paper.title,
+							doi: paper.doi,
+							message: "doi または title が必要です",
+						});
+						continue;
+					}
 
-                await limiter.acquire();
-                try {
-                    const fetched = await fetchBibtex({ doi, title });
-                    if (!fetched) {
-                        errors.push({ title: paper.title, doi: paper.doi, message: "BibTeX を取得できませんでした" });
-                        continue;
-                    }
+					await limiter.acquire();
+					try {
+						const fetched = await fetchBibtex({ doi, title });
+						if (!fetched) {
+							errors.push({
+								title: paper.title,
+								doi: paper.doi,
+								message: "BibTeX を取得できませんでした",
+							});
+							continue;
+						}
 
-                    const customKey = deriveBibtexKey(fetched.bibtex, keyFormat);
-                    const formatted = formatBibtex(fetched.bibtex, { format, keyFormat, key: customKey });
-                    results.push({ index: current, bibtex: formatted.formatted });
-                } catch (error) {
-                    errors.push({
-                        title: paper.title,
-                        doi: paper.doi,
-                        message: error instanceof Error ? error.message : "Unknown error",
-                    });
-                }
-            }
-        })());
+						const customKey = deriveBibtexKey(fetched.bibtex, keyFormat);
+						const formatted = formatBibtex(fetched.bibtex, {
+							format,
+							keyFormat,
+							key: customKey,
+						});
+						results.push({ index: current, bibtex: formatted.formatted });
+					} catch (error) {
+						errors.push({
+							title: paper.title,
+							doi: paper.doi,
+							message: error instanceof Error ? error.message : "Unknown error",
+						});
+					}
+				}
+			})(),
+		);
 
-        await Promise.all(workers);
+		await Promise.all(workers);
 
-        const sorted = results.sort((a, b) => a.index - b.index);
-        const bibtex = sorted.map((item) => item.bibtex).join("\n\n");
+		const sorted = results.sort((a, b) => a.index - b.index);
+		const bibtex = sorted.map((item) => item.bibtex).join("\n\n");
 
-        return NextResponse.json({
-            bibtex,
-            count: sorted.length,
-            errors,
-        });
-    } catch (error) {
-        console.error(error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
-    }
+		return NextResponse.json({
+			bibtex,
+			count: sorted.length,
+			errors,
+		});
+	} catch (error) {
+		console.error(error);
+		return NextResponse.json(
+			{ error: "Internal Server Error" },
+			{ status: 500 },
+		);
+	}
 }

--- a/packages/web/src/app/api/bibtex/route.test.ts
+++ b/packages/web/src/app/api/bibtex/route.test.ts
@@ -1,58 +1,61 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/bibtex/lib", () => ({
-    fetchBibtex: vi.fn(),
-    formatBibtex: vi.fn(),
-    deriveBibtexKey: vi.fn(),
+	fetchBibtex: vi.fn(),
+	formatBibtex: vi.fn(),
+	deriveBibtexKey: vi.fn(),
 }));
 
 const bibtex = await import("@paper-tools/bibtex/lib");
 const { GET } = await import("./route");
 
 describe("/api/bibtex GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("doi で BibTeX を取得して返す", async () => {
-        vi.mocked(bibtex.fetchBibtex).mockResolvedValueOnce({
-            bibtex: "@article{tmp,title={A}}",
-            source: "crossref",
-        } as any);
-        vi.mocked(bibtex.deriveBibtexKey).mockReturnValueOnce("mukai2026a");
-        vi.mocked(bibtex.formatBibtex).mockReturnValueOnce({
-            formatted: "@article{mukai2026a,title={A}}",
-            warnings: [],
-        } as any);
+	it("doi で BibTeX を取得して返す", async () => {
+		vi.mocked(bibtex.fetchBibtex).mockResolvedValueOnce({
+			bibtex: "@article{tmp,title={A}}",
+			source: "crossref",
+		} as any);
+		vi.mocked(bibtex.deriveBibtexKey).mockReturnValueOnce("mukai2026a");
+		vi.mocked(bibtex.formatBibtex).mockReturnValueOnce({
+			formatted: "@article{mukai2026a,title={A}}",
+			warnings: [],
+		} as any);
 
-        const req = new NextRequest("http://localhost/api/bibtex?doi=10.1000/xyz");
-        const res = await GET(req);
-        const data = await res.json();
+		const req = new NextRequest("http://localhost/api/bibtex?doi=10.1000/xyz");
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(bibtex.fetchBibtex).toHaveBeenCalledWith({ doi: "10.1000/xyz", title: undefined });
-        expect(data.source).toBe("crossref");
-        expect(data.bibtex).toContain("mukai2026a");
-    });
+		expect(res.status).toBe(200);
+		expect(bibtex.fetchBibtex).toHaveBeenCalledWith({
+			doi: "10.1000/xyz",
+			title: undefined,
+		});
+		expect(data.source).toBe("crossref");
+		expect(data.bibtex).toContain("mukai2026a");
+	});
 
-    it("doi/title が空なら 400", async () => {
-        const req = new NextRequest("http://localhost/api/bibtex");
-        const res = await GET(req);
-        const data = await res.json();
+	it("doi/title が空なら 400", async () => {
+		const req = new NextRequest("http://localhost/api/bibtex");
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(400);
-        expect(data.error).toContain("doi または title");
-    });
+		expect(res.status).toBe(400);
+		expect(data.error).toContain("doi または title");
+	});
 
-    it("取得失敗時は 404", async () => {
-        vi.mocked(bibtex.fetchBibtex).mockResolvedValueOnce(null as any);
+	it("取得失敗時は 404", async () => {
+		vi.mocked(bibtex.fetchBibtex).mockResolvedValueOnce(null as any);
 
-        const req = new NextRequest("http://localhost/api/bibtex?title=Sample");
-        const res = await GET(req);
-        const data = await res.json();
+		const req = new NextRequest("http://localhost/api/bibtex?title=Sample");
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(404);
-        expect(data.error).toContain("取得");
-    });
+		expect(res.status).toBe(404);
+		expect(data.error).toContain("取得");
+	});
 });

--- a/packages/web/src/app/api/bibtex/route.ts
+++ b/packages/web/src/app/api/bibtex/route.ts
@@ -1,50 +1,66 @@
-import { NextRequest, NextResponse } from "next/server";
-import { deriveBibtexKey, fetchBibtex, formatBibtex } from "@paper-tools/bibtex/lib";
+import {
+	deriveBibtexKey,
+	fetchBibtex,
+	formatBibtex,
+} from "@paper-tools/bibtex/lib";
+import { type NextRequest, NextResponse } from "next/server";
+import { parseSearchParams } from "../utils";
 
 function parseFormat(value: string | null): "bibtex" | "biblatex" {
-    return value === "biblatex" ? "biblatex" : "bibtex";
+	return value === "biblatex" ? "biblatex" : "bibtex";
 }
 
 function parseKeyFormat(value: string | null): "default" | "short" | "venue" {
-    if (value === "short" || value === "venue") return value;
-    return "default";
+	if (value === "short" || value === "venue") return value;
+	return "default";
 }
 
 function normalizeDoi(value?: string): string | undefined {
-    if (!value?.trim()) return undefined;
-    return value.trim().replace(/^https?:\/\/doi\.org\//i, "").replace(/^doi:/i, "").trim();
+	if (!value?.trim()) return undefined;
+	return value
+		.trim()
+		.replace(/^https?:\/\/doi\.org\//i, "")
+		.replace(/^doi:/i, "")
+		.trim();
 }
 
 export async function GET(request: NextRequest) {
-    try {
-        const doi = normalizeDoi(request.nextUrl.searchParams.get("doi") ?? undefined);
-        const title = request.nextUrl.searchParams.get("title")?.trim() || undefined;
-        const format = parseFormat(request.nextUrl.searchParams.get("format"));
-        const keyFormat = parseKeyFormat(request.nextUrl.searchParams.get("keyFormat"));
+	const searchParams = parseSearchParams(request);
+	try {
+		const doi = normalizeDoi(searchParams.get("doi") ?? undefined);
+		const title = searchParams.get("title")?.trim() || undefined;
+		const format = parseFormat(searchParams.get("format"));
+		const keyFormat = parseKeyFormat(searchParams.get("keyFormat"));
 
-        if (!doi && !title) {
-            return NextResponse.json({ error: "doi または title のいずれかが必要です" }, { status: 400 });
-        }
+		if (!doi && !title) {
+			return NextResponse.json(
+				{ error: "doi または title のいずれかが必要です" },
+				{ status: 400 },
+			);
+		}
 
-        const fetched = await fetchBibtex({ doi, title });
-        if (!fetched) {
-            return NextResponse.json({ error: "BibTeX を取得できませんでした" }, { status: 404 });
-        }
+		const fetched = await fetchBibtex({ doi, title });
+		if (!fetched) {
+			return NextResponse.json(
+				{ error: "BibTeX を取得できませんでした" },
+				{ status: 404 },
+			);
+		}
 
-        const customKey = deriveBibtexKey(fetched.bibtex, keyFormat);
-        const formatted = formatBibtex(fetched.bibtex, {
-            format,
-            keyFormat,
-            key: customKey,
-        });
+		const customKey = deriveBibtexKey(fetched.bibtex, keyFormat);
+		const formatted = formatBibtex(fetched.bibtex, {
+			format,
+			keyFormat,
+			key: customKey,
+		});
 
-        return NextResponse.json({
-            bibtex: formatted.formatted,
-            source: fetched.source,
-            warnings: formatted.warnings,
-        });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		return NextResponse.json({
+			bibtex: formatted.formatted,
+			source: fetched.source,
+			warnings: formatted.warnings,
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/databases/route.test.ts
+++ b/packages/web/src/app/api/databases/route.test.ts
@@ -1,143 +1,171 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth", () => ({
-    getAccessToken: vi.fn(),
-    getNotionClient: vi.fn(),
+	getAccessToken: vi.fn(),
+	getNotionClient: vi.fn(),
 }));
 
 const auth = await import("@/lib/auth");
 const { GET } = await import("./route");
 
 function makeRequest() {
-    return new NextRequest("http://localhost/api/databases", {
-        headers: {
-            cookie: "access_token=dummy_token",
-        },
-    });
+	return new NextRequest("http://localhost/api/databases", {
+		headers: {
+			cookie: "access_token=dummy_token",
+		},
+	});
 }
 
 describe("/api/databases GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("Unauthorized 401 when access token is missing", async () => {
-        vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
+	it("Unauthorized 401 when access token is missing", async () => {
+		vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
 
-        const res = await GET(makeRequest());
-        const data = await res.json();
+		const res = await GET(makeRequest());
+		const data = await res.json();
 
-        expect(res.status).toBe(401);
-        expect(data.error).toBe("Unauthorized");
-    });
+		expect(res.status).toBe(401);
+		expect(data.error).toBe("Unauthorized");
+	});
 
-    it("Successfully fetches databases with various properties", async () => {
-        vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
+	it("Successfully fetches databases with various properties", async () => {
+		vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
 
-        const mockSearch = vi.fn().mockResolvedValue({
-            results: [
-                {
-                    id: "db1",
-                    object: "data_source",
-                    title: [{ plain_text: "DB One" }],
-                    description: [{ plain_text: "Desc One" }],
-                    icon: { type: "emoji", emoji: "🌟" }
-                },
-                {
-                    id: "db2",
-                    object: "data_source",
-                    title: [{ plain_text: "DB Two" }],
-                    description: [],
-                    icon: { type: "external", external: { url: "https://example.com/icon.png" } }
-                },
-                {
-                    id: "db3",
-                    object: "data_source",
-                    title: [],
-                    description: [{ plain_text: "Desc Three" }],
-                    icon: { type: "file", file: { url: "https://example.com/file.png" } }
-                },
-                {
-                    id: "ignore1",
-                    object: "page"
-                }
-            ],
-            has_more: false,
-        });
+		const mockSearch = vi.fn().mockResolvedValue({
+			results: [
+				{
+					id: "db1",
+					object: "data_source",
+					title: [{ plain_text: "DB One" }],
+					description: [{ plain_text: "Desc One" }],
+					icon: { type: "emoji", emoji: "🌟" },
+				},
+				{
+					id: "db2",
+					object: "data_source",
+					title: [{ plain_text: "DB Two" }],
+					description: [],
+					icon: {
+						type: "external",
+						external: { url: "https://example.com/icon.png" },
+					},
+				},
+				{
+					id: "db3",
+					object: "data_source",
+					title: [],
+					description: [{ plain_text: "Desc Three" }],
+					icon: { type: "file", file: { url: "https://example.com/file.png" } },
+				},
+				{
+					id: "ignore1",
+					object: "page",
+				},
+			],
+			has_more: false,
+		});
 
-        vi.mocked(auth.getNotionClient).mockReturnValueOnce({ search: mockSearch } as any);
+		vi.mocked(auth.getNotionClient).mockReturnValueOnce({
+			search: mockSearch,
+		} as any);
 
-        const res = await GET(makeRequest());
-        const data = await res.json();
+		const res = await GET(makeRequest());
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(mockSearch).toHaveBeenCalledWith({
-            filter: { property: "object", value: "data_source" },
-            page_size: 100,
-            start_cursor: undefined,
-        });
+		expect(res.status).toBe(200);
+		expect(mockSearch).toHaveBeenCalledWith({
+			filter: { property: "object", value: "data_source" },
+			page_size: 100,
+			start_cursor: undefined,
+		});
 
-        expect(data.databases).toHaveLength(3);
-        expect(data.databases[0]).toEqual({
-            id: "db1",
-            title: "DB One",
-            description: "Desc One",
-            icon: "🌟"
-        });
-        expect(data.databases[1]).toEqual({
-            id: "db2",
-            title: "DB Two",
-            description: "",
-            icon: "https://example.com/icon.png"
-        });
-        expect(data.databases[2]).toEqual({
-            id: "db3",
-            title: "(untitled database)",
-            description: "Desc Three",
-            icon: "https://example.com/file.png"
-        });
-    });
+		expect(data.databases).toHaveLength(3);
+		expect(data.databases[0]).toEqual({
+			id: "db1",
+			title: "DB One",
+			description: "Desc One",
+			icon: "🌟",
+		});
+		expect(data.databases[1]).toEqual({
+			id: "db2",
+			title: "DB Two",
+			description: "",
+			icon: "https://example.com/icon.png",
+		});
+		expect(data.databases[2]).toEqual({
+			id: "db3",
+			title: "(untitled database)",
+			description: "Desc Three",
+			icon: "https://example.com/file.png",
+		});
+	});
 
-    it("Handles pagination properly", async () => {
-        vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
+	it("Handles pagination properly", async () => {
+		vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
 
-        const mockSearch = vi.fn()
-            .mockResolvedValueOnce({
-                results: [{ id: "db1", object: "data_source", title: [{ plain_text: "Page 1" }] }],
-                has_more: true,
-                next_cursor: "cursor_abc",
-            })
-            .mockResolvedValueOnce({
-                results: [{ id: "db2", object: "data_source", title: [{ plain_text: "Page 2" }] }],
-                has_more: false,
-            });
+		const mockSearch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				results: [
+					{
+						id: "db1",
+						object: "data_source",
+						title: [{ plain_text: "Page 1" }],
+					},
+				],
+				has_more: true,
+				next_cursor: "cursor_abc",
+			})
+			.mockResolvedValueOnce({
+				results: [
+					{
+						id: "db2",
+						object: "data_source",
+						title: [{ plain_text: "Page 2" }],
+					},
+				],
+				has_more: false,
+			});
 
-        vi.mocked(auth.getNotionClient).mockReturnValueOnce({ search: mockSearch } as any);
+		vi.mocked(auth.getNotionClient).mockReturnValueOnce({
+			search: mockSearch,
+		} as any);
 
-        const res = await GET(makeRequest());
-        const data = await res.json();
+		const res = await GET(makeRequest());
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(mockSearch).toHaveBeenCalledTimes(2);
-        expect(mockSearch).toHaveBeenNthCalledWith(1, expect.objectContaining({ start_cursor: undefined }));
-        expect(mockSearch).toHaveBeenNthCalledWith(2, expect.objectContaining({ start_cursor: "cursor_abc" }));
+		expect(res.status).toBe(200);
+		expect(mockSearch).toHaveBeenCalledTimes(2);
+		expect(mockSearch).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ start_cursor: undefined }),
+		);
+		expect(mockSearch).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ start_cursor: "cursor_abc" }),
+		);
 
-        expect(data.databases).toHaveLength(2);
-        expect(data.databases[0].id).toBe("db1");
-        expect(data.databases[1].id).toBe("db2");
-    });
+		expect(data.databases).toHaveLength(2);
+		expect(data.databases[0].id).toBe("db1");
+		expect(data.databases[1].id).toBe("db2");
+	});
 
-    it("Returns 500 when Notion API throws an error", async () => {
-        vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
+	it("Returns 500 when Notion API throws an error", async () => {
+		vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
 
-        const mockSearch = vi.fn().mockRejectedValue(new Error("Notion API Error"));
-        vi.mocked(auth.getNotionClient).mockReturnValueOnce({ search: mockSearch } as any);
+		const mockSearch = vi.fn().mockRejectedValue(new Error("Notion API Error"));
+		vi.mocked(auth.getNotionClient).mockReturnValueOnce({
+			search: mockSearch,
+		} as any);
 
-        const res = await GET(makeRequest());
-        const data = await res.json();
+		const res = await GET(makeRequest());
+		const data = await res.json();
 
-        expect(res.status).toBe(500);
-        expect(data.error).toBe("Notion API Error");
-    });
+		expect(res.status).toBe(500);
+		expect(data.error).toBe("Notion API Error");
+	});
 });

--- a/packages/web/src/app/api/databases/route.ts
+++ b/packages/web/src/app/api/databases/route.ts
@@ -1,67 +1,71 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getAccessToken, getNotionClient } from "@/lib/auth";
 
 type DbItem = {
-    id: string;
-    title: string;
-    icon: string | null;
-    description: string;
+	id: string;
+	title: string;
+	icon: string | null;
+	description: string;
 };
 
 export async function GET(request: NextRequest) {
-    const accessToken = getAccessToken(request.cookies);
-    if (!accessToken) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+	const accessToken = getAccessToken(request.cookies);
+	if (!accessToken) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
 
-    try {
-        const notion = getNotionClient(accessToken);
-        const databases: DbItem[] = [];
+	try {
+		const notion = getNotionClient(accessToken);
+		const databases: DbItem[] = [];
 
-        let startCursor: string | undefined;
-        do {
-            const response = await notion.search({
-                filter: { property: "object", value: "data_source" },
-                page_size: 100,
-                start_cursor: startCursor,
-            });
+		let startCursor: string | undefined;
+		do {
+			const response = await notion.search({
+				filter: { property: "object", value: "data_source" },
+				page_size: 100,
+				start_cursor: startCursor,
+			});
 
-            for (const result of response.results) {
-                if (result.object !== "data_source") continue;
-                const ds = result as any;
+			for (const result of response.results) {
+				if (result.object !== "data_source") continue;
+				const ds = result as any;
 
-                const title = (ds.title ?? [])
-                    .map((item: { plain_text?: string }) => item.plain_text ?? "")
-                    .join("")
-                    .trim();
+				const title = (ds.title ?? [])
+					.map((item: { plain_text?: string }) => item.plain_text ?? "")
+					.join("")
+					.trim();
 
-                const description = (ds.description ?? [])
-                    .map((item: { plain_text?: string }) => item.plain_text ?? "")
-                    .join("")
-                    .trim();
+				const description = (ds.description ?? [])
+					.map((item: { plain_text?: string }) => item.plain_text ?? "")
+					.join("")
+					.trim();
 
-                const icon = ds.icon?.type === "emoji"
-                    ? ds.icon.emoji
-                    : ds.icon?.type === "external"
-                        ? ds.icon.external?.url ?? null
-                        : ds.icon?.type === "file"
-                            ? ds.icon.file?.url ?? null
-                            : null;
+				const icon =
+					ds.icon?.type === "emoji"
+						? ds.icon.emoji
+						: ds.icon?.type === "external"
+							? (ds.icon.external?.url ?? null)
+							: ds.icon?.type === "file"
+								? (ds.icon.file?.url ?? null)
+								: null;
 
-                databases.push({
-                    id: ds.id,
-                    title: title || "(untitled database)",
-                    icon,
-                    description,
-                });
-            }
+				databases.push({
+					id: ds.id,
+					title: title || "(untitled database)",
+					icon,
+					description,
+				});
+			}
 
-            startCursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
-        } while (startCursor);
+			startCursor = response.has_more
+				? (response.next_cursor ?? undefined)
+				: undefined;
+		} while (startCursor);
 
-        return NextResponse.json({ databases });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to fetch databases";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		return NextResponse.json({ databases });
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "Failed to fetch databases";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/databases/select/route.ts
+++ b/packages/web/src/app/api/databases/select/route.ts
@@ -1,48 +1,61 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getAccessToken, getNotionClient, setDatabaseCookie } from "@/lib/auth";
 import { resolveNotionDataSource } from "@/lib/notion-data-source";
 
 type SelectBody = {
-    databaseId?: string;
+	databaseId?: string;
 };
 
-function validateDatabaseProperties(properties: Record<string, { type?: string }>) {
-    const entries = Object.entries(properties);
-    const hasTitle = entries.some(([, v]) => v?.type === "title");
-    const hasDoi = entries.some(([key, v]) => {
-        const lower = key.toLowerCase();
-        if (lower === "doi") return true;
-        return lower.includes("doi") && (v?.type === "rich_text" || v?.type === "url" || v?.type === "title");
-    });
+function validateDatabaseProperties(
+	properties: Record<string, { type?: string }>,
+) {
+	const entries = Object.entries(properties);
+	const hasTitle = entries.some(([, v]) => v?.type === "title");
+	const hasDoi = entries.some(([key, v]) => {
+		const lower = key.toLowerCase();
+		if (lower === "doi") return true;
+		return (
+			lower.includes("doi") &&
+			(v?.type === "rich_text" || v?.type === "url" || v?.type === "title")
+		);
+	});
 
-    const warnings: string[] = [];
-    if (!hasTitle) warnings.push("必須プロパティ: タイトル(title) が見つかりません");
-    if (!hasDoi) warnings.push("推奨プロパティ: DOI が見つかりません");
-    return warnings;
+	const warnings: string[] = [];
+	if (!hasTitle)
+		warnings.push("必須プロパティ: タイトル(title) が見つかりません");
+	if (!hasDoi) warnings.push("推奨プロパティ: DOI が見つかりません");
+	return warnings;
 }
 
 export async function POST(request: NextRequest) {
-    const accessToken = getAccessToken(request.cookies);
-    if (!accessToken) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+	const accessToken = getAccessToken(request.cookies);
+	if (!accessToken) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
 
-    try {
-        const body = (await request.json()) as SelectBody;
-        const databaseId = body.databaseId?.trim();
-        if (!databaseId) {
-            return NextResponse.json({ error: "databaseId is required" }, { status: 400 });
-        }
+	try {
+		const body = (await request.json()) as SelectBody;
+		const databaseId = body.databaseId?.trim();
+		if (!databaseId) {
+			return NextResponse.json(
+				{ error: "databaseId is required" },
+				{ status: 400 },
+			);
+		}
 
-        const notion = getNotionClient(accessToken);
-        const dataSource = await resolveNotionDataSource<{ type?: string }>(notion, databaseId);
-        const warnings = validateDatabaseProperties(dataSource.properties);
+		const notion = getNotionClient(accessToken);
+		const dataSource = await resolveNotionDataSource<{ type?: string }>(
+			notion,
+			databaseId,
+		);
+		const warnings = validateDatabaseProperties(dataSource.properties);
 
-        const response = NextResponse.json({ success: true, warnings });
-        setDatabaseCookie(response, dataSource.id, request);
-        return response;
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to select database";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		const response = NextResponse.json({ success: true, warnings });
+		setDatabaseCookie(response, dataSource.id, request);
+		return response;
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "Failed to select database";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/graph/export/route.test.ts
+++ b/packages/web/src/app/api/graph/export/route.test.ts
@@ -1,116 +1,117 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/visualizer", () => ({
-  formatGraph: vi.fn(),
-  SUPPORTED_FORMATS: ["json", "dot", "mermaid"],
+	formatGraph: vi.fn(),
+	SUPPORTED_FORMATS: ["json", "dot", "mermaid"],
 }));
 
 const visualizer = await import("@paper-tools/visualizer");
 const { POST } = await import("./route");
 
 describe("/api/graph/export POST", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
 
-  const mockGraph = {
-    nodes: [{ id: "1", title: "Paper 1" }],
-    edges: [],
-  };
+	const mockGraph = {
+		nodes: [{ id: "1", title: "Paper 1" }],
+		edges: [],
+	};
 
-  const createRequest = (body: unknown) => {
-    return new NextRequest("http://localhost/api/graph/export", {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-  };
+	const createRequest = (body: unknown) => {
+		return new NextRequest("http://localhost/api/graph/export", {
+			method: "POST",
+			body: JSON.stringify(body),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+	};
 
-  it("graphとformatが必須であることをチェックする", async () => {
-    // Both missing
-    let req = createRequest({});
-    let res = await POST(req);
-    let data = await res.json();
-    expect(res.status).toBe(400);
-    expect(data.error).toBe("graph and format are required");
+	it("graphとformatが必須であることをチェックする", async () => {
+		// Both missing
+		let req = createRequest({});
+		let res = await POST(req);
+		const data = await res.json();
+		expect(res.status).toBe(400);
+		expect(data.error).toBe("graph and format are required");
 
-    // Only format present
-    req = createRequest({ format: "json" });
-    res = await POST(req);
-    expect(res.status).toBe(400);
+		// Only format present
+		req = createRequest({ format: "json" });
+		res = await POST(req);
+		expect(res.status).toBe(400);
 
-    // Only graph present
-    req = createRequest({ graph: mockGraph });
-    res = await POST(req);
-    expect(res.status).toBe(400);
-  });
+		// Only graph present
+		req = createRequest({ graph: mockGraph });
+		res = await POST(req);
+		expect(res.status).toBe(400);
+	});
 
-  it("サポートされていないformatで400を返す", async () => {
-    const req = createRequest({ graph: mockGraph, format: "xml" });
-    const res = await POST(req);
-    const data = await res.json();
+	it("サポートされていないformatで400を返す", async () => {
+		const req = createRequest({ graph: mockGraph, format: "xml" });
+		const res = await POST(req);
+		const data = await res.json();
 
-    expect(res.status).toBe(400);
-    expect(data.error).toContain("Unsupported format");
-  });
+		expect(res.status).toBe(400);
+		expect(data.error).toContain("Unsupported format");
+	});
 
-  it("formatがjsonのとき、toJsonの結果を返す", async () => {
-    const mockOutput = '{"mocked": "json"}';
-    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
+	it("formatがjsonのとき、toJsonの結果を返す", async () => {
+		const mockOutput = '{"mocked": "json"}';
+		vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
 
-    const req = createRequest({ graph: mockGraph, format: "json" });
-    const res = await POST(req);
-    const data = await res.json();
+		const req = createRequest({ graph: mockGraph, format: "json" });
+		const res = await POST(req);
+		const data = await res.json();
 
-    expect(res.status).toBe(200);
-    expect(data.output).toBe(mockOutput);
-    expect(data.format).toBe("json");
-    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "json");
-  });
+		expect(res.status).toBe(200);
+		expect(data.output).toBe(mockOutput);
+		expect(data.format).toBe("json");
+		expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "json");
+	});
 
-  it("formatがdotのとき、toDotの結果を返す", async () => {
-    const mockOutput = "digraph { mock }";
-    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
+	it("formatがdotのとき、toDotの結果を返す", async () => {
+		const mockOutput = "digraph { mock }";
+		vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
 
-    const req = createRequest({ graph: mockGraph, format: "dot" });
-    const res = await POST(req);
-    const data = await res.json();
+		const req = createRequest({ graph: mockGraph, format: "dot" });
+		const res = await POST(req);
+		const data = await res.json();
 
-    expect(res.status).toBe(200);
-    expect(data.output).toBe(mockOutput);
-    expect(data.format).toBe("dot");
-    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "dot");
-  });
+		expect(res.status).toBe(200);
+		expect(data.output).toBe(mockOutput);
+		expect(data.format).toBe("dot");
+		expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "dot");
+	});
 
-  it("formatがmermaidのとき、toMermaidの結果を返す", async () => {
-    const mockOutput = "graph TD; mock;";
-    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
+	it("formatがmermaidのとき、toMermaidの結果を返す", async () => {
+		const mockOutput = "graph TD; mock;";
+		vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
 
-    const req = createRequest({ graph: mockGraph, format: "mermaid" });
-    const res = await POST(req);
-    const data = await res.json();
+		const req = createRequest({ graph: mockGraph, format: "mermaid" });
+		const res = await POST(req);
+		const data = await res.json();
 
-    expect(res.status).toBe(200);
-    expect(data.output).toBe(mockOutput);
-    expect(data.format).toBe("mermaid");
-    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "mermaid");
-  });
+		expect(res.status).toBe(200);
+		expect(data.output).toBe(mockOutput);
+		expect(data.format).toBe("mermaid");
+		expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "mermaid");
+	});
 
-  it("予期せぬエラー発生時に500を返す", async () => {
-    // 異常なJSONを渡してエラーを誘発する
-    const req = new NextRequest("http://localhost/api/graph/export", {
-      method: "POST",
-      body: "invalid json",
-    });
+	it("予期せぬエラー発生時に500を返す", async () => {
+		// 異常なJSONを渡してエラーを誘発する
+		const req = new NextRequest("http://localhost/api/graph/export", {
+			method: "POST",
+			body: "invalid json",
+		});
 
-    const res = await POST(req);
-    const data = await res.json();
+		const res = await POST(req);
+		const data = await res.json();
 
-    expect(res.status).toBe(500);
-    expect(data.error).toBeDefined();
-  });
+		expect(res.status).toBe(500);
+		expect(data.error).toBeDefined();
+	});
 });

--- a/packages/web/src/app/api/graph/export/route.ts
+++ b/packages/web/src/app/api/graph/export/route.ts
@@ -1,36 +1,38 @@
-import { NextRequest, NextResponse } from "next/server";
-import { formatGraph, SUPPORTED_FORMATS } from "@paper-tools/visualizer";
 import type { CitationGraph, Format } from "@paper-tools/visualizer";
+import { formatGraph, SUPPORTED_FORMATS } from "@paper-tools/visualizer";
+import { type NextRequest, NextResponse } from "next/server";
 
 interface ExportBody {
-  graph: CitationGraph;
-  format: Format;
+	graph: CitationGraph;
+	format: Format;
 }
 
 export async function POST(request: NextRequest) {
-  try {
-    const body = (await request.json()) as ExportBody;
-    const { graph, format } = body;
+	try {
+		const body = (await request.json()) as ExportBody;
+		const { graph, format } = body;
 
-    if (!graph || !format) {
-      return NextResponse.json(
-        { error: "graph and format are required" },
-        { status: 400 },
-      );
-    }
+		if (!graph || !format) {
+			return NextResponse.json(
+				{ error: "graph and format are required" },
+				{ status: 400 },
+			);
+		}
 
-    if (!(SUPPORTED_FORMATS as readonly string[]).includes(format)) {
-      return NextResponse.json(
-        { error: `Unsupported format: ${format}. Use ${SUPPORTED_FORMATS.join(", ")}.` },
-        { status: 400 },
-      );
-    }
+		if (!(SUPPORTED_FORMATS as readonly string[]).includes(format)) {
+			return NextResponse.json(
+				{
+					error: `Unsupported format: ${format}. Use ${SUPPORTED_FORMATS.join(", ")}.`,
+				},
+				{ status: 400 },
+			);
+		}
 
-    const output = formatGraph(graph, format);
+		const output = formatGraph(graph, format);
 
-    return NextResponse.json({ output, format });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+		return NextResponse.json({ output, format });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/graph/multi/route.ts
+++ b/packages/web/src/app/api/graph/multi/route.ts
@@ -1,34 +1,39 @@
-import { NextRequest, NextResponse } from "next/server";
-import { buildCitationGraph, DEFAULT_CONCURRENCY, mapConcurrent, mergeGraphs } from "@paper-tools/visualizer";
 import type { Direction } from "@paper-tools/visualizer";
+import {
+	buildCitationGraph,
+	DEFAULT_CONCURRENCY,
+	mapConcurrent,
+	mergeGraphs,
+} from "@paper-tools/visualizer";
+import { type NextRequest, NextResponse } from "next/server";
 
 interface MultiGraphBody {
-    dois: string[];
-    depth?: number;
-    direction?: Direction;
+	dois: string[];
+	depth?: number;
+	direction?: Direction;
 }
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = (await request.json()) as MultiGraphBody;
-        const { dois, depth = 1, direction = "both" } = body;
+	try {
+		const body = (await request.json()) as MultiGraphBody;
+		const { dois, depth = 1, direction = "both" } = body;
 
-        if (!dois || dois.length === 0) {
-            return NextResponse.json(
-                { error: "dois array is required and must not be empty" },
-                { status: 400 },
-            );
-        }
+		if (!dois || dois.length === 0) {
+			return NextResponse.json(
+				{ error: "dois array is required and must not be empty" },
+				{ status: 400 },
+			);
+		}
 
-        const graphs = await mapConcurrent(
-            dois,
-            (doi) => buildCitationGraph(doi, depth, direction),
-            DEFAULT_CONCURRENCY,
-        );
-        const merged = mergeGraphs(...graphs);
-        return NextResponse.json({ graph: merged });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		const graphs = await mapConcurrent(
+			dois,
+			(doi) => buildCitationGraph(doi, depth, direction),
+			DEFAULT_CONCURRENCY,
+		);
+		const merged = mergeGraphs(...graphs);
+		return NextResponse.json({ graph: merged });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/graph/route.test.ts
+++ b/packages/web/src/app/api/graph/route.test.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/visualizer", () => ({
-    buildCitationGraph: vi.fn(),
+	buildCitationGraph: vi.fn(),
 }));
 
 const visualizer = await import("@paper-tools/visualizer");
@@ -11,59 +11,71 @@ const { GET } = await import("./route");
 // @vitest-environment jsdom
 
 describe("/api/graph GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("doi が指定された場合、デフォルトの depth と direction でグラフを返す", async () => {
-        vi.mocked(visualizer.buildCitationGraph).mockResolvedValueOnce({
-            nodes: [{ id: "10.1000/xyz", label: "Paper" }],
-            edges: [],
-        } as any);
+	it("doi が指定された場合、デフォルトの depth と direction でグラフを返す", async () => {
+		vi.mocked(visualizer.buildCitationGraph).mockResolvedValueOnce({
+			nodes: [{ id: "10.1000/xyz", label: "Paper" }],
+			edges: [],
+		} as any);
 
-        const req = new NextRequest("http://localhost/api/graph?doi=10.1000/xyz");
-        const res = await GET(req);
-        const data = await res.json();
+		const req = new NextRequest("http://localhost/api/graph?doi=10.1000/xyz");
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(visualizer.buildCitationGraph).toHaveBeenCalledWith("10.1000/xyz", 1, "both");
-        expect(data.graph).toBeDefined();
-        expect(data.graph.nodes[0].id).toBe("10.1000/xyz");
-    });
+		expect(res.status).toBe(200);
+		expect(visualizer.buildCitationGraph).toHaveBeenCalledWith(
+			"10.1000/xyz",
+			1,
+			"both",
+		);
+		expect(data.graph).toBeDefined();
+		expect(data.graph.nodes[0].id).toBe("10.1000/xyz");
+	});
 
-    it("doi とともに depth と direction が指定された場合、それらの値でグラフを返す", async () => {
-        vi.mocked(visualizer.buildCitationGraph).mockResolvedValueOnce({
-            nodes: [],
-            edges: [],
-        } as any);
+	it("doi とともに depth と direction が指定された場合、それらの値でグラフを返す", async () => {
+		vi.mocked(visualizer.buildCitationGraph).mockResolvedValueOnce({
+			nodes: [],
+			edges: [],
+		} as any);
 
-        const req = new NextRequest("http://localhost/api/graph?doi=10.1000/xyz&depth=2&direction=forward");
-        const res = await GET(req);
-        const data = await res.json();
+		const req = new NextRequest(
+			"http://localhost/api/graph?doi=10.1000/xyz&depth=2&direction=forward",
+		);
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(visualizer.buildCitationGraph).toHaveBeenCalledWith("10.1000/xyz", 2, "forward");
-        expect(data.graph).toBeDefined();
-    });
+		expect(res.status).toBe(200);
+		expect(visualizer.buildCitationGraph).toHaveBeenCalledWith(
+			"10.1000/xyz",
+			2,
+			"forward",
+		);
+		expect(data.graph).toBeDefined();
+	});
 
-    it("doi が空の場合は 400 を返す", async () => {
-        const req = new NextRequest("http://localhost/api/graph");
-        const res = await GET(req);
-        const data = await res.json();
+	it("doi が空の場合は 400 を返す", async () => {
+		const req = new NextRequest("http://localhost/api/graph");
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(400);
-        expect(data.error).toBe("doi parameter is required");
-    });
+		expect(res.status).toBe(400);
+		expect(data.error).toBe("doi parameter is required");
+	});
 
-    it("buildCitationGraph でエラーが発生した場合は 500 を返す", async () => {
-        vi.spyOn(console, 'error').mockImplementation(() => {});
-        vi.mocked(visualizer.buildCitationGraph).mockRejectedValueOnce(new Error("Graph build error"));
+	it("buildCitationGraph でエラーが発生した場合は 500 を返す", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.mocked(visualizer.buildCitationGraph).mockRejectedValueOnce(
+			new Error("Graph build error"),
+		);
 
-        const req = new NextRequest("http://localhost/api/graph?doi=10.1000/xyz");
-        const res = await GET(req);
-        const data = await res.json();
+		const req = new NextRequest("http://localhost/api/graph?doi=10.1000/xyz");
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(500);
-        expect(data.error).toBe("Graph build error");
-    });
+		expect(res.status).toBe(500);
+		expect(data.error).toBe("Graph build error");
+	});
 });

--- a/packages/web/src/app/api/graph/route.ts
+++ b/packages/web/src/app/api/graph/route.ts
@@ -1,22 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
-import { buildCitationGraph } from "@paper-tools/visualizer";
 import type { Direction } from "@paper-tools/visualizer";
+import { buildCitationGraph } from "@paper-tools/visualizer";
+import { type NextRequest, NextResponse } from "next/server";
+import { parseSearchParams } from "../utils";
 
 export async function GET(request: NextRequest) {
-    const { searchParams } = new URL(request.url);
-    const doi = searchParams.get("doi");
-    const depth = Number(searchParams.get("depth") ?? "1");
-    const direction = (searchParams.get("direction") ?? "both") as Direction;
+	const searchParams = parseSearchParams(request);
+	const doi = searchParams.get("doi");
+	const depth = Number(searchParams.get("depth") ?? "1");
+	const direction = (searchParams.get("direction") ?? "both") as Direction;
 
-    if (!doi) {
-        return NextResponse.json({ error: "doi parameter is required" }, { status: 400 });
-    }
+	if (!doi) {
+		return NextResponse.json(
+			{ error: "doi parameter is required" },
+			{ status: 400 },
+		);
+	}
 
-    try {
-        const graph = await buildCitationGraph(doi, depth, direction);
-        return NextResponse.json({ graph });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+	try {
+		const graph = await buildCitationGraph(doi, depth, direction);
+		return NextResponse.json({ graph });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/paper/[paperId]/route.test.ts
+++ b/packages/web/src/app/api/paper/[paperId]/route.test.ts
@@ -1,69 +1,82 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PaperDetail } from "@/types/paper";
 
 vi.mock("@paper-tools/core", () => ({
-    RateLimiter: class {
-        async acquire() {
-            return;
-        }
-    },
-    getPaper: vi.fn(),
+	RateLimiter: class {
+		async acquire() {
+			return;
+		}
+	},
+	getPaper: vi.fn(),
 }));
 
 const core = await import("@paper-tools/core");
 const { GET } = await import("./route");
 
 function ctx(paperId: string) {
-    return { params: Promise.resolve({ paperId }) } as { params: Promise<{ paperId: string }> };
+	return { params: Promise.resolve({ paperId }) } as {
+		params: Promise<{ paperId: string }>;
+	};
 }
 
 describe("/api/paper/[paperId] GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("paper detail を返す", async () => {
-        vi.mocked(core.getPaper).mockResolvedValueOnce({
-            paperId: "abc",
-            title: "Paper",
-            abstract: "Abstract",
-            authors: [{ authorId: "a1", name: "Alice" }],
-            year: 2024,
-            venue: "ICSE",
-            citationCount: 10,
-            influentialCitationCount: 3,
-            referenceCount: 20,
-            externalIds: { DOI: "10.1/xyz", CorpusId: "123" },
-            url: "https://www.semanticscholar.org/paper/abc",
-            tldr: { model: "x", text: "summary" },
-            fieldsOfStudy: [{ category: "Computer Science", source: "s2" }],
-            publicationDate: "2024-01-01",
-            journal: { name: "J", volume: "1", pages: "1-10" },
-        } as unknown as Partial<PaperDetail>);
+	it("paper detail を返す", async () => {
+		vi.mocked(core.getPaper).mockResolvedValueOnce({
+			paperId: "abc",
+			title: "Paper",
+			abstract: "Abstract",
+			authors: [{ authorId: "a1", name: "Alice" }],
+			year: 2024,
+			venue: "ICSE",
+			citationCount: 10,
+			influentialCitationCount: 3,
+			referenceCount: 20,
+			externalIds: { DOI: "10.1/xyz", CorpusId: "123" },
+			url: "https://www.semanticscholar.org/paper/abc",
+			tldr: { model: "x", text: "summary" },
+			fieldsOfStudy: [{ category: "Computer Science", source: "s2" }],
+			publicationDate: "2024-01-01",
+			journal: { name: "J", volume: "1", pages: "1-10" },
+		} as unknown as Partial<PaperDetail>);
 
-        const res = await GET(new NextRequest("http://localhost/api/paper/abc"), ctx("abc"));
-        const data = await res.json();
+		const res = await GET(
+			new NextRequest("http://localhost/api/paper/abc"),
+			ctx("abc"),
+		);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(core.getPaper).toHaveBeenCalledWith(
-            "abc",
-            expect.stringContaining("influentialCitationCount"),
-        );
-        expect(data.paperId).toBe("abc");
-        expect(data.externalIds.CorpusId).toBe(123);
-    });
+		expect(res.status).toBe(200);
+		expect(core.getPaper).toHaveBeenCalledWith(
+			"abc",
+			expect.stringContaining("influentialCitationCount"),
+		);
+		expect(data.paperId).toBe("abc");
+		expect(data.externalIds.CorpusId).toBe(123);
+	});
 
-    it("paperId が空なら 400", async () => {
-        const res = await GET(new NextRequest("http://localhost/api/paper"), ctx(""));
-        const data = await res.json();
-        expect(res.status).toBe(400);
-        expect(data.error).toContain("paperId");
-    });
+	it("paperId が空なら 400", async () => {
+		const res = await GET(
+			new NextRequest("http://localhost/api/paper"),
+			ctx(""),
+		);
+		const data = await res.json();
+		expect(res.status).toBe(400);
+		expect(data.error).toContain("paperId");
+	});
 
-    it("上流404は 404 を返す", async () => {
-        vi.mocked(core.getPaper).mockRejectedValueOnce(new Error("Semantic Scholar API error: 404 Not Found"));
-        const res = await GET(new NextRequest("http://localhost/api/paper/unknown"), ctx("unknown"));
-        expect(res.status).toBe(404);
-    });
+	it("上流404は 404 を返す", async () => {
+		vi.mocked(core.getPaper).mockRejectedValueOnce(
+			new Error("Semantic Scholar API error: 404 Not Found"),
+		);
+		const res = await GET(
+			new NextRequest("http://localhost/api/paper/unknown"),
+			ctx("unknown"),
+		);
+		expect(res.status).toBe(404);
+	});
 });

--- a/packages/web/src/app/api/paper/[paperId]/route.ts
+++ b/packages/web/src/app/api/paper/[paperId]/route.ts
@@ -1,144 +1,155 @@
-import { NextRequest, NextResponse } from "next/server";
-import { RateLimiter, getPaper } from "@paper-tools/core";
+import type { S2Author, S2Paper } from "@paper-tools/core";
+import { getPaper, RateLimiter } from "@paper-tools/core";
+import { type NextRequest, NextResponse } from "next/server";
 import type { PaperDetail } from "@/types/paper";
-import type { S2Paper, S2Author } from "@paper-tools/core";
 
 export const runtime = "nodejs";
 
 const SEMANTIC_SCHOLAR_FIELDS = [
-    "paperId",
-    "title",
-    "abstract",
-    "authors",
-    "year",
-    "venue",
-    "citationCount",
-    "influentialCitationCount",
-    "externalIds",
-    "url",
-    "tldr",
-    "fieldsOfStudy",
-    "publicationDate",
-    "journal",
-    "referenceCount",
+	"paperId",
+	"title",
+	"abstract",
+	"authors",
+	"year",
+	"venue",
+	"citationCount",
+	"influentialCitationCount",
+	"externalIds",
+	"url",
+	"tldr",
+	"fieldsOfStudy",
+	"publicationDate",
+	"journal",
+	"referenceCount",
 ].join(",");
 
 const detailLimiter = new RateLimiter(100, 300000);
 
 type RouteContext = {
-    params: Promise<{ paperId: string }>;
+	params: Promise<{ paperId: string }>;
 };
 
 function getStatusCodeFromError(error: unknown): number | null {
-    if (!(error instanceof Error)) {
-        return null;
-    }
+	if (!(error instanceof Error)) {
+		return null;
+	}
 
-    const match = error.message.match(/Semantic Scholar API error:\s*(\d{3})\b/i);
-    if (!match?.[1]) {
-        return null;
-    }
+	const match = error.message.match(/Semantic Scholar API error:\s*(\d{3})\b/i);
+	if (!match?.[1]) {
+		return null;
+	}
 
-    const status = Number(match[1]);
-    return Number.isInteger(status) ? status : null;
+	const status = Number(match[1]);
+	return Number.isInteger(status) ? status : null;
 }
 
 type ExtendedS2Paper = Omit<S2Paper, "fieldsOfStudy"> & {
-    influentialCitationCount?: number;
-    tldr?: { model?: string; text?: string };
-    fieldsOfStudy?: Array<string | { category?: string; source?: string }>;
-    publicationDate?: string;
-    journal?: {
-        name?: string;
-        volume?: string | number;
-        pages?: string | number;
-    };
+	influentialCitationCount?: number;
+	tldr?: { model?: string; text?: string };
+	fieldsOfStudy?: Array<string | { category?: string; source?: string }>;
+	publicationDate?: string;
+	journal?: {
+		name?: string;
+		volume?: string | number;
+		pages?: string | number;
+	};
 };
 
 function toPaperDetail(input: ExtendedS2Paper): PaperDetail {
-    const rawFields = Array.isArray(input?.fieldsOfStudy) ? input.fieldsOfStudy : null;
-    const fieldsOfStudy = rawFields
-        ? rawFields.map((f: string | { category?: string; source?: string }) => {
-            if (typeof f === "string") {
-                return { category: f, source: "unknown" };
-            }
-            return {
-                category: String((f as Record<string, unknown>)?.category ?? "Unknown"),
-                source: String((f as Record<string, unknown>)?.source ?? "unknown"),
-            };
-        })
-        : null;
+	const rawFields = Array.isArray(input?.fieldsOfStudy)
+		? input.fieldsOfStudy
+		: null;
+	const fieldsOfStudy = rawFields
+		? rawFields.map((f: string | { category?: string; source?: string }) => {
+				if (typeof f === "string") {
+					return { category: f, source: "unknown" };
+				}
+				return {
+					category: String(
+						(f as Record<string, unknown>)?.category ?? "Unknown",
+					),
+					source: String((f as Record<string, unknown>)?.source ?? "unknown"),
+				};
+			})
+		: null;
 
-    const corpusRaw = input?.externalIds?.CorpusId;
-    const corpusId =
-        typeof corpusRaw === "number"
-            ? corpusRaw
-            : typeof corpusRaw === "string" && /^\d+$/.test(corpusRaw)
-                ? Number(corpusRaw)
-                : undefined;
+	const corpusRaw = input?.externalIds?.CorpusId;
+	const corpusId =
+		typeof corpusRaw === "number"
+			? corpusRaw
+			: typeof corpusRaw === "string" && /^\d+$/.test(corpusRaw)
+				? Number(corpusRaw)
+				: undefined;
 
-    return {
-        paperId: String(input?.paperId ?? ""),
-        title: String(input?.title ?? "Untitled"),
-        abstract: input?.abstract ?? null,
-        authors: Array.isArray(input?.authors)
-            ? input.authors.map((a: S2Author) => ({
-                authorId: String(a?.authorId ?? ""),
-                name: String(a?.name ?? "Unknown"),
-            }))
-            : [],
-        year: typeof input?.year === "number" ? input.year : null,
-        venue: String(input?.venue ?? ""),
-        citationCount: Number(input?.citationCount ?? 0),
-        influentialCitationCount: Number(input?.influentialCitationCount ?? 0),
-        referenceCount: Number(input?.referenceCount ?? 0),
-        externalIds: {
-            DOI: input?.externalIds?.DOI,
-            ArXiv: input?.externalIds?.ArXiv,
-            ACL: input?.externalIds?.ACL,
-            DBLP: input?.externalIds?.DBLP,
-            CorpusId: corpusId,
-        },
-        url: String(input?.url ?? `https://www.semanticscholar.org/paper/${input?.paperId ?? ""}`),
-        tldr:
-            input?.tldr && typeof input.tldr.text === "string"
-                ? { model: String(input.tldr.model ?? ""), text: input.tldr.text }
-                : null,
-        fieldsOfStudy,
-        publicationDate: input?.publicationDate ?? null,
-        journal:
-            input?.journal && typeof input.journal === "object"
-                ? {
-                    name: String(input.journal.name ?? ""),
-                    volume: input.journal.volume ? String(input.journal.volume) : undefined,
-                    pages: input.journal.pages ? String(input.journal.pages) : undefined,
-                }
-                : null,
-    };
+	return {
+		paperId: String(input?.paperId ?? ""),
+		title: String(input?.title ?? "Untitled"),
+		abstract: input?.abstract ?? null,
+		authors: Array.isArray(input?.authors)
+			? input.authors.map((a: S2Author) => ({
+					authorId: String(a?.authorId ?? ""),
+					name: String(a?.name ?? "Unknown"),
+				}))
+			: [],
+		year: typeof input?.year === "number" ? input.year : null,
+		venue: String(input?.venue ?? ""),
+		citationCount: Number(input?.citationCount ?? 0),
+		influentialCitationCount: Number(input?.influentialCitationCount ?? 0),
+		referenceCount: Number(input?.referenceCount ?? 0),
+		externalIds: {
+			DOI: input?.externalIds?.DOI,
+			ArXiv: input?.externalIds?.ArXiv,
+			ACL: input?.externalIds?.ACL,
+			DBLP: input?.externalIds?.DBLP,
+			CorpusId: corpusId,
+		},
+		url: String(
+			input?.url ??
+				`https://www.semanticscholar.org/paper/${input?.paperId ?? ""}`,
+		),
+		tldr:
+			input?.tldr && typeof input.tldr.text === "string"
+				? { model: String(input.tldr.model ?? ""), text: input.tldr.text }
+				: null,
+		fieldsOfStudy,
+		publicationDate: input?.publicationDate ?? null,
+		journal:
+			input?.journal && typeof input.journal === "object"
+				? {
+						name: String(input.journal.name ?? ""),
+						volume: input.journal.volume
+							? String(input.journal.volume)
+							: undefined,
+						pages: input.journal.pages
+							? String(input.journal.pages)
+							: undefined,
+					}
+				: null,
+	};
 }
 
 export async function GET(_request: NextRequest, context: RouteContext) {
-    const { paperId } = await context.params;
-    if (!paperId?.trim()) {
-        return NextResponse.json({ error: "paperId is required" }, { status: 400 });
-    }
+	const { paperId } = await context.params;
+	if (!paperId?.trim()) {
+		return NextResponse.json({ error: "paperId is required" }, { status: 400 });
+	}
 
-    try {
-        await detailLimiter.acquire();
-        const paper = await getPaper(paperId, SEMANTIC_SCHOLAR_FIELDS);
-        const normalized = toPaperDetail(paper as ExtendedS2Paper);
+	try {
+		await detailLimiter.acquire();
+		const paper = await getPaper(paperId, SEMANTIC_SCHOLAR_FIELDS);
+		const normalized = toPaperDetail(paper as ExtendedS2Paper);
 
-        if (!normalized.paperId) {
-            return NextResponse.json({ error: "Paper not found" }, { status: 404 });
-        }
+		if (!normalized.paperId) {
+			return NextResponse.json({ error: "Paper not found" }, { status: 404 });
+		}
 
-        return NextResponse.json(normalized);
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        const statusCode = getStatusCodeFromError(error);
-        if (statusCode === 404) {
-            return NextResponse.json({ error: message }, { status: 404 });
-        }
-        return NextResponse.json({ error: message }, { status: 502 });
-    }
+		return NextResponse.json(normalized);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		const statusCode = getStatusCodeFromError(error);
+		if (statusCode === 404) {
+			return NextResponse.json({ error: message }, { status: 404 });
+		}
+		return NextResponse.json({ error: message }, { status: 502 });
+	}
 }

--- a/packages/web/src/app/api/recommend/route.ts
+++ b/packages/web/src/app/api/recommend/route.ts
@@ -1,62 +1,64 @@
-import { NextRequest, NextResponse } from "next/server";
 import {
-  recommendFromSingle,
-  recommendFromMultiple,
-  resolveToS2Id,
+	recommendFromMultiple,
+	recommendFromSingle,
+	resolveToS2Id,
 } from "@paper-tools/recommender";
+import { type NextRequest, NextResponse } from "next/server";
 
 interface SingleBody {
-  paperId: string;
-  limit?: number;
-  from?: "recent" | "all-cs";
+	paperId: string;
+	limit?: number;
+	from?: "recent" | "all-cs";
 }
 
 interface MultiBody {
-  positiveIds: string[];
-  negativeIds?: string[];
-  limit?: number;
+	positiveIds: string[];
+	negativeIds?: string[];
+	limit?: number;
 }
 
 type RecommendBody = SingleBody | MultiBody;
 
 function isMultiBody(body: RecommendBody): body is MultiBody {
-  return "positiveIds" in body;
+	return "positiveIds" in body;
 }
 
 export async function POST(request: NextRequest) {
-  try {
-    const body = (await request.json()) as RecommendBody;
+	try {
+		const body = (await request.json()) as RecommendBody;
 
-    if (isMultiBody(body)) {
-      const { positiveIds, negativeIds = [], limit } = body;
+		if (isMultiBody(body)) {
+			const { positiveIds, negativeIds = [], limit } = body;
 
-      if (!positiveIds || positiveIds.length === 0) {
-        return NextResponse.json(
-          { error: "positiveIds array is required and must not be empty" },
-          { status: 400 },
-        );
-      }
+			if (!positiveIds || positiveIds.length === 0) {
+				return NextResponse.json(
+					{ error: "positiveIds array is required and must not be empty" },
+					{ status: 400 },
+				);
+			}
 
-      const resolvedPos = await Promise.all(positiveIds.map(resolveToS2Id));
-      const resolvedNeg = await Promise.all(negativeIds.map(resolveToS2Id));
-      const papers = await recommendFromMultiple(resolvedPos, resolvedNeg, { limit });
-      return NextResponse.json({ papers, total: papers.length });
-    } else {
-      const { paperId, limit, from } = body;
+			const resolvedPos = await Promise.all(positiveIds.map(resolveToS2Id));
+			const resolvedNeg = await Promise.all(negativeIds.map(resolveToS2Id));
+			const papers = await recommendFromMultiple(resolvedPos, resolvedNeg, {
+				limit,
+			});
+			return NextResponse.json({ papers, total: papers.length });
+		} else {
+			const { paperId, limit, from } = body;
 
-      if (!paperId) {
-        return NextResponse.json(
-          { error: "paperId is required" },
-          { status: 400 },
-        );
-      }
+			if (!paperId) {
+				return NextResponse.json(
+					{ error: "paperId is required" },
+					{ status: 400 },
+				);
+			}
 
-      const resolvedId = await resolveToS2Id(paperId);
-      const papers = await recommendFromSingle(resolvedId, { limit, from });
-      return NextResponse.json({ papers, total: papers.length });
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+			const resolvedId = await resolveToS2Id(paperId);
+			const papers = await recommendFromSingle(resolvedId, { limit, from });
+			return NextResponse.json({ papers, total: papers.length });
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/resolve/route.test.ts
+++ b/packages/web/src/app/api/resolve/route.test.ts
@@ -1,90 +1,90 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/core", () => ({
-    getPaper: vi.fn(),
-    searchPapers: vi.fn(),
+	getPaper: vi.fn(),
+	searchPapers: vi.fn(),
 }));
 
 const core = await import("@paper-tools/core");
 const { POST } = await import("./route");
 
 function makeRequest(body: unknown) {
-    return new NextRequest("http://localhost/api/resolve", {
-        method: "POST",
-        body: JSON.stringify(body),
-        headers: { "content-type": "application/json" },
-    });
+	return new NextRequest("http://localhost/api/resolve", {
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "content-type": "application/json" },
+	});
 }
 
 describe("/api/resolve POST", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("doi から論文を解決する", async () => {
-        vi.mocked(core.getPaper).mockResolvedValueOnce({
-            paperId: "s2-1",
-            title: "Paper",
-            externalIds: { DOI: "10.1000/xyz" },
-        } as any);
+	it("doi から論文を解決する", async () => {
+		vi.mocked(core.getPaper).mockResolvedValueOnce({
+			paperId: "s2-1",
+			title: "Paper",
+			externalIds: { DOI: "10.1000/xyz" },
+		} as any);
 
-        const res = await POST(makeRequest({ doi: "10.1000/xyz" }));
-        const data = await res.json();
+		const res = await POST(makeRequest({ doi: "10.1000/xyz" }));
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(core.getPaper).toHaveBeenCalledWith("DOI:10.1000/xyz");
-        expect(data.paper.paperId).toBe("s2-1");
-    });
+		expect(res.status).toBe(200);
+		expect(core.getPaper).toHaveBeenCalledWith("DOI:10.1000/xyz");
+		expect(data.paper.paperId).toBe("s2-1");
+	});
 
-    it("title から最初の検索結果を返す", async () => {
-        vi.mocked(core.searchPapers).mockResolvedValueOnce({
-            total: 1,
-            offset: 0,
-            data: [{ paperId: "s2-title", title: "A Title" }],
-        } as any);
+	it("title から最初の検索結果を返す", async () => {
+		vi.mocked(core.searchPapers).mockResolvedValueOnce({
+			total: 1,
+			offset: 0,
+			data: [{ paperId: "s2-title", title: "A Title" }],
+		} as any);
 
-        const res = await POST(makeRequest({ title: "A Title" }));
-        const data = await res.json();
+		const res = await POST(makeRequest({ title: "A Title" }));
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(core.searchPapers).toHaveBeenCalledWith("A Title");
-        expect(data.paper.paperId).toBe("s2-title");
-    });
+		expect(res.status).toBe(200);
+		expect(core.searchPapers).toHaveBeenCalledWith("A Title");
+		expect(data.paper.paperId).toBe("s2-title");
+	});
 
-    it("s2Id から論文を解決する", async () => {
-        vi.mocked(core.getPaper).mockResolvedValueOnce({
-            paperId: "abc123",
-            title: "By ID",
-        } as any);
+	it("s2Id から論文を解決する", async () => {
+		vi.mocked(core.getPaper).mockResolvedValueOnce({
+			paperId: "abc123",
+			title: "By ID",
+		} as any);
 
-        const res = await POST(makeRequest({ s2Id: "abc123" }));
-        const data = await res.json();
+		const res = await POST(makeRequest({ s2Id: "abc123" }));
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(core.getPaper).toHaveBeenCalledWith("abc123");
-        expect(data.paper.paperId).toBe("abc123");
-    });
+		expect(res.status).toBe(200);
+		expect(core.getPaper).toHaveBeenCalledWith("abc123");
+		expect(data.paper.paperId).toBe("abc123");
+	});
 
-    it("入力不足は400", async () => {
-        const res = await POST(makeRequest({}));
-        const data = await res.json();
+	it("入力不足は400", async () => {
+		const res = await POST(makeRequest({}));
+		const data = await res.json();
 
-        expect(res.status).toBe(400);
-        expect(data.error).toContain("いずれか1つが必要");
-    });
+		expect(res.status).toBe(400);
+		expect(data.error).toContain("いずれか1つが必要");
+	});
 
-    it("タイトル検索で結果がない場合は404", async () => {
-        vi.mocked(core.searchPapers).mockResolvedValueOnce({
-            total: 0,
-            offset: 0,
-            data: [],
-        } as any);
+	it("タイトル検索で結果がない場合は404", async () => {
+		vi.mocked(core.searchPapers).mockResolvedValueOnce({
+			total: 0,
+			offset: 0,
+			data: [],
+		} as any);
 
-        const res = await POST(makeRequest({ title: "Not Found" }));
-        const data = await res.json();
+		const res = await POST(makeRequest({ title: "Not Found" }));
+		const data = await res.json();
 
-        expect(res.status).toBe(404);
-        expect(data.error).toContain("解決できませんでした");
-    });
+		expect(res.status).toBe(404);
+		expect(data.error).toContain("解決できませんでした");
+	});
 });

--- a/packages/web/src/app/api/resolve/route.ts
+++ b/packages/web/src/app/api/resolve/route.ts
@@ -1,63 +1,63 @@
-import { NextRequest, NextResponse } from "next/server";
 import { getPaper, searchPapers } from "@paper-tools/core";
+import { type NextRequest, NextResponse } from "next/server";
 
 interface ResolveBody {
-    doi?: string;
-    title?: string;
-    s2Id?: string;
+	doi?: string;
+	title?: string;
+	s2Id?: string;
 }
 
 function normalizeDoi(input: string) {
-    return input.replace(/^DOI:/i, "").trim();
+	return input.replace(/^DOI:/i, "").trim();
 }
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = (await request.json()) as ResolveBody;
-        const doi = body.doi?.trim();
-        const title = body.title?.trim();
-        const s2Id = body.s2Id?.trim();
+	try {
+		const body = (await request.json()) as ResolveBody;
+		const doi = body.doi?.trim();
+		const title = body.title?.trim();
+		const s2Id = body.s2Id?.trim();
 
-        if (!doi && !title && !s2Id) {
-            return NextResponse.json(
-                { error: "doi, title, s2Id のいずれか1つが必要です" },
-                { status: 400 },
-            );
-        }
+		if (!doi && !title && !s2Id) {
+			return NextResponse.json(
+				{ error: "doi, title, s2Id のいずれか1つが必要です" },
+				{ status: 400 },
+			);
+		}
 
-        if (doi) {
-            const paper = await getPaper(`DOI:${normalizeDoi(doi)}`);
-            if (!paper) {
-                return NextResponse.json(
-                    { error: "DOI から論文を解決できませんでした" },
-                    { status: 404 },
-                );
-            }
-            return NextResponse.json({ paper });
-        }
+		if (doi) {
+			const paper = await getPaper(`DOI:${normalizeDoi(doi)}`);
+			if (!paper) {
+				return NextResponse.json(
+					{ error: "DOI から論文を解決できませんでした" },
+					{ status: 404 },
+				);
+			}
+			return NextResponse.json({ paper });
+		}
 
-        if (title) {
-            const result = await searchPapers(title);
-            const paper = result.data?.[0];
-            if (!paper) {
-                return NextResponse.json(
-                    { error: "タイトルから論文を解決できませんでした" },
-                    { status: 404 },
-                );
-            }
-            return NextResponse.json({ paper });
-        }
+		if (title) {
+			const result = await searchPapers(title);
+			const paper = result.data?.[0];
+			if (!paper) {
+				return NextResponse.json(
+					{ error: "タイトルから論文を解決できませんでした" },
+					{ status: 404 },
+				);
+			}
+			return NextResponse.json({ paper });
+		}
 
-        const paper = await getPaper(s2Id!);
-        if (!paper) {
-            return NextResponse.json(
-                { error: "S2 ID から論文を解決できませんでした" },
-                { status: 404 },
-            );
-        }
-        return NextResponse.json({ paper });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		const paper = await getPaper(s2Id!);
+		if (!paper) {
+			return NextResponse.json(
+				{ error: "S2 ID から論文を解決できませんでした" },
+				{ status: 404 },
+			);
+		}
+		return NextResponse.json({ paper });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/search/drilldown/route.test.ts
+++ b/packages/web/src/app/api/search/drilldown/route.test.ts
@@ -1,92 +1,92 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/drilldown", () => ({
-    drilldown: vi.fn(),
+	drilldown: vi.fn(),
 }));
 
 const { drilldown } = await import("@paper-tools/drilldown");
 const { POST } = await import("./route");
 
 function makeRequest(body: unknown) {
-    return new NextRequest("http://localhost/api/search/drilldown", {
-        method: "POST",
-        body: JSON.stringify(body),
-        headers: { "content-type": "application/json" },
-    });
+	return new NextRequest("http://localhost/api/search/drilldown", {
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "content-type": "application/json" },
+	});
 }
 
 describe("/api/search/drilldown POST", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("seedPapersのみ指定でdrilldownがデフォルト引数で呼ばれる", async () => {
-        const mockResults = [
-            { paperId: "res1", title: "Drilldown Result 1" }
-        ];
-        vi.mocked(drilldown).mockResolvedValueOnce(mockResults as any);
+	it("seedPapersのみ指定でdrilldownがデフォルト引数で呼ばれる", async () => {
+		const mockResults = [{ paperId: "res1", title: "Drilldown Result 1" }];
+		vi.mocked(drilldown).mockResolvedValueOnce(mockResults as any);
 
-        const seedPapers = [{ paperId: "seed1", title: "Seed 1" }];
-        const res = await POST(makeRequest({ seedPapers }));
-        const data = await res.json();
+		const seedPapers = [{ paperId: "seed1", title: "Seed 1" }];
+		const res = await POST(makeRequest({ seedPapers }));
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        // seedPapers, depth=1, maxPerLevel=10, enrich=false
-        expect(drilldown).toHaveBeenCalledWith(seedPapers, 1, 10, false);
-        expect(data.results).toEqual(mockResults);
-    });
+		expect(res.status).toBe(200);
+		// seedPapers, depth=1, maxPerLevel=10, enrich=false
+		expect(drilldown).toHaveBeenCalledWith(seedPapers, 1, 10, false);
+		expect(data.results).toEqual(mockResults);
+	});
 
-    it("すべてのパラメータを指定した場合にdrilldownに正しく渡される", async () => {
-        const mockResults = [
-            { paperId: "res2", title: "Drilldown Result 2" }
-        ];
-        vi.mocked(drilldown).mockResolvedValueOnce(mockResults as any);
+	it("すべてのパラメータを指定した場合にdrilldownに正しく渡される", async () => {
+		const mockResults = [{ paperId: "res2", title: "Drilldown Result 2" }];
+		vi.mocked(drilldown).mockResolvedValueOnce(mockResults as any);
 
-        const seedPapers = [{ paperId: "seed2", title: "Seed 2" }];
-        const reqBody = {
-            seedPapers,
-            depth: 2,
-            maxPerLevel: 5,
-            enrich: true,
-        };
-        const res = await POST(makeRequest(reqBody));
-        const data = await res.json();
+		const seedPapers = [{ paperId: "seed2", title: "Seed 2" }];
+		const reqBody = {
+			seedPapers,
+			depth: 2,
+			maxPerLevel: 5,
+			enrich: true,
+		};
+		const res = await POST(makeRequest(reqBody));
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(drilldown).toHaveBeenCalledWith(seedPapers, 2, 5, true);
-        expect(data.results).toEqual(mockResults);
-    });
+		expect(res.status).toBe(200);
+		expect(drilldown).toHaveBeenCalledWith(seedPapers, 2, 5, true);
+		expect(data.results).toEqual(mockResults);
+	});
 
-    it("seedPapersが空配列の場合は400エラー", async () => {
-        const res = await POST(makeRequest({ seedPapers: [] }));
-        const data = await res.json();
+	it("seedPapersが空配列の場合は400エラー", async () => {
+		const res = await POST(makeRequest({ seedPapers: [] }));
+		const data = await res.json();
 
-        expect(res.status).toBe(400);
-        expect(data.error).toContain("seedPapers array is required and must not be empty");
-    });
+		expect(res.status).toBe(400);
+		expect(data.error).toContain(
+			"seedPapers array is required and must not be empty",
+		);
+	});
 
-    it("seedPapersが未指定の場合は400エラー", async () => {
-        const res = await POST(makeRequest({}));
-        const data = await res.json();
+	it("seedPapersが未指定の場合は400エラー", async () => {
+		const res = await POST(makeRequest({}));
+		const data = await res.json();
 
-        expect(res.status).toBe(400);
-        expect(data.error).toContain("seedPapers array is required and must not be empty");
-    });
+		expect(res.status).toBe(400);
+		expect(data.error).toContain(
+			"seedPapers array is required and must not be empty",
+		);
+	});
 
-    it("drilldownでエラーが発生した場合は500エラー", async () => {
-        vi.mocked(drilldown).mockRejectedValueOnce(new Error("Drilldown failed"));
+	it("drilldownでエラーが発生した場合は500エラー", async () => {
+		vi.mocked(drilldown).mockRejectedValueOnce(new Error("Drilldown failed"));
 
-        // suppress console.error in tests
-        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		// suppress console.error in tests
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-        const seedPapers = [{ paperId: "seed3", title: "Seed 3" }];
-        const res = await POST(makeRequest({ seedPapers }));
-        const data = await res.json();
+		const seedPapers = [{ paperId: "seed3", title: "Seed 3" }];
+		const res = await POST(makeRequest({ seedPapers }));
+		const data = await res.json();
 
-        expect(res.status).toBe(500);
-        expect(data.error).toBe("Drilldown failed");
+		expect(res.status).toBe(500);
+		expect(data.error).toBe("Drilldown failed");
 
-        consoleSpy.mockRestore();
-    });
+		consoleSpy.mockRestore();
+	});
 });

--- a/packages/web/src/app/api/search/drilldown/route.ts
+++ b/packages/web/src/app/api/search/drilldown/route.ts
@@ -1,30 +1,30 @@
-import { NextRequest, NextResponse } from "next/server";
-import { drilldown } from "@paper-tools/drilldown";
 import type { Paper } from "@paper-tools/core";
+import { drilldown } from "@paper-tools/drilldown";
+import { type NextRequest, NextResponse } from "next/server";
 
 interface DrilldownBody {
-    seedPapers: Paper[];
-    depth?: number;
-    maxPerLevel?: number;
-    enrich?: boolean;
+	seedPapers: Paper[];
+	depth?: number;
+	maxPerLevel?: number;
+	enrich?: boolean;
 }
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = (await request.json()) as DrilldownBody;
-        const { seedPapers, depth = 1, maxPerLevel = 10, enrich = false } = body;
+	try {
+		const body = (await request.json()) as DrilldownBody;
+		const { seedPapers, depth = 1, maxPerLevel = 10, enrich = false } = body;
 
-        if (!seedPapers || seedPapers.length === 0) {
-            return NextResponse.json(
-                { error: "seedPapers array is required and must not be empty" },
-                { status: 400 },
-            );
-        }
+		if (!seedPapers || seedPapers.length === 0) {
+			return NextResponse.json(
+				{ error: "seedPapers array is required and must not be empty" },
+				{ status: 400 },
+			);
+		}
 
-        const results = await drilldown(seedPapers, depth, maxPerLevel, enrich);
-        return NextResponse.json({ results });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		const results = await drilldown(seedPapers, depth, maxPerLevel, enrich);
+		return NextResponse.json({ results });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/search/route.ts
+++ b/packages/web/src/app/api/search/route.ts
@@ -1,25 +1,29 @@
-import { NextRequest, NextResponse } from "next/server";
 import { searchByKeyword } from "@paper-tools/drilldown";
+import { type NextRequest, NextResponse } from "next/server";
+import { parseLimitParam, parseSearchParams } from "../utils";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
-    const { searchParams } = new URL(request.url);
-    const q = searchParams.get("q");
-    const parsedMaxResults = Number(searchParams.get("maxResults") ?? "30");
-    const maxResults = Number.isFinite(parsedMaxResults)
-        ? Math.max(1, Math.min(100, parsedMaxResults))
-        : 30;
+	const searchParams = parseSearchParams(request);
+	const q = searchParams.get("q");
+	const maxResults = parseLimitParam(searchParams, 30, 100, "maxResults");
 
-    if (!q) {
-        return NextResponse.json({ error: "q parameter is required" }, { status: 400 });
-    }
+	if (!q) {
+		return NextResponse.json(
+			{ error: "q parameter is required" },
+			{ status: 400 },
+		);
+	}
 
-    try {
-        const papers = await searchByKeyword(q, maxResults);
-        return NextResponse.json({ papers, total: papers.length });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: `Search backend failed: ${message}` }, { status: 502 });
-    }
+	try {
+		const papers = await searchByKeyword(q, maxResults);
+		return NextResponse.json({ papers, total: papers.length });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json(
+			{ error: `Search backend failed: ${message}` },
+			{ status: 502 },
+		);
+	}
 }

--- a/packages/web/src/app/api/tags/suggest/route.test.ts
+++ b/packages/web/src/app/api/tags/suggest/route.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveNotionDataSourceMock = vi.fn();
 const getAccessTokenMock = vi.fn();
@@ -7,80 +7,85 @@ const getSelectedDatabaseIdMock = vi.fn();
 const getNotionClientMock = vi.fn();
 
 vi.mock("@/lib/notion-data-source", () => ({
-    resolveNotionDataSource: resolveNotionDataSourceMock,
+	resolveNotionDataSource: resolveNotionDataSourceMock,
 }));
 
 vi.mock("@/lib/auth", () => ({
-    getAccessToken: getAccessTokenMock,
-    getSelectedDatabaseId: getSelectedDatabaseIdMock,
-    getNotionClient: getNotionClientMock,
+	getAccessToken: getAccessTokenMock,
+	getSelectedDatabaseId: getSelectedDatabaseIdMock,
+	getNotionClient: getNotionClientMock,
 }));
 
 const { GET } = await import("./route");
 
 describe("/api/tags/suggest GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-        getAccessTokenMock.mockReturnValue("token");
-        getSelectedDatabaseIdMock.mockReturnValue("db-1");
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getAccessTokenMock.mockReturnValue("token");
+		getSelectedDatabaseIdMock.mockReturnValue("db-1");
+	});
 
-    it("q が2文字未満なら候補は空", async () => {
-        const req = new NextRequest("http://localhost/api/tags/suggest?q=m");
-        const res = await GET(req);
-        const data = await res.json();
+	it("q が2文字未満なら候補は空", async () => {
+		const req = new NextRequest("http://localhost/api/tags/suggest?q=m");
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(data.suggestions).toEqual([]);
-    });
+		expect(res.status).toBe(200);
+		expect(data.suggestions).toEqual([]);
+	});
 
-    it("タグ候補を返す", async () => {
-        resolveNotionDataSourceMock.mockResolvedValueOnce({
-            id: "ds-1",
-            properties: {
-                Tags: { type: "multi_select" },
-            },
-        });
+	it("タグ候補を返す", async () => {
+		resolveNotionDataSourceMock.mockResolvedValueOnce({
+			id: "ds-1",
+			properties: {
+				Tags: { type: "multi_select" },
+			},
+		});
 
-        getNotionClientMock.mockReturnValue({
-            dataSources: {
-                query: vi.fn().mockResolvedValue({
-                    results: [
-                        {
-                            object: "page",
-                            properties: {
-                                Tags: {
-                                    multi_select: [{ name: "Machine Learning" }, { name: "ML" }],
-                                },
-                            },
-                        },
-                        {
-                            object: "page",
-                            properties: {
-                                Tags: {
-                                    multi_select: [{ name: "machine learning" }, { name: "Data Mining" }],
-                                },
-                            },
-                        },
-                    ],
-                    has_more: false,
-                    next_cursor: null,
-                }),
-            },
-        });
+		getNotionClientMock.mockReturnValue({
+			dataSources: {
+				query: vi.fn().mockResolvedValue({
+					results: [
+						{
+							object: "page",
+							properties: {
+								Tags: {
+									multi_select: [{ name: "Machine Learning" }, { name: "ML" }],
+								},
+							},
+						},
+						{
+							object: "page",
+							properties: {
+								Tags: {
+									multi_select: [
+										{ name: "machine learning" },
+										{ name: "Data Mining" },
+									],
+								},
+							},
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				}),
+			},
+		});
 
-        const req = new NextRequest("http://localhost/api/tags/suggest?q=ma&limit=5");
-        const res = await GET(req);
-        const data = await res.json();
+		const req = new NextRequest(
+			"http://localhost/api/tags/suggest?q=ma&limit=5",
+		);
+		const res = await GET(req);
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(data.suggestions).toEqual(["Machine Learning"]);
-    });
+		expect(res.status).toBe(200);
+		expect(data.suggestions).toEqual(["Machine Learning"]);
+	});
 
-    it("未認証は401", async () => {
-        getAccessTokenMock.mockReturnValueOnce(null);
-        const req = new NextRequest("http://localhost/api/tags/suggest?q=ml");
-        const res = await GET(req);
-        expect(res.status).toBe(401);
-    });
+	it("未認証は401", async () => {
+		getAccessTokenMock.mockReturnValueOnce(null);
+		const req = new NextRequest("http://localhost/api/tags/suggest?q=ml");
+		const res = await GET(req);
+		expect(res.status).toBe(401);
+	});
 });

--- a/packages/web/src/app/api/tags/suggest/route.ts
+++ b/packages/web/src/app/api/tags/suggest/route.ts
@@ -1,116 +1,134 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getAccessToken, getNotionClient, getSelectedDatabaseId } from "@/lib/auth";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	getAccessToken,
+	getNotionClient,
+	getSelectedDatabaseId,
+} from "@/lib/auth";
 import { resolveNotionDataSource } from "@/lib/notion-data-source";
+import { parseLimitParam, parseSearchParams } from "../../utils";
 
 export const runtime = "nodejs";
 
 type NotionProperty = {
-    type?: string;
-    multi_select?: Array<{ name?: string }>;
+	type?: string;
+	multi_select?: Array<{ name?: string }>;
 };
 
 const MAX_QUERY_PAGES = 8;
 
-function clampLimit(limit: number) {
-    if (!Number.isFinite(limit)) return 10;
-    return Math.max(1, Math.min(20, limit));
-}
-
 function normalizeTag(value: string) {
-    return value.trim();
+	return value.trim();
 }
 
 function findTagPropertyKeys(properties: Record<string, NotionProperty>) {
-    const entries = Object.entries(properties);
-    const multiSelectEntries = entries.filter(([, prop]) => prop.type === "multi_select");
-    const preferred = multiSelectEntries.filter(([name]) => /tag|タグ|label/i.test(name));
-    return (preferred.length > 0 ? preferred : multiSelectEntries).map(([name]) => name);
+	const entries = Object.entries(properties);
+	const multiSelectEntries = entries.filter(
+		([, prop]) => prop.type === "multi_select",
+	);
+	const preferred = multiSelectEntries.filter(([name]) =>
+		/tag|タグ|label/i.test(name),
+	);
+	return (preferred.length > 0 ? preferred : multiSelectEntries).map(
+		([name]) => name,
+	);
 }
 
-function isPageRecord(value: unknown): value is { properties: Record<string, NotionProperty> } {
-    if (typeof value !== "object" || value === null) {
-        return false;
-    }
-    const record = value as Record<string, unknown>;
-    return record.object === "page"
-        && typeof record.properties === "object"
-        && record.properties !== null;
+function isPageRecord(
+	value: unknown,
+): value is { properties: Record<string, NotionProperty> } {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	const record = value as Record<string, unknown>;
+	return (
+		record.object === "page" &&
+		typeof record.properties === "object" &&
+		record.properties !== null
+	);
 }
 
 export async function GET(request: NextRequest) {
-    const accessToken = getAccessToken(request.cookies);
-    const dataSourceId = getSelectedDatabaseId(request.cookies);
-    if (!accessToken) {
-        return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    if (!dataSourceId) {
-        return NextResponse.json({ error: "Database is not selected" }, { status: 400 });
-    }
+	const accessToken = getAccessToken(request.cookies);
+	const dataSourceId = getSelectedDatabaseId(request.cookies);
+	if (!accessToken) {
+		return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+	}
+	if (!dataSourceId) {
+		return NextResponse.json(
+			{ error: "Database is not selected" },
+			{ status: 400 },
+		);
+	}
 
-    const { searchParams } = new URL(request.url);
-    const q = searchParams.get("q")?.trim() ?? "";
-    const limit = clampLimit(Number(searchParams.get("limit") ?? "10"));
+	const searchParams = parseSearchParams(request);
+	const q = searchParams.get("q")?.trim() ?? "";
+	const limit = parseLimitParam(searchParams);
 
-    if (q.length < 2) {
-        return NextResponse.json({ suggestions: [] as string[] });
-    }
+	if (q.length < 2) {
+		return NextResponse.json({ suggestions: [] as string[] });
+	}
 
-    try {
-        const notion = getNotionClient(accessToken);
-        const dataSource = await resolveNotionDataSource<NotionProperty>(notion, dataSourceId);
-        const tagKeys = findTagPropertyKeys(dataSource.properties);
-        if (tagKeys.length === 0) {
-            return NextResponse.json({ suggestions: [] as string[] });
-        }
+	try {
+		const notion = getNotionClient(accessToken);
+		const dataSource = await resolveNotionDataSource<NotionProperty>(
+			notion,
+			dataSourceId,
+		);
+		const tagKeys = findTagPropertyKeys(dataSource.properties);
+		if (tagKeys.length === 0) {
+			return NextResponse.json({ suggestions: [] as string[] });
+		}
 
-        const uniqueTags = new Map<string, string>();
-        let startCursor: string | undefined;
-        let pageCount = 0;
+		const uniqueTags = new Map<string, string>();
+		let startCursor: string | undefined;
+		let pageCount = 0;
 
-        do {
-            const response = await notion.dataSources.query({
-                data_source_id: dataSource.id,
-                page_size: 100,
-                start_cursor: startCursor,
-            });
-            pageCount += 1;
+		do {
+			const response = await notion.dataSources.query({
+				data_source_id: dataSource.id,
+				page_size: 100,
+				start_cursor: startCursor,
+			});
+			pageCount += 1;
 
-            for (const record of response.results) {
-                if (!isPageRecord(record)) continue;
-                for (const key of tagKeys) {
-                    const items = record.properties[key]?.multi_select;
-                    if (!items) continue;
-                    for (const item of items) {
-                        const normalized = normalizeTag(item.name ?? "");
-                        if (!normalized) continue;
-                        const dedupeKey = normalized.toLowerCase();
-                        if (!uniqueTags.has(dedupeKey)) {
-                            uniqueTags.set(dedupeKey, normalized);
-                        }
-                    }
-                }
-            }
+			for (const record of response.results) {
+				if (!isPageRecord(record)) continue;
+				for (const key of tagKeys) {
+					const items = record.properties[key]?.multi_select;
+					if (!items) continue;
+					for (const item of items) {
+						const normalized = normalizeTag(item.name ?? "");
+						if (!normalized) continue;
+						const dedupeKey = normalized.toLowerCase();
+						if (!uniqueTags.has(dedupeKey)) {
+							uniqueTags.set(dedupeKey, normalized);
+						}
+					}
+				}
+			}
 
-            startCursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
-            if (pageCount >= MAX_QUERY_PAGES) {
-                startCursor = undefined;
-            }
-        } while (startCursor);
+			startCursor = response.has_more
+				? (response.next_cursor ?? undefined)
+				: undefined;
+			if (pageCount >= MAX_QUERY_PAGES) {
+				startCursor = undefined;
+			}
+		} while (startCursor);
 
-        const normalizedQuery = q.toLowerCase();
-        const suggestions = Array.from(uniqueTags.values())
-            .filter((tag) => tag.toLowerCase().includes(normalizedQuery))
-            .sort((a, b) => {
-                const aStarts = a.toLowerCase().startsWith(normalizedQuery) ? 0 : 1;
-                const bStarts = b.toLowerCase().startsWith(normalizedQuery) ? 0 : 1;
-                if (aStarts !== bStarts) return aStarts - bStarts;
-                return a.localeCompare(b, "ja");
-            })
-            .slice(0, limit);
+		const normalizedQuery = q.toLowerCase();
+		const suggestions = Array.from(uniqueTags.values())
+			.filter((tag) => tag.toLowerCase().includes(normalizedQuery))
+			.sort((a, b) => {
+				const aStarts = a.toLowerCase().startsWith(normalizedQuery) ? 0 : 1;
+				const bStarts = b.toLowerCase().startsWith(normalizedQuery) ? 0 : 1;
+				if (aStarts !== bStarts) return aStarts - bStarts;
+				return a.localeCompare(b, "ja");
+			})
+			.slice(0, limit);
 
-        return NextResponse.json({ suggestions });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		return NextResponse.json({ suggestions });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
 }

--- a/packages/web/src/app/api/utils.ts
+++ b/packages/web/src/app/api/utils.ts
@@ -1,0 +1,24 @@
+export function parseSearchParams(
+	request:
+		| Request
+		| { url: string; nextUrl?: { searchParams: URLSearchParams } },
+) {
+	if ("nextUrl" in request && request.nextUrl) {
+		return request.nextUrl.searchParams as URLSearchParams;
+	}
+	return new URL(request.url).searchParams;
+}
+
+export function parseLimitParam(
+	searchParams: URLSearchParams,
+	defaultLimit = 10,
+	maxLimit = 20,
+	paramName = "limit",
+) {
+	const rawLimit = Number(
+		searchParams.get(paramName) ?? defaultLimit.toString(),
+	);
+	return Number.isFinite(rawLimit)
+		? Math.max(1, Math.min(maxLimit, rawLimit))
+		: defaultLimit;
+}


### PR DESCRIPTION
🎯 **What:** Extracted common API route parameter parsing (URL setup and limit bounds) into shared utilities.

💡 **Why:** To reduce duplication and improve maintainability of Next.js API routes.

✅ **Verification:** Verified by running formatters and the test suite (`cd packages/web && pnpm test`).

✨ **Result:** Simplified parameter parsing across multiple route handlers using shared utility functions.

---
*PR created automatically by Jules for task [6680314672596780517](https://jules.google.com/task/6680314672596780517) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

共通のAPIルートパラメータ解析ロジック（URLパラメータ取得・`limit` パラメータのバウンドチェック）を `packages/web/src/app/api/utils.ts` に抽出し、34ファイルにわたるAPIルートで再利用するリファクタリングです。機能的な変更はほとんどなく、大部分はインデントのスペース→タブへの統一とインポート順の整形です。

- **`parseSearchParams`**: `NextRequest.nextUrl.searchParams` を優先しつつ、プレーン `Request` にもフォールバックする汎用パラメータ取得関数を追加。
- **`parseLimitParam`**: デフォルト値・最大値のクランプ付きで `limit` パラメータを解析する共通関数を追加。ただし空文字列 (`?limit=`) を `0` として扱いデフォルト値ではなく `1` を返すバグがある。
- 34ファイル中33ファイルはフォーマット変更のみ、または既存ロジックをユーティリティ関数に委譲する小さな置き換えで構成されている。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

新規の `parseLimitParam` に空文字列パラメータの処理バグがあり、`?limit=` を送ると意図せずレスポンスが 1 件に絞られる。共有ユーティリティへの変更のためバグが複数ルートに影響する。

`parseLimitParam` が `?limit=` の空文字列ケースで `defaultLimit` の代わりに `1` を返すバグは、複数の API エンドポイント (`/api/authors/search`、`/api/tags/suggest` など) に同時に影響する。共有ユーティリティとして抽出されているため、修正前にマージするとその後も同じ挙動が広がる。その他の変更はすべてフォーマット統一のみで安全。

packages/web/src/app/api/utils.ts の `parseLimitParam` 関数（特に `??` 演算子と空文字列の扱い）と、それを `parseLimitParam(searchParams)` のデフォルト引数で呼び出している `authors/search/route.ts`・`tags/suggest/route.ts`。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/utils.ts | 新規ユーティリティファイル。`parseSearchParams` と `parseLimitParam` を追加。`parseLimitParam` が空文字列パラメータ (`?limit=`) を誤って処理し、デフォルト値の代わりに 1 を返すバグがある。テストも未整備。 |
| packages/web/src/app/api/search/route.ts | 共有ユーティリティ (`parseSearchParams`, `parseLimitParam`) を利用するよう更新。インデントをタブに変換。ロジックの変更なし。 |
| packages/web/src/app/api/authors/search/route.ts | 共有ユーティリティ利用に切り替え。`parseLimitParam` のデフォルト引数 (limit=10, max=20) を使用。 |
| packages/web/src/app/api/tags/suggest/route.ts | 共有ユーティリティ利用に切り替え。ロジックの変更なし。 |
| packages/web/src/app/api/archive/route.ts | インデント・インポート順の整形のみ。ロジック変更なし。 |
| packages/web/src/app/api/graph/route.ts | `parseSearchParams` を利用するよう切り替え。ロジック変更なし。 |
| packages/web/src/app/api/bibtex/route.ts | `parseSearchParams` を利用するよう切り替え。ロジック変更なし。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web/src/app/api/utils.ts:18-23
`parseLimitParam` が空文字列の `limit` パラメータを誤って処理します。`searchParams.get("limit")` が `""` (空文字列) を返すとき、`"" ?? defaultLimit.toString()` は `""` のまま（空文字列は `null`/`undefined` ではないため `??` でフォールバックされない）、`Number("")` は `0` になり、有限値なので `Math.max(1, Math.min(maxLimit, 0))` = **1** を返します。`?limit=` のような空パラメータを送ると、期待されるデフォルト値の代わりに `1` 件しか返らなくなります。

```suggestion
	const raw = searchParams.get(paramName)?.trim();
	const rawLimit = raw ? Number(raw) : defaultLimit;
	return Number.isFinite(rawLimit)
		? Math.max(1, Math.min(maxLimit, rawLimit))
		: defaultLimit;
```

### Issue 2 of 2
packages/web/src/app/api/utils.ts:1-24
**`utils.ts` に専用のユニットテストがありません**

`parseSearchParams` と `parseLimitParam` は複数のルートで共有される重要なユーティリティ関数ですが、直接テストするファイルが存在しません。特に `parseLimitParam` は複数のデフォルト引数の組み合わせや境界値（`0`、負数、空文字列、非数値、`Infinity` など）を持つため、独立したテストがあると回帰検知に役立ちます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Extract API route utilities"](https://github.com/hiroki-org/paper-tools/commit/46c44496801ec94c884dd70a67386db5aac20667) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32487786)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->