### PR TITLE
🧪 Add useSaveToNotion hook tests

### DIFF
--- a/packages/web/src/hooks/useSaveToNotion.test.ts
+++ b/packages/web/src/hooks/useSaveToNotion.test.ts
@@ -45,26 +45,66 @@ describe("useSaveToNotion", () => {
 		expect(fetch).not.toHaveBeenCalled();
 	});
 
-	it("should return early if status is resolving, saving, or done", async () => {
-		// Mock fetch to delay so we can check state mid-flight
+	it("should return early while saving", async () => {
 		vi.mocked(fetch).mockImplementationOnce(
 			() => new Promise(() => {}),
 		);
 
 		const { result } = renderHook(() => useSaveToNotion({ paper: mockPaper }));
 
-		act(() => {
-			result.current.save();
+		await act(async () => {
+			void result.current.save();
 		});
 
 		expect(result.current.status).toBe("saving");
 
-		// Call save again while saving
-		act(() => {
-			result.current.save();
+		await act(async () => {
+			await result.current.save();
 		});
 
-		// Should only have been called once
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("should return early while resolving", async () => {
+		vi.mocked(fetch).mockImplementationOnce(
+			() => new Promise(() => {}),
+		);
+
+		const { result } = renderHook(() =>
+			useSaveToNotion({ doi: "10.1234/test" }),
+		);
+
+		await act(async () => {
+			void result.current.save();
+		});
+
+		expect(result.current.status).toBe("resolving");
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("should return early after save is done", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ success: true }),
+		} as Response);
+
+		const { result } = renderHook(() => useSaveToNotion({ paper: mockPaper }));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(result.current.status).toBe("done");
+
+		await act(async () => {
+			await result.current.save();
+		});
+
 		expect(fetch).toHaveBeenCalledTimes(1);
 	});
 
@@ -94,11 +134,9 @@ describe("useSaveToNotion", () => {
 				useSaveToNotion({ paper: mockPaper, onSaved: onSavedMock }),
 			);
 
-			act(() => {
-				result.current.save();
+			await act(async () => {
+				await result.current.save();
 			});
-
-			expect(result.current.status).toBe("saving");
 
 			await waitFor(() => {
 				expect(result.current.status).toBe("done");
@@ -164,6 +202,37 @@ describe("useSaveToNotion", () => {
 			expect(result.current.status).toBe("error");
 			expect(result.current.error).toBe("Unknown error");
 		});
+
+		it("should retry successfully after an archive error", async () => {
+			vi.mocked(fetch)
+				.mockResolvedValueOnce({
+					ok: false,
+					json: async () => ({ error: "Temporary Notion Error" }),
+				} as Response)
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ success: true }),
+				} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ paper: mockPaper }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("error");
+			expect(result.current.error).toBe("Temporary Notion Error");
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("done");
+			expect(result.current.error).toBeNull();
+			expect(fetch).toHaveBeenCalledTimes(2);
+		});
 	});
 
 	describe("when providing doi or title without paper", () => {
@@ -186,11 +255,9 @@ describe("useSaveToNotion", () => {
 				useSaveToNotion({ doi: "10.1234/test", onSaved: onSavedMock }),
 			);
 
-			act(() => {
-				result.current.save();
+			await act(async () => {
+				await result.current.save();
 			});
-
-			expect(result.current.status).toBe("resolving");
 
 			await waitFor(() => {
 				expect(result.current.status).toBe("done");

--- a/packages/web/src/hooks/useSaveToNotion.test.ts
+++ b/packages/web/src/hooks/useSaveToNotion.test.ts
@@ -1,0 +1,329 @@
+// @vitest-environment jsdom
+
+import type { S2Paper } from "@paper-tools/core";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSaveToNotion } from "./useSaveToNotion";
+
+describe("useSaveToNotion", () => {
+	const mockPaper: S2Paper = {
+		paperId: "test-id",
+		title: "Test Paper",
+		abstract: "Test Abstract",
+		year: 2024,
+		authors: [{ authorId: "author-1", name: "Test Author" }],
+		url: "https://example.com/paper",
+		referenceCount: 0,
+		citationCount: 0,
+		influentialCitationCount: 0,
+		externalIds: {},
+	};
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("should initialize with idle status and null error", () => {
+		const { result } = renderHook(() => useSaveToNotion({}));
+		expect(result.current.status).toBe("idle");
+		expect(result.current.error).toBeNull();
+	});
+
+	it("should return early if already saved", async () => {
+		const { result } = renderHook(() => useSaveToNotion({ saved: true }));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(result.current.status).toBe("idle");
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("should return early if status is resolving, saving, or done", async () => {
+		// Mock fetch to delay so we can check state mid-flight
+		vi.mocked(fetch).mockImplementationOnce(
+			() => new Promise(() => {}),
+		);
+
+		const { result } = renderHook(() => useSaveToNotion({ paper: mockPaper }));
+
+		act(() => {
+			result.current.save();
+		});
+
+		expect(result.current.status).toBe("saving");
+
+		// Call save again while saving
+		act(() => {
+			result.current.save();
+		});
+
+		// Should only have been called once
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("should throw error if paper, doi, and title are missing", async () => {
+		const { result } = renderHook(() => useSaveToNotion({}));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toBe(
+			"保存対象の DOI またはタイトルが見つかりません",
+		);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	describe("when providing paper", () => {
+		it("should skip resolve and archive directly on success", async () => {
+			const onSavedMock = vi.fn();
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ paper: mockPaper, onSaved: onSavedMock }),
+			);
+
+			act(() => {
+				result.current.save();
+			});
+
+			expect(result.current.status).toBe("saving");
+
+			await waitFor(() => {
+				expect(result.current.status).toBe("done");
+			});
+
+			expect(result.current.error).toBeNull();
+			expect(fetch).toHaveBeenCalledTimes(1);
+			expect(fetch).toHaveBeenCalledWith("/api/archive", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			expect(onSavedMock).toHaveBeenCalled();
+		});
+
+		it("should handle archive failure", async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				json: async () => ({ error: "Notion API Error" }),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ paper: mockPaper }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("error");
+			expect(result.current.error).toBe("Notion API Error");
+		});
+
+		it("should handle archive failure with default error message", async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				json: async () => ({}),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ paper: mockPaper }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("error");
+			expect(result.current.error).toBe("Notionへの保存に失敗しました");
+		});
+
+		it("should handle unknown error", async () => {
+			vi.mocked(fetch).mockRejectedValueOnce("Unknown primitive error");
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ paper: mockPaper }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("error");
+			expect(result.current.error).toBe("Unknown error");
+		});
+	});
+
+	describe("when providing doi or title without paper", () => {
+		it("should resolve paper and then archive on success", async () => {
+			const onSavedMock = vi.fn();
+
+			// Mock resolve response
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ paper: mockPaper }),
+			} as Response);
+
+			// Mock archive response
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ doi: "10.1234/test", onSaved: onSavedMock }),
+			);
+
+			act(() => {
+				result.current.save();
+			});
+
+			expect(result.current.status).toBe("resolving");
+
+			await waitFor(() => {
+				expect(result.current.status).toBe("done");
+			});
+
+			expect(fetch).toHaveBeenCalledTimes(2);
+
+			// Check resolve call
+			expect(fetch).toHaveBeenNthCalledWith(1, "/api/resolve", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ doi: "10.1234/test" }),
+			});
+
+			// Check archive call
+			expect(fetch).toHaveBeenNthCalledWith(2, "/api/archive", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+
+			expect(onSavedMock).toHaveBeenCalled();
+		});
+
+		it("should resolve paper with title if doi is not provided", async () => {
+			// Mock resolve response
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ paper: mockPaper }),
+			} as Response);
+
+			// Mock archive response
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ title: "Test Paper Title" }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(fetch).toHaveBeenNthCalledWith(1, "/api/resolve", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "Test Paper Title" }),
+			});
+		});
+
+		it("should trim doi and title", async () => {
+			// Mock resolve response
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ paper: mockPaper }),
+			} as Response);
+
+			// Mock archive response
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ doi: "  10.1234/test  " }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(fetch).toHaveBeenNthCalledWith(1, "/api/resolve", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ doi: "10.1234/test" }),
+			});
+		});
+
+		it("should handle resolve failure", async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				json: async () => ({ error: "Resolve Error" }),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ doi: "10.1234/test" }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("error");
+			expect(result.current.error).toBe("Resolve Error");
+			expect(fetch).toHaveBeenCalledTimes(1); // Should not call archive
+		});
+
+		it("should handle resolve failure with default error message", async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				json: async () => ({}),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ doi: "10.1234/test" }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("error");
+			expect(result.current.error).toBe("論文の解決に失敗しました");
+		});
+
+		it("should handle resolve success but missing paper", async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ paper: null }),
+			} as Response);
+
+			const { result } = renderHook(() =>
+				useSaveToNotion({ doi: "10.1234/test" }),
+			);
+
+			await act(async () => {
+				await result.current.save();
+			});
+
+			expect(result.current.status).toBe("error");
+			expect(result.current.error).toBe("保存対象の論文を取得できませんでした");
+		});
+	});
+});


### PR DESCRIPTION
Replaces #270 with a clean branch.

Validation:
- pnpm --filter @paper-tools/web test -- useSaveToNotion.test.ts
- pnpm --filter @paper-tools/web build

Scope: adds only packages/web/src/hooks/useSaveToNotion.test.ts.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Review completed successfully.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only file addition, safe to merge.

No production code changes.

No files require special attention.
</details>

<sub>Reviews (3): Last reviewed commit: ["Address useSaveToNotion retry test feedb..."](https://github.com/hiroki-org/paper-tools/commit/2db69b775beb5671a09badf43915836f426ea257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32558498)</sub>

<!-- /greptile_comment -->