### PR TITLE
fix: validate drilldown route payload

### DIFF
--- a/packages/web/src/app/api/search/drilldown/route.test.ts
+++ b/packages/web/src/app/api/search/drilldown/route.test.ts
@@ -84,6 +84,19 @@ describe("/api/search/drilldown POST", () => {
         expect(drilldown).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ["配列", [{ seedPapers: [{ paperId: "seed-array", title: "Seed array" }] }]],
+        ["文字列", "string"],
+        ["数値", 123],
+    ])("リクエストボディが%sの場合は400エラー", async (_, body) => {
+        const res = await POST(makeRequest(body));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("Invalid request body");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
     it("空のリクエストボディの場合は400エラー", async () => {
         const res = await POST(makeRawRequest());
         const data = await res.json();
@@ -143,6 +156,18 @@ describe("/api/search/drilldown POST", () => {
         expect(drilldown).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ["空白のみのtitle", { paperId: "seed-blank-title", title: "   " }],
+        ["非文字列のtitle", { paperId: "seed-number-title", title: 123 }],
+    ])("%sのseedPapersの場合は400エラー", async (_, seedPaper) => {
+        const res = await POST(makeRequest({ seedPapers: [seedPaper] }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("seedPapers must each include a title");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
     it("drilldownでエラーが発生した場合は500エラー", async () => {
         vi.mocked(drilldown).mockRejectedValueOnce(new Error("Drilldown failed"));
 
@@ -154,7 +179,7 @@ describe("/api/search/drilldown POST", () => {
         const data = await res.json();
 
         expect(res.status).toBe(500);
-        expect(data.error).toBe("Drilldown failed");
+        expect(data.error).toContain("Drilldown failed");
 
         consoleSpy.mockRestore();
     });

--- a/packages/web/src/app/api/search/drilldown/route.test.ts
+++ b/packages/web/src/app/api/search/drilldown/route.test.ts
@@ -147,6 +147,36 @@ describe("/api/search/drilldown POST", () => {
         expect(drilldown).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ["0", 0],
+        ["小数", 1.5],
+        ["上限超過", 6],
+        ["文字列", "2"],
+    ])("depthが%sの場合は400エラー", async (_, depth) => {
+        const seedPapers = [{ paperId: "seed-depth", title: "Seed depth" }];
+        const res = await POST(makeRequest({ seedPapers, depth }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("depth must be an integer between 1 and 5");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["0", 0],
+        ["小数", 10.5],
+        ["上限超過", 101],
+        ["文字列", "10"],
+    ])("maxPerLevelが%sの場合は400エラー", async (_, maxPerLevel) => {
+        const seedPapers = [{ paperId: "seed-max", title: "Seed max" }];
+        const res = await POST(makeRequest({ seedPapers, maxPerLevel }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("maxPerLevel must be an integer between 1 and 100");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
     it("titleがないseedPapersの場合は400エラー", async () => {
         const res = await POST(makeRequest({ seedPapers: [{ paperId: "seed-no-title" }] }));
         const data = await res.json();

--- a/packages/web/src/app/api/search/drilldown/route.test.ts
+++ b/packages/web/src/app/api/search/drilldown/route.test.ts
@@ -64,6 +64,16 @@ describe("/api/search/drilldown POST", () => {
 
         expect(res.status).toBe(400);
         expect(data.error).toContain("seedPapers array is required and must not be empty");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
+    it("リクエストボディがnullの場合は400エラー", async () => {
+        const res = await POST(makeRequest(null));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("Invalid request body");
+        expect(drilldown).not.toHaveBeenCalled();
     });
 
     it("seedPapersが未指定の場合は400エラー", async () => {
@@ -95,6 +105,15 @@ describe("/api/search/drilldown POST", () => {
 
         expect(res.status).toBe(400);
         expect(data.error).toContain("seedPapers array must contain 100 papers or fewer");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
+    it("titleがないseedPapersの場合は400エラー", async () => {
+        const res = await POST(makeRequest({ seedPapers: [{ paperId: "seed-no-title" }] }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("seedPapers must each include a title");
         expect(drilldown).not.toHaveBeenCalled();
     });
 

--- a/packages/web/src/app/api/search/drilldown/route.test.ts
+++ b/packages/web/src/app/api/search/drilldown/route.test.ts
@@ -16,6 +16,14 @@ function makeRequest(body: unknown) {
     });
 }
 
+function makeRawRequest(body?: BodyInit) {
+    return new NextRequest("http://localhost/api/search/drilldown", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/json" },
+    });
+}
+
 describe("/api/search/drilldown POST", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -73,6 +81,24 @@ describe("/api/search/drilldown POST", () => {
 
         expect(res.status).toBe(400);
         expect(data.error).toContain("Invalid request body");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
+    it("空のリクエストボディの場合は400エラー", async () => {
+        const res = await POST(makeRawRequest());
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("Invalid JSON request body");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
+    it("不正なJSONボディの場合は400エラー", async () => {
+        const res = await POST(makeRawRequest("{invalid"));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("Invalid JSON request body");
         expect(drilldown).not.toHaveBeenCalled();
     });
 

--- a/packages/web/src/app/api/search/drilldown/route.test.ts
+++ b/packages/web/src/app/api/search/drilldown/route.test.ts
@@ -72,6 +72,30 @@ describe("/api/search/drilldown POST", () => {
 
         expect(res.status).toBe(400);
         expect(data.error).toContain("seedPapers array is required and must not be empty");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
+    it("seedPapersが配列ではない場合は400エラー", async () => {
+        const res = await POST(makeRequest({ seedPapers: "paper-1" }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("seedPapers array is required and must not be empty");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
+    it("seedPapersが100件を超える場合は400エラー", async () => {
+        const seedPapers = Array.from({ length: 101 }, (_, index) => ({
+            paperId: `seed-${index}`,
+            title: `Seed ${index}`,
+        }));
+
+        const res = await POST(makeRequest({ seedPapers }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("seedPapers array must contain 100 papers or fewer");
+        expect(drilldown).not.toHaveBeenCalled();
     });
 
     it("drilldownでエラーが発生した場合は500エラー", async () => {

--- a/packages/web/src/app/api/search/drilldown/route.test.ts
+++ b/packages/web/src/app/api/search/drilldown/route.test.ts
@@ -177,6 +177,20 @@ describe("/api/search/drilldown POST", () => {
         expect(drilldown).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ["数値", 1],
+        ["文字列", "false"],
+        ["null", null],
+    ])("enrichが%sの場合は400エラー", async (_, enrich) => {
+        const seedPapers = [{ paperId: "seed-enrich", title: "Seed enrich" }];
+        const res = await POST(makeRequest({ seedPapers, enrich }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("enrich must be a boolean");
+        expect(drilldown).not.toHaveBeenCalled();
+    });
+
     it("titleがないseedPapersの場合は400エラー", async () => {
         const res = await POST(makeRequest({ seedPapers: [{ paperId: "seed-no-title" }] }));
         const data = await res.json();

--- a/packages/web/src/app/api/search/drilldown/route.ts
+++ b/packages/web/src/app/api/search/drilldown/route.ts
@@ -2,10 +2,26 @@ import { NextRequest, NextResponse } from "next/server";
 import { drilldown } from "@paper-tools/drilldown";
 import type { DrilldownBody } from "./route.types";
 
+function hasTitle(value: unknown): value is { title: string } {
+    return (
+        !!value &&
+        typeof value === "object" &&
+        typeof (value as { title?: unknown }).title === "string" &&
+        (value as { title: string }).title.trim().length > 0
+    );
+}
+
 export async function POST(request: NextRequest) {
     try {
-        const payload = await request.json();
-        const body = payload as unknown as DrilldownBody;
+        const payload: unknown = await request.json();
+        if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+            return NextResponse.json(
+                { error: "Invalid request body" },
+                { status: 400 },
+            );
+        }
+
+        const body = payload as DrilldownBody;
         const { seedPapers, depth = 1, maxPerLevel = 10, enrich = false } = body;
 
         if (!Array.isArray(seedPapers) || seedPapers.length === 0) {
@@ -17,6 +33,12 @@ export async function POST(request: NextRequest) {
         if (seedPapers.length > 100) {
             return NextResponse.json(
                 { error: "seedPapers array must contain 100 papers or fewer" },
+                { status: 400 },
+            );
+        }
+        if (!seedPapers.every(hasTitle)) {
+            return NextResponse.json(
+                { error: "seedPapers must each include a title" },
                 { status: 400 },
             );
         }

--- a/packages/web/src/app/api/search/drilldown/route.ts
+++ b/packages/web/src/app/api/search/drilldown/route.ts
@@ -51,6 +51,12 @@ export async function POST(request: NextRequest) {
         const body = payload as DrilldownBody;
         const { seedPapers, depth = 1, maxPerLevel = 10, enrich = false } = body;
 
+        if (typeof enrich !== "boolean") {
+            return NextResponse.json(
+                { error: drilldownValidationError("enrich must be a boolean") },
+                { status: 400 },
+            );
+        }
         if (!isBoundedInteger(depth, MIN_DEPTH, MAX_DEPTH)) {
             return NextResponse.json(
                 {

--- a/packages/web/src/app/api/search/drilldown/route.ts
+++ b/packages/web/src/app/api/search/drilldown/route.ts
@@ -1,22 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { drilldown } from "@paper-tools/drilldown";
-import type { Paper } from "@paper-tools/core";
-
-interface DrilldownBody {
-    seedPapers: Paper[];
-    depth?: number;
-    maxPerLevel?: number;
-    enrich?: boolean;
-}
+import type { DrilldownBody } from "./route.types";
 
 export async function POST(request: NextRequest) {
     try {
-        const body = (await request.json()) as DrilldownBody;
+        const payload = await request.json();
+        const body = payload as unknown as DrilldownBody;
         const { seedPapers, depth = 1, maxPerLevel = 10, enrich = false } = body;
 
-        if (!seedPapers || seedPapers.length === 0) {
+        if (!Array.isArray(seedPapers) || seedPapers.length === 0) {
             return NextResponse.json(
                 { error: "seedPapers array is required and must not be empty" },
+                { status: 400 },
+            );
+        }
+        if (seedPapers.length > 100) {
+            return NextResponse.json(
+                { error: "seedPapers array must contain 100 papers or fewer" },
                 { status: 400 },
             );
         }

--- a/packages/web/src/app/api/search/drilldown/route.ts
+++ b/packages/web/src/app/api/search/drilldown/route.ts
@@ -13,7 +13,16 @@ function hasTitle(value: unknown): value is { title: string } {
 
 export async function POST(request: NextRequest) {
     try {
-        const payload: unknown = await request.json();
+        let payload: unknown;
+        try {
+            payload = await request.json();
+        } catch {
+            return NextResponse.json(
+                { error: "Invalid JSON request body" },
+                { status: 400 },
+            );
+        }
+
         if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
             return NextResponse.json(
                 { error: "Invalid request body" },

--- a/packages/web/src/app/api/search/drilldown/route.ts
+++ b/packages/web/src/app/api/search/drilldown/route.ts
@@ -3,6 +3,10 @@ import { drilldown } from "@paper-tools/drilldown";
 import type { DrilldownBody } from "./route.types.js";
 
 const DRILLDOWN_CONTEXT = "[drilldown]";
+const MIN_DEPTH = 1;
+const MAX_DEPTH = 5;
+const MIN_MAX_PER_LEVEL = 1;
+const MAX_MAX_PER_LEVEL = 100;
 
 function drilldownValidationError(message: string) {
     return `${DRILLDOWN_CONTEXT} Validation failed: ${message}`;
@@ -19,6 +23,10 @@ function hasTitle(value: unknown): value is { title: string } {
         typeof (value as { title?: unknown }).title === "string" &&
         (value as { title: string }).title.trim().length > 0
     );
+}
+
+function isBoundedInteger(value: unknown, min: number, max: number) {
+    return Number.isInteger(value) && (value as number) >= min && (value as number) <= max;
 }
 
 export async function POST(request: NextRequest) {
@@ -42,6 +50,27 @@ export async function POST(request: NextRequest) {
 
         const body = payload as DrilldownBody;
         const { seedPapers, depth = 1, maxPerLevel = 10, enrich = false } = body;
+
+        if (!isBoundedInteger(depth, MIN_DEPTH, MAX_DEPTH)) {
+            return NextResponse.json(
+                {
+                    error: drilldownValidationError(
+                        `depth must be an integer between ${MIN_DEPTH} and ${MAX_DEPTH}`,
+                    ),
+                },
+                { status: 400 },
+            );
+        }
+        if (!isBoundedInteger(maxPerLevel, MIN_MAX_PER_LEVEL, MAX_MAX_PER_LEVEL)) {
+            return NextResponse.json(
+                {
+                    error: drilldownValidationError(
+                        `maxPerLevel must be an integer between ${MIN_MAX_PER_LEVEL} and ${MAX_MAX_PER_LEVEL}`,
+                    ),
+                },
+                { status: 400 },
+            );
+        }
 
         if (!Array.isArray(seedPapers) || seedPapers.length === 0) {
             return NextResponse.json(

--- a/packages/web/src/app/api/search/drilldown/route.ts
+++ b/packages/web/src/app/api/search/drilldown/route.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { drilldown } from "@paper-tools/drilldown";
-import type { DrilldownBody } from "./route.types";
+import type { DrilldownBody } from "./route.types.js";
+
+const DRILLDOWN_CONTEXT = "[drilldown]";
+
+function drilldownValidationError(message: string) {
+    return `${DRILLDOWN_CONTEXT} Validation failed: ${message}`;
+}
+
+function drilldownOperationError(message: string) {
+    return `${DRILLDOWN_CONTEXT} Operation failed: ${message}`;
+}
 
 function hasTitle(value: unknown): value is { title: string } {
     return (
@@ -18,14 +28,14 @@ export async function POST(request: NextRequest) {
             payload = await request.json();
         } catch {
             return NextResponse.json(
-                { error: "Invalid JSON request body" },
+                { error: drilldownValidationError("Invalid JSON request body") },
                 { status: 400 },
             );
         }
 
         if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
             return NextResponse.json(
-                { error: "Invalid request body" },
+                { error: drilldownValidationError("Invalid request body") },
                 { status: 400 },
             );
         }
@@ -35,19 +45,31 @@ export async function POST(request: NextRequest) {
 
         if (!Array.isArray(seedPapers) || seedPapers.length === 0) {
             return NextResponse.json(
-                { error: "seedPapers array is required and must not be empty" },
+                {
+                    error: drilldownValidationError(
+                        "seedPapers array is required and must not be empty",
+                    ),
+                },
                 { status: 400 },
             );
         }
         if (seedPapers.length > 100) {
             return NextResponse.json(
-                { error: "seedPapers array must contain 100 papers or fewer" },
+                {
+                    error: drilldownValidationError(
+                        "seedPapers array must contain 100 papers or fewer",
+                    ),
+                },
                 { status: 400 },
             );
         }
         if (!seedPapers.every(hasTitle)) {
             return NextResponse.json(
-                { error: "seedPapers must each include a title" },
+                {
+                    error: drilldownValidationError(
+                        "seedPapers must each include a title",
+                    ),
+                },
                 { status: 400 },
             );
         }
@@ -56,6 +78,9 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ results });
     } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
+        return NextResponse.json(
+            { error: drilldownOperationError(message) },
+            { status: 500 },
+        );
     }
 }

--- a/packages/web/src/app/api/search/drilldown/route.types.ts
+++ b/packages/web/src/app/api/search/drilldown/route.types.ts
@@ -1,0 +1,8 @@
+import type { Paper } from "@paper-tools/core";
+
+export interface DrilldownBody {
+    seedPapers: Paper[];
+    depth?: number;
+    maxPerLevel?: number;
+    enrich?: boolean;
+}


### PR DESCRIPTION
Replaces #254, which was closed after its head branch picked up unrelated author-profiler/search churn.\n\nWhat changed:\n- Move the drilldown request body type into route.types.ts.\n- Cast request.json() through unknown before using the typed payload.\n- Validate seedPapers is a non-empty array and cap it at 100 entries.\n- Add route tests for non-array and over-limit seed payloads.\n\nLocal verification:\n- pnpm --filter @paper-tools/web test\n- pnpm --filter @paper-tools/web build

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはドリルダウン API ルートのリクエストボディバリデーションを全面的に強化します。以前の `seedPapers` の空チェックのみという実装から、JSON パースエラー・非オブジェクトボディ・`depth`/`maxPerLevel`/`enrich` の型・範囲チェック・各 `seedPaper` の `title` 検証までを網羅する堅牢な実装へ刷新されています。

- `DrilldownBody` インターフェースを `route.types.ts` へ分離し、`request.json()` を独立した try-catch で囲んで JSON パース失敗時に 400 を返すよう修正。
- `depth`（1–5）・`maxPerLevel`（1–100）・`enrich`（boolean）・`seedPapers`（非空配列、100 件以下、各要素に非空 `title`）を個別にバリデートし、不正入力はすべて 400 で返す。
- テストを大幅拡充し、null/不正 JSON ボディ、各フィールドの境界値・型エラー・上限超過など計 20 近いケースをカバー。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージして問題ありません。バリデーションロジックは正確で、テストカバレッジも十分です。

すべての入力バリデーションが正しく実装されており、以前の指摘事項（JSON パース失敗時の 500 返却・depth/maxPerLevel の上限なし・空配列テストの not.toHaveBeenCalled 欠落）はすべて解消されています。デフォルト値の適用と型チェックの組み合わせも正確で、テストが境界値・型エラーを網羅的にカバーしています。

特になし。変更されたすべてのファイルは問題なく実装されています。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/search/drilldown/route.ts | リクエストボディの完全バリデーション実装。JSON パース失敗の 400 ハンドリング、null/非オブジェクトチェック、depth/maxPerLevel の境界整数チェック、enrich のブール型チェック、seedPapers の空・上限・各要素の title 検証を追加。以前の未解決問題はすべて対処済み。 |
| packages/web/src/app/api/search/drilldown/route.test.ts | テストケースを大幅拡充。null/不正 JSON/非オブジェクトボディ、depth・maxPerLevel・enrich の無効値、seedPapers の上限超過・title 検証をカバー。既存の空配列テストに not.toHaveBeenCalled アサーションも追加済み。 |
| packages/web/src/app/api/search/drilldown/route.types.ts | DrilldownBody インターフェースを route.ts から分離して専用ファイルへ移動。変更内容は最小限。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /api/search/drilldown] --> B[request.json]
    B -->|SyntaxError| C[400 Invalid JSON request body]
    B -->|OK| D{payload: 非null 非配列 オブジェクト?}
    D -->|No| E[400 Invalid request body]
    D -->|Yes| F{enrich が boolean?}
    F -->|No| G[400 enrich must be a boolean]
    F -->|Yes| H{depth が 1 から 5 の整数?}
    H -->|No| I[400 depth out of range]
    H -->|Yes| J{maxPerLevel が 1 から 100 の整数?}
    J -->|No| K[400 maxPerLevel out of range]
    J -->|Yes| L{seedPapers が非空配列?}
    L -->|No| M[400 seedPapers array is required]
    L -->|Yes| N{seedPapers が 100 件以下?}
    N -->|No| O[400 seedPapers over limit]
    N -->|Yes| P{全 seedPaper に非空 title?}
    P -->|No| Q[400 seedPapers must each include a title]
    P -->|Yes| R[drilldown 実行]
    R -->|OK| S[200 results]
    R -->|Error| T[500 Operation failed]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/web/src/app/api/search/drilldown/route.ts`, line 7-9 ([link](https://github.com/hiroki-org/paper-tools/blob/75c889363edf333e8cca1527462683fd590f2a35/packages/web/src/app/api/search/drilldown/route.ts#L7-L9)) 

   **null ボディで 500 が返る**

   `request.json()` がリテラル `null`（有効な JSON）を返した場合、`body` は実行時に `null` となり、直後の分割代入 `const { seedPapers, ... } = body` が `TypeError: Cannot destructure property 'seedPapers' of null` をスローします。これは `catch` ブロックに捕捉されて 500 レスポンスとなりますが、入力が不正なケースでは 400 を返すべきです。

2. `packages/web/src/app/api/search/drilldown/route.test.ts`, line 61-67 ([link](https://github.com/hiroki-org/paper-tools/blob/75c889363edf333e8cca1527462683fd590f2a35/packages/web/src/app/api/search/drilldown/route.test.ts#L61-L67)) 

   **空配列テストに `drilldown` 未呼び出しアサーションが欠けている**

   他の 400 系テスト（未指定・非配列・100件超）には `expect(drilldown).not.toHaveBeenCalled()` が含まれているのに、空配列の場合のテストにはありません。他のテストと一貫させるため追加を推奨します。

3. `packages/web/src/app/api/search/drilldown/route.ts`, line 48-51 ([link](https://github.com/hiroki-org/paper-tools/blob/7a4096def7c351299e1df318bcf457248e33f981/packages/web/src/app/api/search/drilldown/route.ts#L48-L51)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **不正/空の JSON ボディで 500 が返る**

   `request.json()` がスローするケース（空ボディ、不正 JSON など）は外側の `catch` に捕捉され、`status: 500` で返されます。`null` ボディ（有効な JSON `"null"`）は `!payload` チェックで 400 を返すようになりましたが、空ボディや `{invalid` のような不正 JSON を送ると引き続き 500 になります。クライアントエラーには 400 を返すべきです。`request.json()` の呼び出しを独立した `try/catch` で囲んで `SyntaxError` の場合は 400 を返すことで対処できます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web/src/app/api/search/drilldown/route.ts
   Line: 48-51

   Comment:
   **不正/空の JSON ボディで 500 が返る**

   `request.json()` がスローするケース（空ボディ、不正 JSON など）は外側の `catch` に捕捉され、`status: 500` で返されます。`null` ボディ（有効な JSON `"null"`）は `!payload` チェックで 400 を返すようになりましたが、空ボディや `{invalid` のような不正 JSON を送ると引き続き 500 になります。クライアントエラーには 400 を返すべきです。`request.json()` の呼び出しを独立した `try/catch` で囲んで `SyntaxError` の場合は 400 を返すことで対処できます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix: validate drilldown enrich flag"](https://github.com/hiroki-org/paper-tools/commit/5498cdbf3143aa5475b7db2b260c7909740fd261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32785535)</sub>

<!-- /greptile_comment -->