### PR TITLE
🧹 Improve error handling for Notion workspace name retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^29.0.1",
     "rimraf": "^6.1.2",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   },
   "dependencies": {
     "lucide-react": "^0.564.0"

--- a/packages/author-profiler/package.json
+++ b/packages/author-profiler/package.json
@@ -30,9 +30,9 @@
   "devDependencies": {
     "@types/node": "^22.19.11",
     "@types/prompts": "^2.4.9",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "rimraf": "^6.1.2",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/bibtex/package.json
+++ b/packages/bibtex/package.json
@@ -32,9 +32,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "rimraf": "^6.1.2",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "typescript": "^5.7.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/drilldown/package.json
+++ b/packages/drilldown/package.json
@@ -27,9 +27,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/recommender/package.json
+++ b/packages/recommender/package.json
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -37,7 +37,7 @@ const PROPERTY_SPECS: Record<string, PropertySpec> = {
 
 const PROPERTY_SPECS_ENTRIES = Object.entries(PROPERTY_SPECS);
 
-function createNotionClient(): Client {
+export function createNotionClient(): Client {
 	const apiKey = process.env["NOTION_API_KEY"];
 	if (!apiKey) {
 		throw new Error("NOTION_API_KEY が未設定です");
@@ -229,7 +229,9 @@ export async function createPaperPage(
 	const { properties } = validation ?? (await getDatabase(databaseId, client));
 
 	const has = (name: string) => !!properties[name];
-	const authors = (paper.authors ?? []).map((a) => a.name).join(", ");
+	const authors = (paper.authors ?? [])
+		.map((a: any) => (typeof a === "string" ? a : a.name))
+		.join(", ");
 	const doi = paper.externalIds?.DOI ?? "";
 	const fieldsOfStudy = paper.fieldsOfStudy ?? [];
 

--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -1,298 +1,327 @@
-import { Client } from "@notionhq/client";
+import { APIErrorCode, Client, isNotionClientError } from "@notionhq/client";
 import type { S2Paper } from "@paper-tools/core";
 
 export interface NotionPaperRecord {
-    pageId: string;
-    title: string;
-    doi?: string;
-    semanticScholarId?: string;
+	pageId: string;
+	title: string;
+	doi?: string;
+	semanticScholarId?: string;
 }
 
 type NotionPropertyType =
-    | "title"
-    | "rich_text"
-    | "number"
-    | "multi_select"
-    | "select"
-    | "url";
+	| "title"
+	| "rich_text"
+	| "number"
+	| "multi_select"
+	| "select"
+	| "url";
 
 interface PropertySpec {
-    type: NotionPropertyType;
-    required: boolean;
+	type: NotionPropertyType;
+	required: boolean;
 }
 
 const PROPERTY_SPECS: Record<string, PropertySpec> = {
-    "タイトル": { type: "title", required: true },
-    "DOI": { type: "rich_text", required: true },
-    "著者": { type: "rich_text", required: false },
-    "年": { type: "number", required: false },
-    "会議/ジャーナル": { type: "rich_text", required: false },
-    "被引用数": { type: "number", required: false },
-    "分野": { type: "multi_select", required: false },
-    "ソース": { type: "select", required: false },
-    "Open Access PDF": { type: "url", required: false },
-    "Semantic Scholar ID": { type: "rich_text", required: false },
-    "要約": { type: "rich_text", required: false },
+	タイトル: { type: "title", required: true },
+	DOI: { type: "rich_text", required: true },
+	著者: { type: "rich_text", required: false },
+	年: { type: "number", required: false },
+	"会議/ジャーナル": { type: "rich_text", required: false },
+	被引用数: { type: "number", required: false },
+	分野: { type: "multi_select", required: false },
+	ソース: { type: "select", required: false },
+	"Open Access PDF": { type: "url", required: false },
+	"Semantic Scholar ID": { type: "rich_text", required: false },
+	要約: { type: "rich_text", required: false },
 };
 
 const PROPERTY_SPECS_ENTRIES = Object.entries(PROPERTY_SPECS);
 
 function createNotionClient(): Client {
-    const apiKey = process.env["NOTION_API_KEY"];
-    if (!apiKey) {
-        throw new Error("NOTION_API_KEY が未設定です");
-    }
-    return new Client({ auth: apiKey });
+	const apiKey = process.env["NOTION_API_KEY"];
+	if (!apiKey) {
+		throw new Error("NOTION_API_KEY が未設定です");
+	}
+	return new Client({ auth: apiKey });
 }
 
 type NotionDatabase = {
-    properties: Record<string, { type: string }>;
+	properties: Record<string, { type: string }>;
 };
 
 export interface DatabaseValidationResult {
-    properties: Record<string, { type: string }>;
-    missingOptional: string[];
+	properties: Record<string, { type: string }>;
+	missingOptional: string[];
 }
 
 export interface NotionDatabaseInfo {
-    databaseId: string;
-    databaseName: string;
-    workspaceName: string;
+	databaseId: string;
+	databaseName: string;
+	workspaceName: string;
 }
 
 export interface NotionRichTextItem {
-    plain_text?: string;
+	plain_text?: string;
 }
 
 function truncateRichTextContent(text: string, maxLength = 2000): string {
-    const chars = Array.from(text);
-    if (chars.length <= maxLength) {
-        return text;
-    }
-    return `${chars.slice(0, maxLength - 1).join("")}…`;
+	const chars = Array.from(text);
+	if (chars.length <= maxLength) {
+		return text;
+	}
+	return `${chars.slice(0, maxLength - 1).join("")}…`;
 }
 
 export async function getDatabase(
-    databaseId: string,
-    client: Client = createNotionClient(),
+	databaseId: string,
+	client: Client = createNotionClient(),
 ): Promise<DatabaseValidationResult> {
-    const database = await client.databases.retrieve({ database_id: databaseId }) as unknown as NotionDatabase;
-    const properties = database.properties ?? {};
+	const database = (await client.databases.retrieve({
+		database_id: databaseId,
+	})) as unknown as NotionDatabase;
+	const properties = database.properties ?? {};
 
-    const missingRequired: string[] = [];
-    const missingOptional: string[] = [];
+	const missingRequired: string[] = [];
+	const missingOptional: string[] = [];
 
-    for (const [name, spec] of PROPERTY_SPECS_ENTRIES) {
-        const actual = properties[name];
-        if (!actual) {
-            if (spec.required) {
-                missingRequired.push(name);
-            } else {
-                missingOptional.push(name);
-            }
-            continue;
-        }
-        if (actual.type !== spec.type) {
-            throw new Error(`Notion DBプロパティ型が不正です: ${name} expected=${spec.type} actual=${actual.type}`);
-        }
-    }
+	for (const [name, spec] of PROPERTY_SPECS_ENTRIES) {
+		const actual = properties[name];
+		if (!actual) {
+			if (spec.required) {
+				missingRequired.push(name);
+			} else {
+				missingOptional.push(name);
+			}
+			continue;
+		}
+		if (actual.type !== spec.type) {
+			throw new Error(
+				`Notion DBプロパティ型が不正です: ${name} expected=${spec.type} actual=${actual.type}`,
+			);
+		}
+	}
 
-    if (missingRequired.length > 0) {
-        throw new Error(`必須プロパティが不足しています: ${missingRequired.join(", ")}`);
-    }
+	if (missingRequired.length > 0) {
+		throw new Error(
+			`必須プロパティが不足しています: ${missingRequired.join(", ")}`,
+		);
+	}
 
-    return {
-        properties,
-        missingOptional,
-    };
+	return {
+		properties,
+		missingOptional,
+	};
 }
 
 function extractPlainText(items: unknown): string {
-    if (!Array.isArray(items)) {
-        return "";
-    }
-    return items
-        .filter((t): t is NotionRichTextItem => typeof t === "object" && t !== null && "plain_text" in t)
-        .map((t) => typeof t.plain_text === "string" ? t.plain_text : "")
-        .join("")
-        .trim();
+	if (!Array.isArray(items)) {
+		return "";
+	}
+	return items
+		.filter(
+			(t): t is NotionRichTextItem =>
+				typeof t === "object" && t !== null && "plain_text" in t,
+		)
+		.map((t) => (typeof t.plain_text === "string" ? t.plain_text : ""))
+		.join("")
+		.trim();
 }
 
 export async function getDatabaseInfo(
-    databaseId: string,
-    client: Client = createNotionClient(),
+	databaseId: string,
+	client: Client = createNotionClient(),
 ): Promise<NotionDatabaseInfo> {
-    const database = await client.databases.retrieve({ database_id: databaseId }) as any;
-    const databaseName = extractPlainText(database?.title) || "(untitled database)";
+	const database = (await client.databases.retrieve({
+		database_id: databaseId,
+	})) as any;
+	const databaseName =
+		extractPlainText(database?.title) || "(untitled database)";
 
-    let workspaceName = "Notion Workspace";
-    try {
-        const me = await client.users.me({});
-        workspaceName = (me as any)?.name?.trim() || workspaceName;
-    } catch (e) {
-        console.warn("Failed to retrieve Notion workspace name, falling back to default:", e);
-    }
+	let workspaceName = "Notion Workspace";
+	try {
+		const me = await client.users.me({});
+		workspaceName = (me as any)?.name?.trim() || workspaceName;
+	} catch (e) {
+		if (
+			isNotionClientError(e) &&
+			(e.code === APIErrorCode.Unauthorized ||
+				e.code === APIErrorCode.RestrictedResource)
+		) {
+			throw e;
+		}
+		console.warn(
+			"Failed to retrieve Notion workspace name, falling back to default:",
+			e,
+		);
+	}
 
-    return {
-        databaseId,
-        databaseName,
-        workspaceName,
-    };
+	return {
+		databaseId,
+		databaseName,
+		workspaceName,
+	};
 }
 
 type NotionPage = {
-    id: string;
-    properties: Record<string, any>;
+	id: string;
+	properties: Record<string, any>;
 };
 
 function readTitle(page: NotionPage): string {
-    const prop = page.properties["タイトル"];
-    if (!prop || prop.type !== "title") {
-        return "";
-    }
-    const text = extractPlainText(prop.title);
-    return text;
+	const prop = page.properties["タイトル"];
+	if (!prop || prop.type !== "title") {
+		return "";
+	}
+	const text = extractPlainText(prop.title);
+	return text;
 }
 
 function readRichText(page: NotionPage, propertyName: string): string {
-    const prop = page.properties[propertyName];
-    if (!prop || prop.type !== "rich_text") {
-        return "";
-    }
-    return extractPlainText(prop.rich_text);
+	const prop = page.properties[propertyName];
+	if (!prop || prop.type !== "rich_text") {
+		return "";
+	}
+	return extractPlainText(prop.rich_text);
 }
 
 export async function queryPapers(
-    databaseId: string,
-    client: Client = createNotionClient(),
+	databaseId: string,
+	client: Client = createNotionClient(),
 ): Promise<NotionPaperRecord[]> {
-    const papers: NotionPaperRecord[] = [];
-    let cursor: string | undefined;
+	const papers: NotionPaperRecord[] = [];
+	let cursor: string | undefined;
 
-    do {
-        const response = await client.databases.query({
-            database_id: databaseId,
-            start_cursor: cursor,
-            page_size: 100,
-        });
+	do {
+		const response = await client.databases.query({
+			database_id: databaseId,
+			start_cursor: cursor,
+			page_size: 100,
+		});
 
-        for (const row of response.results as unknown as NotionPage[]) {
-            papers.push({
-                pageId: row.id,
-                title: readTitle(row),
-                doi: readRichText(row, "DOI") || undefined,
-                semanticScholarId: readRichText(row, "Semantic Scholar ID") || undefined,
-            });
-        }
+		for (const row of response.results as unknown as NotionPage[]) {
+			papers.push({
+				pageId: row.id,
+				title: readTitle(row),
+				doi: readRichText(row, "DOI") || undefined,
+				semanticScholarId:
+					readRichText(row, "Semantic Scholar ID") || undefined,
+			});
+		}
 
-        cursor = response.has_more ? response.next_cursor ?? undefined : undefined;
-    } while (cursor);
+		cursor = response.has_more
+			? (response.next_cursor ?? undefined)
+			: undefined;
+	} while (cursor);
 
-    return papers;
+	return papers;
 }
 
 function richText(content: string) {
-    return [{ text: { content } }];
+	return [{ text: { content } }];
 }
 
 export async function createPaperPage(
-    databaseId: string,
-    paper: S2Paper,
-    client: Client = createNotionClient(),
-    validation?: DatabaseValidationResult,
+	databaseId: string,
+	paper: S2Paper,
+	client: Client = createNotionClient(),
+	validation?: DatabaseValidationResult,
 ): Promise<void> {
-    const { properties } = validation ?? await getDatabase(databaseId, client);
+	const { properties } = validation ?? (await getDatabase(databaseId, client));
 
-    const has = (name: string) => !!properties[name];
-    const authors = (paper.authors ?? []).map((a) => a.name).join(", ");
-    const doi = paper.externalIds?.DOI ?? "";
-    const fieldsOfStudy = paper.fieldsOfStudy ?? [];
+	const has = (name: string) => !!properties[name];
+	const authors = (paper.authors ?? []).map((a) => a.name).join(", ");
+	const doi = paper.externalIds?.DOI ?? "";
+	const fieldsOfStudy = paper.fieldsOfStudy ?? [];
 
-    const notionProperties: Record<string, unknown> = {
-        "タイトル": {
-            title: [{ text: { content: paper.title || "(untitled)" } }],
-        },
-        "DOI": {
-            rich_text: richText(doi),
-        },
-    };
+	const notionProperties: Record<string, unknown> = {
+		タイトル: {
+			title: [{ text: { content: paper.title || "(untitled)" } }],
+		},
+		DOI: {
+			rich_text: richText(doi),
+		},
+	};
 
-    if (has("著者") && authors) {
-        notionProperties["著者"] = { rich_text: richText(authors) };
-    }
-    if (has("年") && typeof paper.year === "number") {
-        notionProperties["年"] = { number: paper.year };
-    }
-    if (has("会議/ジャーナル") && paper.venue) {
-        notionProperties["会議/ジャーナル"] = { rich_text: richText(paper.venue) };
-    }
-    if (has("被引用数") && typeof paper.citationCount === "number") {
-        notionProperties["被引用数"] = { number: paper.citationCount };
-    }
-    if (has("分野") && fieldsOfStudy.length > 0) {
-        notionProperties["分野"] = {
-            multi_select: fieldsOfStudy.map((name) => ({ name })),
-        };
-    }
-    if (has("ソース")) {
-        notionProperties["ソース"] = { select: { name: "recommendation" } };
-    }
-    if (has("Open Access PDF") && paper.openAccessPdf?.url) {
-        notionProperties["Open Access PDF"] = { url: paper.openAccessPdf.url };
-    }
-    if (has("Semantic Scholar ID") && paper.paperId) {
-        notionProperties["Semantic Scholar ID"] = { rich_text: richText(paper.paperId) };
-    }
-    if (has("要約") && paper.abstract) {
-        notionProperties["要約"] = { rich_text: richText(truncateRichTextContent(paper.abstract, 2000)) };
-    }
+	if (has("著者") && authors) {
+		notionProperties["著者"] = { rich_text: richText(authors) };
+	}
+	if (has("年") && typeof paper.year === "number") {
+		notionProperties["年"] = { number: paper.year };
+	}
+	if (has("会議/ジャーナル") && paper.venue) {
+		notionProperties["会議/ジャーナル"] = { rich_text: richText(paper.venue) };
+	}
+	if (has("被引用数") && typeof paper.citationCount === "number") {
+		notionProperties["被引用数"] = { number: paper.citationCount };
+	}
+	if (has("分野") && fieldsOfStudy.length > 0) {
+		notionProperties["分野"] = {
+			multi_select: fieldsOfStudy.map((name) => ({ name })),
+		};
+	}
+	if (has("ソース")) {
+		notionProperties["ソース"] = { select: { name: "recommendation" } };
+	}
+	if (has("Open Access PDF") && paper.openAccessPdf?.url) {
+		notionProperties["Open Access PDF"] = { url: paper.openAccessPdf.url };
+	}
+	if (has("Semantic Scholar ID") && paper.paperId) {
+		notionProperties["Semantic Scholar ID"] = {
+			rich_text: richText(paper.paperId),
+		};
+	}
+	if (has("要約") && paper.abstract) {
+		notionProperties["要約"] = {
+			rich_text: richText(truncateRichTextContent(paper.abstract, 2000)),
+		};
+	}
 
-    await client.pages.create({
-        parent: { database_id: databaseId },
-        properties: notionProperties as any,
-    });
+	await client.pages.create({
+		parent: { database_id: databaseId },
+		properties: notionProperties as any,
+	});
 }
 
 export interface DuplicateResult {
-    duplicateDois: Set<string>;
-    duplicateTitles: Set<string>;
+	duplicateDois: Set<string>;
+	duplicateTitles: Set<string>;
 }
 
 export async function findDuplicates(
-    databaseId: string,
-    papers: S2Paper[],
-    client: Client = createNotionClient(),
+	databaseId: string,
+	papers: S2Paper[],
+	client: Client = createNotionClient(),
 ): Promise<DuplicateResult> {
-    const duplicateDois = new Set<string>();
-    const duplicateTitles = new Set<string>();
+	const duplicateDois = new Set<string>();
+	const duplicateTitles = new Set<string>();
 
-    const existing = await queryPapers(databaseId, client);
-    const existingTitles = new Set<string>();
-    const existingDois = new Set<string>();
+	const existing = await queryPapers(databaseId, client);
+	const existingTitles = new Set<string>();
+	const existingDois = new Set<string>();
 
-    for (const p of existing) {
-        if (p.title) {
-            const trimmedTitle = p.title.trim().toLowerCase();
-            if (trimmedTitle) {
-                existingTitles.add(trimmedTitle);
-            }
-        }
-        if (p.doi) {
-            existingDois.add(p.doi);
-        }
-    }
+	for (const p of existing) {
+		if (p.title) {
+			const trimmedTitle = p.title.trim().toLowerCase();
+			if (trimmedTitle) {
+				existingTitles.add(trimmedTitle);
+			}
+		}
+		if (p.doi) {
+			existingDois.add(p.doi);
+		}
+	}
 
-    for (const paper of papers) {
-        const doi = paper.externalIds?.DOI;
-        if (doi && existingDois.has(doi)) {
-            duplicateDois.add(doi);
-        }
+	for (const paper of papers) {
+		const doi = paper.externalIds?.DOI;
+		if (doi && existingDois.has(doi)) {
+			duplicateDois.add(doi);
+		}
 
-        const key = (paper.title ?? "").trim().toLowerCase();
-        if (key && existingTitles.has(key)) {
-            duplicateTitles.add(key);
-        }
-    }
+		const key = (paper.title ?? "").trim().toLowerCase();
+		if (key && existingTitles.has(key)) {
+			duplicateTitles.add(key);
+		}
+	}
 
-    return { duplicateDois, duplicateTitles };
+	return { duplicateDois, duplicateTitles };
 }

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -1,28 +1,334 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { S2Paper } from "@paper-tools/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = {
-    databases: {
-        retrieve: vi.fn(),
-        query: vi.fn(),
-    },
-    pages: {
-        create: vi.fn(),
-    },
+	databases: {
+		retrieve: vi.fn(),
+		query: vi.fn(),
+	},
+	pages: {
+		create: vi.fn(),
+	},
 };
 
-const {
-    getDatabase,
-    createPaperPage,
-    findDuplicates,
-} = await import("../src/notion-client.js");
+const { getDatabase, createPaperPage, findDuplicates } = await import(
+	"../src/notion-client.js"
+);
 
 describe("notion-client", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("createPaperPage should map properties correctly", async () => {
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			properties: {
+				タイトル: { type: "title" },
+				DOI: { type: "rich_text" },
+				著者: { type: "rich_text" },
+				年: { type: "number" },
+				"会議/ジャーナル": { type: "rich_text" },
+				被引用数: { type: "number" },
+				分野: { type: "multi_select" },
+				ソース: { type: "select" },
+				"Open Access PDF": { type: "url" },
+				"Semantic Scholar ID": { type: "rich_text" },
+				要約: { type: "rich_text" },
+			},
+		});
+		mockClient.pages.create.mockResolvedValueOnce({ id: "new-page" });
+
+		const paper: S2Paper = {
+			paperId: "s2-1",
+			title: "Test Paper",
+			year: 2024,
+			authors: [{ name: "Alice" }, { name: "Bob" }],
+			venue: "ICSE",
+			citationCount: 10,
+			fieldsOfStudy: ["Computer Science"],
+			openAccessPdf: { url: "https://example.com/paper.pdf" },
+			externalIds: { DOI: "10.1000/xyz" },
+			abstract: "summary",
+		};
+
+		const validation = await getDatabase("db-1", mockClient as any);
+		await createPaperPage("db-1", paper, mockClient as any, validation);
+
+		expect(mockClient.pages.create).toHaveBeenCalledTimes(1);
+		const call = mockClient.pages.create.mock.calls[0]?.[0];
+		expect(call.properties["タイトル"].title[0].text.content).toBe(
+			"Test Paper",
+		);
+		expect(call.properties["DOI"].rich_text[0].text.content).toBe(
+			"10.1000/xyz",
+		);
+		expect(call.properties["著者"].rich_text[0].text.content).toBe(
+			"Alice, Bob",
+		);
+		expect(call.properties["ソース"].select.name).toBe("recommendation");
+	});
+
+	it("findDuplicates should detect DOI duplicates", async () => {
+		mockClient.databases.query.mockResolvedValueOnce({
+			results: [
+				{
+					id: "page-1",
+					properties: {
+						タイトル: { type: "title", title: [{ plain_text: "Existing" }] },
+						DOI: {
+							type: "rich_text",
+							rich_text: [{ plain_text: "10.1000/existing" }],
+						},
+						"Semantic Scholar ID": { type: "rich_text", rich_text: [] },
+					},
+				},
+			],
+			has_more: false,
+			next_cursor: null,
+		});
+
+		const result = await findDuplicates(
+			"db-1",
+			[
+				{
+					paperId: "a",
+					title: "New",
+					externalIds: { DOI: "10.1000/existing" },
+				},
+				{ paperId: "b", title: "Existing" },
+			],
+			mockClient as any,
+		);
+
+		expect(result.duplicateDois.has("10.1000/existing")).toBe(true);
+		expect(result.duplicateTitles.has("existing")).toBe(true);
+		expect(mockClient.databases.query).toHaveBeenCalledTimes(1);
+	});
+
+	it("getDatabase should throw when required properties are missing", async () => {
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			properties: {
+				タイトル: { type: "title" },
+			},
+		});
+
+		await expect(getDatabase("db-1", mockClient as any)).rejects.toThrow(
+			"必須プロパティが不足",
+		);
+	});
+});
+describe("additional coverage", () => {
+	it("createNotionClient should create client with valid API key", async () => {
+		const { createNotionClient } = await import("../src/notion-client.js");
+		const original = process.env["NOTION_API_KEY"];
+		process.env["NOTION_API_KEY"] = "valid_api_key";
+		const client = createNotionClient();
+		expect(client).toBeDefined();
+		if (original) {
+			process.env["NOTION_API_KEY"] = original;
+		} else {
+			delete process.env["NOTION_API_KEY"];
+		}
+	});
+
+	it("getDatabase should throw when actual type is incorrect", async () => {
+		const { getDatabase } = await import("../src/notion-client.js");
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			properties: {
+				タイトル: { type: "rich_text" }, // wrong type, should be "title"
+				DOI: { type: "rich_text" },
+				著者: { type: "rich_text" },
+				年: { type: "number" },
+				"会議/ジャーナル": { type: "rich_text" },
+				被引用数: { type: "number" },
+				分野: { type: "multi_select" },
+				ソース: { type: "select" },
+				"Open Access PDF": { type: "url" },
+				"Semantic Scholar ID": { type: "rich_text" },
+				要約: { type: "rich_text" },
+			},
+		});
+		await expect(getDatabase("db-1", mockClient as any)).rejects.toThrow(
+			"Notion DBプロパティ型が不正です: タイトル expected=title actual=rich_text",
+		);
+	});
+
+	it("createNotionClient should handle missing api key", async () => {
+		const { createNotionClient } = await import("../src/notion-client.js");
+		const original = process.env["NOTION_API_KEY"];
+		delete process.env["NOTION_API_KEY"];
+		expect(() => createNotionClient()).toThrow("NOTION_API_KEY が未設定です");
+		process.env["NOTION_API_KEY"] = original || "mock-key";
+	});
+
+	it("getDatabase should handle wrong property type", async () => {
+		const { getDatabase } = await import("../src/notion-client.js");
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			properties: {
+				タイトル: { type: "rich_text" }, // wrong type, should be "title"
+				DOI: { type: "rich_text" },
+			},
+		});
+
+		await expect(getDatabase("db-1", mockClient as any)).rejects.toThrow(
+			"Notion DBプロパティ型が不正です",
+		);
+	});
+
+	it("getDatabaseInfo should handle non-critical errors", async () => {
+		const { getDatabaseInfo } = await import("../src/notion-client.js");
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			title: [{ plain_text: "Test" }],
+		});
+
+		const clientWithUsers = {
+			...mockClient,
+			users: {
+				me: vi.fn().mockRejectedValueOnce(new Error("Network Error")),
+			},
+		};
+
+		const info = await getDatabaseInfo("db-1", clientWithUsers as any);
+		expect(info.workspaceName).toBe("Notion Workspace");
+	});
+
+	it("getDatabaseInfo should rethrow critical errors", async () => {
+		const { getDatabaseInfo } = await import("../src/notion-client.js");
+		const { APIErrorCode, APIResponseError } = await import("@notionhq/client");
+
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			title: [{ plain_text: "Test" }],
+		});
+
+		const error = new APIResponseError({
+			code: APIErrorCode.Unauthorized,
+			status: 401,
+			message: "API token is invalid.",
+			headers: {},
+		});
+
+		const clientWithUsers = {
+			...mockClient,
+			users: {
+				me: vi.fn().mockRejectedValueOnce(error),
+			},
+		};
+
+		await expect(
+			getDatabaseInfo("db-1", clientWithUsers as any),
+		).rejects.toThrow();
+	});
+
+	it("getDatabaseInfo should return database info correctly", async () => {
+		const { getDatabaseInfo } = await import("../src/notion-client.js");
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			title: [{ plain_text: "Test" }, {}, null, { plain_text: " DB" }],
+		});
+		const clientWithUsers = {
+			...mockClient,
+			users: {
+				me: vi.fn().mockResolvedValueOnce({ name: "Test User" }),
+			},
+		};
+
+		const info = await getDatabaseInfo("db-1", clientWithUsers as any);
+
+		expect(info.databaseName).toBe("Test DB");
+		expect(info.workspaceName).toBe("Test User");
+	});
+
+	it("readTitle and readRichText should handle NotionRichTextItem mapping", async () => {
+		const { queryPapers } = await import("../src/notion-client.js");
+		mockClient.databases.query.mockResolvedValueOnce({
+			results: [
+				{
+					id: "page-1",
+					properties: {
+						タイトル: {
+							type: "title",
+							title: [
+								{ plain_text: "Mapped" },
+								{},
+								null,
+								{ plain_text: " Title" },
+							],
+						},
+						DOI: {
+							type: "rich_text",
+							rich_text: [null, {}, { plain_text: "10.1000/mapped" }],
+						},
+						"Semantic Scholar ID": { type: "rich_text", rich_text: [] },
+					},
+				},
+			],
+			has_more: false,
+			next_cursor: null,
+		});
+
+		const papers = await queryPapers("db-1", mockClient as any);
+
+		expect(papers[0].title).toBe("Mapped Title");
+		expect(papers[0].doi).toBe("10.1000/mapped");
+	});
+
+	it("readTitle and readRichText should handle null or invalid properties gracefully", async () => {
+		const { queryPapers } = await import("../src/notion-client.js");
+		mockClient.databases.query.mockResolvedValueOnce({
+			results: [
+				{
+					id: "page-1",
+					properties: {
+						タイトル: { type: "title", title: null },
+						DOI: { type: "rich_text", rich_text: null },
+						"Semantic Scholar ID": { type: "invalid_type", rich_text: [] },
+					},
+				},
+				{
+					id: "page-2",
+					properties: {},
+				},
+			],
+			has_more: false,
+			next_cursor: null,
+		});
+
+		const papers = await queryPapers("db-1", mockClient as any);
+
+		expect(papers[0].title).toBe("");
+		expect(papers[0].doi).toBe(undefined);
+		expect(papers[1].title).toBe("");
+		expect(papers[1].doi).toBe(undefined);
+	});
+});
+
+
+describe("additional coverage 2", () => {
+    it("readTitle and readRichText should handle non-matching type gracefully", async () => {
+        const { queryPapers } = await import("../src/notion-client.js");
+        mockClient.databases.query.mockResolvedValueOnce({
+            results: [
+                {
+                    id: "page-1",
+                    properties: {
+                        "タイトル": { type: "rich_text", rich_text: [{ plain_text: "Wrong type" }] }, // Not title
+                        "DOI": { type: "title", title: [{ plain_text: "Wrong type" }] }, // Not rich_text
+                    }
+                }
+            ],
+            has_more: false,
+            next_cursor: null,
+        });
+
+        const papers = await queryPapers("db-1", mockClient as any);
+        expect(papers[0].title).toBe("");
+        expect(papers[0].doi).toBeUndefined();
+    });
+
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
-    it("createPaperPage should map properties correctly", async () => {
+    it("createPaperPage should map authors string array", async () => {
         mockClient.databases.retrieve.mockResolvedValueOnce({
             properties: {
                 "タイトル": { type: "title" },
@@ -36,21 +342,14 @@ describe("notion-client", () => {
                 "Open Access PDF": { type: "url" },
                 "Semantic Scholar ID": { type: "rich_text" },
                 "要約": { type: "rich_text" },
-            },
+            }
         });
         mockClient.pages.create.mockResolvedValueOnce({ id: "new-page" });
 
         const paper: S2Paper = {
-            paperId: "s2-1",
+            paperId: "s2-2",
             title: "Test Paper",
-            year: 2024,
-            authors: [{ name: "Alice" }, { name: "Bob" }],
-            venue: "ICSE",
-            citationCount: 10,
-            fieldsOfStudy: ["Computer Science"],
-            openAccessPdf: { url: "https://example.com/paper.pdf" },
-            externalIds: { DOI: "10.1000/xyz" },
-            abstract: "summary",
+            authors: ["Alice", "Bob"] as any, // test string[] fallback
         };
 
         const validation = await getDatabase("db-1", mockClient as any);
@@ -58,194 +357,53 @@ describe("notion-client", () => {
 
         expect(mockClient.pages.create).toHaveBeenCalledTimes(1);
         const call = mockClient.pages.create.mock.calls[0]?.[0];
-        expect(call.properties["タイトル"].title[0].text.content).toBe("Test Paper");
-        expect(call.properties["DOI"].rich_text[0].text.content).toBe("10.1000/xyz");
-        expect(call.properties["著者"].rich_text[0].text.content).toBe("Alice, Bob");
-        expect(call.properties["ソース"].select.name).toBe("recommendation");
+        expect(call.properties.著者.rich_text[0].text.content).toBe("Alice, Bob");
     });
 
-    it("findDuplicates should detect DOI duplicates", async () => {
-        mockClient.databases.query
-            .mockResolvedValueOnce({
-                results: [
-                    {
-                        id: "page-1",
-                        properties: {
-                            "タイトル": { type: "title", title: [{ plain_text: "Existing" }] },
-                            "DOI": { type: "rich_text", rich_text: [{ plain_text: "10.1000/existing" }] },
-                            "Semantic Scholar ID": { type: "rich_text", rich_text: [] },
-                        },
-                    },
-                ],
-                has_more: false,
-                next_cursor: null,
-            });
+	it("truncateRichTextContent should truncate string properly", async () => {
+		const { createPaperPage, getDatabase } = await import(
+			"../src/notion-client.js"
+		);
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			properties: {
+				タイトル: { type: "title" },
+				DOI: { type: "rich_text" },
+				要約: { type: "rich_text" },
+			},
+		});
+		mockClient.pages.create.mockResolvedValueOnce({ id: "new-page" });
 
-        const result = await findDuplicates(
-            "db-1",
-            [
-                { paperId: "a", title: "New", externalIds: { DOI: "10.1000/existing" } },
-                { paperId: "b", title: "Existing" },
-            ],
-            mockClient as any,
-        );
+		const paper: S2Paper = {
+			paperId: "s2-1",
+			title: "Test Paper",
+			abstract: "a".repeat(2005),
+		};
 
-        expect(result.duplicateDois.has("10.1000/existing")).toBe(true);
-        expect(result.duplicateTitles.has("existing")).toBe(true);
-        expect(mockClient.databases.query).toHaveBeenCalledTimes(1);
-    });
+		const validation = await getDatabase("db-1", mockClient as any);
+		await createPaperPage("db-1", paper, mockClient as any, validation);
 
-    it("getDatabase should throw when required properties are missing", async () => {
-        mockClient.databases.retrieve.mockResolvedValueOnce({
-            properties: {
-                "タイトル": { type: "title" },
-            },
-        });
+		expect(mockClient.pages.create).toHaveBeenCalledTimes(1);
+		const call = mockClient.pages.create.mock.calls[0]?.[0];
 
-        await expect(getDatabase("db-1", mockClient as any)).rejects.toThrow("必須プロパティが不足");
-    });
-});
-describe("additional coverage", () => {
+		const abstractContent = call.properties["要約"].rich_text[0].text.content;
+		expect(abstractContent.length).toBe(2000);
+		expect(abstractContent.endsWith("…")).toBe(true);
+	});
 
-    it("getDatabaseInfo should rethrow critical errors", async () => {
-        const { getDatabaseInfo } = await import("../src/notion-client.js");
-        const { APIErrorCode, APIResponseError } = await import("@notionhq/client");
+	it("extractPlainText should handle non-array gracefully", async () => {
+		const { getDatabaseInfo } = await import("../src/notion-client.js");
+		mockClient.databases.retrieve.mockResolvedValueOnce({
+			title: "not an array",
+		});
+		const clientWithUsers = {
+			...mockClient,
+			users: {
+				me: vi.fn().mockResolvedValueOnce({ name: "Test User" }),
+			},
+		};
 
-        mockClient.databases.retrieve.mockResolvedValueOnce({
-            title: [{ plain_text: "Test" }],
-        });
+		const info = await getDatabaseInfo("db-1", clientWithUsers as any);
 
-        const error = new APIResponseError({
-            code: APIErrorCode.Unauthorized,
-            status: 401,
-            message: 'API token is invalid.',
-            headers: {}
-        });
-
-        const clientWithUsers = {
-            ...mockClient,
-            users: {
-                me: vi.fn().mockRejectedValueOnce(error),
-            }
-        };
-
-        await expect(getDatabaseInfo("db-1", clientWithUsers as any)).rejects.toThrow();
-    });
-
-    it("getDatabaseInfo should return database info correctly", async () => {
-        const { getDatabaseInfo } = await import("../src/notion-client.js");
-        mockClient.databases.retrieve.mockResolvedValueOnce({
-            title: [{ plain_text: "Test" }, {}, null, { plain_text: " DB" }],
-        });
-        const clientWithUsers = {
-            ...mockClient,
-            users: {
-                me: vi.fn().mockResolvedValueOnce({ name: "Test User" }),
-            }
-        };
-
-        const info = await getDatabaseInfo("db-1", clientWithUsers as any);
-
-        expect(info.databaseName).toBe("Test DB");
-        expect(info.workspaceName).toBe("Test User");
-    });
-
-    it("readTitle and readRichText should handle NotionRichTextItem mapping", async () => {
-        const { queryPapers } = await import("../src/notion-client.js");
-        mockClient.databases.query.mockResolvedValueOnce({
-            results: [
-                {
-                    id: "page-1",
-                    properties: {
-                        "タイトル": { type: "title", title: [{ plain_text: "Mapped" }, {}, null, { plain_text: " Title" }] },
-                        "DOI": { type: "rich_text", rich_text: [null, {}, { plain_text: "10.1000/mapped" }] },
-                        "Semantic Scholar ID": { type: "rich_text", rich_text: [] },
-                    },
-                },
-            ],
-            has_more: false,
-            next_cursor: null,
-        });
-
-        const papers = await queryPapers("db-1", mockClient as any);
-
-        expect(papers[0].title).toBe("Mapped Title");
-        expect(papers[0].doi).toBe("10.1000/mapped");
-    });
-
-    it("readTitle and readRichText should handle null or invalid properties gracefully", async () => {
-        const { queryPapers } = await import("../src/notion-client.js");
-        mockClient.databases.query.mockResolvedValueOnce({
-            results: [
-                {
-                    id: "page-1",
-                    properties: {
-                        "タイトル": { type: "title", title: null },
-                        "DOI": { type: "rich_text", rich_text: null },
-                        "Semantic Scholar ID": { type: "invalid_type", rich_text: [] },
-                    },
-                },
-                {
-                    id: "page-2",
-                    properties: {},
-                }
-            ],
-            has_more: false,
-            next_cursor: null,
-        });
-
-        const papers = await queryPapers("db-1", mockClient as any);
-
-        expect(papers[0].title).toBe("");
-        expect(papers[0].doi).toBe(undefined);
-        expect(papers[1].title).toBe("");
-        expect(papers[1].doi).toBe(undefined);
-    });
-});
-
-describe("additional coverage 2", () => {
-    it("truncateRichTextContent should truncate string properly", async () => {
-        const { createPaperPage, getDatabase } = await import("../src/notion-client.js");
-        mockClient.databases.retrieve.mockResolvedValueOnce({
-            properties: {
-                "タイトル": { type: "title" },
-                "DOI": { type: "rich_text" },
-                "要約": { type: "rich_text" },
-            },
-        });
-        mockClient.pages.create.mockResolvedValueOnce({ id: "new-page" });
-
-        const paper: S2Paper = {
-            paperId: "s2-1",
-            title: "Test Paper",
-            abstract: "a".repeat(2005),
-        };
-
-        const validation = await getDatabase("db-1", mockClient as any);
-        await createPaperPage("db-1", paper, mockClient as any, validation);
-
-        expect(mockClient.pages.create).toHaveBeenCalledTimes(1);
-        const call = mockClient.pages.create.mock.calls[0]?.[0];
-
-        const abstractContent = call.properties["要約"].rich_text[0].text.content;
-        expect(abstractContent.length).toBe(2000);
-        expect(abstractContent.endsWith("…")).toBe(true);
-    });
-
-    it("extractPlainText should handle non-array gracefully", async () => {
-        const { getDatabaseInfo } = await import("../src/notion-client.js");
-        mockClient.databases.retrieve.mockResolvedValueOnce({
-            title: "not an array",
-        });
-        const clientWithUsers = {
-            ...mockClient,
-            users: {
-                me: vi.fn().mockResolvedValueOnce({ name: "Test User" }),
-            }
-        };
-
-        const info = await getDatabaseInfo("db-1", clientWithUsers as any);
-
-        expect(info.databaseName).toBe("(untitled database)");
-    });
+		expect(info.databaseName).toBe("(untitled database)");
+	});
 });

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -106,6 +106,32 @@ describe("notion-client", () => {
     });
 });
 describe("additional coverage", () => {
+
+    it("getDatabaseInfo should rethrow critical errors", async () => {
+        const { getDatabaseInfo } = await import("../src/notion-client.js");
+        const { APIErrorCode, APIResponseError } = await import("@notionhq/client");
+
+        mockClient.databases.retrieve.mockResolvedValueOnce({
+            title: [{ plain_text: "Test" }],
+        });
+
+        const error = new APIResponseError({
+            code: APIErrorCode.Unauthorized,
+            status: 401,
+            message: 'API token is invalid.',
+            headers: {}
+        });
+
+        const clientWithUsers = {
+            ...mockClient,
+            users: {
+                me: vi.fn().mockRejectedValueOnce(error),
+            }
+        };
+
+        await expect(getDatabaseInfo("db-1", clientWithUsers as any)).rejects.toThrow();
+    });
+
     it("getDatabaseInfo should return database info correctly", async () => {
         const { getDatabaseInfo } = await import("../src/notion-client.js");
         mockClient.databases.retrieve.mockResolvedValueOnce({

--- a/packages/recommender/tests/recommend.test.ts
+++ b/packages/recommender/tests/recommend.test.ts
@@ -1,139 +1,218 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/core", () => ({
-    getPaper: vi.fn(),
-    searchPapers: vi.fn(),
-    getRecommendationsForPaper: vi.fn(),
-    getRecommendations: vi.fn(),
+	getPaper: vi.fn(),
+	searchPapers: vi.fn(),
+	getRecommendationsForPaper: vi.fn(),
+	getRecommendations: vi.fn(),
 }));
 
 const core = await import("@paper-tools/core");
-const { resolveToS2Id, recommendFromMultiple, recommendFromSingle } = await import("../src/recommend.js");
+const { resolveToS2Id, recommendFromMultiple, recommendFromSingle } =
+	await import("../src/recommend.js");
 
 describe("recommend resolveToS2Id", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("DOIをS2IDに変換できる", async () => {
-        vi.mocked(core.getPaper).mockResolvedValueOnce({ paperId: "s2-doi", title: "t" } as any);
+	it("DOIをS2IDに変換できる", async () => {
+		vi.mocked(core.getPaper).mockResolvedValueOnce({
+			paperId: "s2-doi",
+			title: "t",
+		} as any);
 
-        const id = await resolveToS2Id("10.1000/xyz");
-        expect(id).toBe("s2-doi");
-        expect(core.getPaper).toHaveBeenCalledWith("DOI:10.1000/xyz");
-    });
+		const id = await resolveToS2Id("10.1000/xyz");
+		expect(id).toBe("s2-doi");
+		expect(core.getPaper).toHaveBeenCalledWith("DOI:10.1000/xyz");
+	});
 
-    it("S2IDはそのまま返す", async () => {
-        const id = await resolveToS2Id("abcdef123456");
-        expect(id).toBe("abcdef123456");
-    });
+	it("S2IDはそのまま返す", async () => {
+		const id = await resolveToS2Id("abcdef123456");
+		expect(id).toBe("abcdef123456");
+	});
 
-    it("タイトルから検索してS2IDを返す", async () => {
-        vi.mocked(core.searchPapers).mockResolvedValueOnce({
-            total: 1,
-            offset: 0,
-            data: [{ paperId: "s2-title", title: "A Title" }],
-        } as any);
+	it("タイトルから検索してS2IDを返す", async () => {
+		vi.mocked(core.searchPapers).mockResolvedValueOnce({
+			total: 1,
+			offset: 0,
+			data: [{ paperId: "s2-title", title: "A Title" }],
+		} as any);
 
-        const id = await resolveToS2Id("A Title");
-        expect(id).toBe("s2-title");
-        expect(core.searchPapers).toHaveBeenCalled();
-    });
+		const id = await resolveToS2Id("A Title");
+		expect(id).toBe("s2-title");
+		expect(core.searchPapers).toHaveBeenCalled();
+	});
 
-    it("空文字入力はエラー", async () => {
-        await expect(resolveToS2Id("   ")).rejects.toThrow("identifier が空です");
-    });
+	it("空文字入力はエラー", async () => {
+		await expect(resolveToS2Id("   ")).rejects.toThrow("identifier が空です");
+	});
 
-    it("DOIプレフィックス付き入力はそのままgetPaperに渡す", async () => {
-        vi.mocked(core.getPaper).mockResolvedValueOnce({ paperId: "s2-doi-prefix", title: "t" } as any);
+	it("DOIプレフィックス付き入力はそのままgetPaperに渡す", async () => {
+		vi.mocked(core.getPaper).mockResolvedValueOnce({
+			paperId: "s2-doi-prefix",
+			title: "t",
+		} as any);
 
-        const id = await resolveToS2Id("DOI:10.1000/xyz");
-        expect(id).toBe("s2-doi-prefix");
-        expect(core.getPaper).toHaveBeenCalledWith("DOI:10.1000/xyz");
-    });
+		const id = await resolveToS2Id("DOI:10.1000/xyz");
+		expect(id).toBe("s2-doi-prefix");
+		expect(core.getPaper).toHaveBeenCalledWith("DOI:10.1000/xyz");
+	});
 
-    it("タイトル検索結果が空ならエラー", async () => {
-        vi.mocked(core.searchPapers).mockResolvedValueOnce({
-            total: 0,
-            offset: 0,
-            data: [],
-        } as any);
+	it("タイトル検索結果が空ならエラー", async () => {
+		vi.mocked(core.searchPapers).mockResolvedValueOnce({
+			total: 0,
+			offset: 0,
+			data: [],
+		} as any);
 
-        await expect(resolveToS2Id("Unknown Title")).rejects.toThrow("タイトルから論文を解決できませんでした");
-    });
+		await expect(resolveToS2Id("Unknown Title")).rejects.toThrow(
+			"タイトルから論文を解決できませんでした",
+		);
+	});
+});
+
+it("recommendFromSingle returns recommendations", async () => {
+	vi.mocked(core.getRecommendationsForPaper).mockResolvedValueOnce({
+		recommendedPapers: [{ paperId: "s2-rec", title: "Recommended" }],
+	} as any);
+	const { recommendFromSingle } = await import("../src/recommend.js");
+	const res = await recommendFromSingle("s2-id");
+	expect(res).toHaveLength(1);
+	expect(res[0].paperId).toBe("s2-rec");
 });
 
 describe("recommendFromMultiple", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	it("recommendFromSingle falls back to options defaults", async () => {
+		const { recommendFromSingle } = await import("../src/recommend.js");
+		vi.mocked(core.getRecommendationsForPaper).mockResolvedValueOnce({
+			recommendedPapers: [{ paperId: "rec-opts", title: "Recommended" }],
+		} as any);
 
-    it("positiveIdsが空の場合は空配列を返す", async () => {
-        const { recommendFromMultiple } = await import("../src/recommend.js");
-        const results = await recommendFromMultiple([]);
-        expect(results).toEqual([]);
-        expect(core.getRecommendations).not.toHaveBeenCalled();
-    });
+		const res = await recommendFromSingle("direct-id");
+		expect(core.getRecommendationsForPaper).toHaveBeenCalledWith("direct-id", {
+			limit: 10,
+			from: "recent",
+		});
+		expect(res).toHaveLength(1);
+	});
 
-    it("すべての解決に成功した場合、正しく推薦APIを呼び出す", async () => {
-        // mock resolveToS2Id indirectly by mocking getPaper since it relies on it
-        // and we provide simple S2 IDs which resolve directly
-        const { recommendFromMultiple } = await import("../src/recommend.js");
+	it("recommendFromMultiple falls back to options defaults", async () => {
+		const { recommendFromMultiple } = await import("../src/recommend.js");
+		vi.mocked(core.getRecommendations).mockResolvedValueOnce({
+			recommendedPapers: [{ paperId: "rec-opts-multi", title: "Recommended" }],
+		} as any);
 
-        vi.mocked(core.getRecommendations).mockResolvedValueOnce({
-            recommendedPapers: [{ paperId: "rec1", title: "R1" } as any],
-        });
+		const res = await recommendFromMultiple(["direct-id"]);
+		expect(core.getRecommendations).toHaveBeenCalledWith(["direct-id"], [], {
+			limit: 20,
+		});
+		expect(res).toHaveLength(1);
+	});
 
-        const results = await recommendFromMultiple(["pos1", "pos2"], ["neg1"]);
-        expect(results).toHaveLength(1);
-        expect(results[0].paperId).toBe("rec1");
-        expect(core.getRecommendations).toHaveBeenCalledWith(
-            ["pos1", "pos2"],
-            ["neg1"],
-            { limit: 20 }
-        );
-    });
+	it("recommendFromMultiple ignores failed negative resolution and still resolves if negatives have no resolved values", async () => {
+		vi.mocked(core.getRecommendations).mockResolvedValueOnce({
+			recommendedPapers: [{ paperId: "rec1", title: "Recommended" }],
+		} as any);
 
-    it("解決に失敗したIDはフィルタリングされる", async () => {
-        const { recommendFromMultiple } = await import("../src/recommend.js");
+		const { recommendFromMultiple } = await import("../src/recommend.js");
+		const res = await recommendFromMultiple(["direct-id"], ["fail-bad-title"]);
+		expect(res).toHaveLength(1);
+	});
 
-        // title search fails for "bad-title", works for "good-title"
-        vi.mocked(core.searchPapers).mockImplementation(async (query) => {
-            if (query === "bad-title") {
-                return { total: 0, offset: 0, data: [] } as any;
-            }
-            return { total: 1, offset: 0, data: [{ paperId: `s2-${query}` }] } as any;
-        });
+	it("recommendFromMultiple ignores rejected promises", async () => {
+		vi.mocked(core.getRecommendations).mockResolvedValueOnce({
+			recommendedPapers: [{ paperId: "s2-rec", title: "Recommended" }],
+		} as any);
 
-        vi.mocked(core.getRecommendations).mockResolvedValueOnce({
-            recommendedPapers: [{ paperId: "rec2", title: "R2" } as any],
-        });
+		vi.mocked(core.searchPapers).mockImplementation(async (query) => {
+			if (query === "fail-query") {
+				throw new Error("mocked fail");
+			}
+			return { total: 1, offset: 0, data: [{ paperId: `s2-${query}` }] } as any;
+		});
 
-        const results = await recommendFromMultiple(
-            ["title:good-title", "title:bad-title", "direct-id"],
-            ["title:bad-title2", "neg-id"]
-        );
+		const { recommendFromMultiple } = await import("../src/recommend.js");
+		const res = await recommendFromMultiple([
+			"title:good-query",
+			"title:fail-query",
+		]);
+		expect(res).toHaveLength(1);
+	});
 
-        expect(results).toHaveLength(1);
-        expect(core.getRecommendations).toHaveBeenCalledWith(
-            ["s2-good-title", "direct-id"],
-            ["s2-bad-title2", "neg-id"],
-            { limit: 20 }
-        );
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("解決後、positiveIdsが空になった場合は空配列を返す", async () => {
-        const { recommendFromMultiple } = await import("../src/recommend.js");
+	it("positiveIdsが空の場合は空配列を返す", async () => {
+		const { recommendFromMultiple } = await import("../src/recommend.js");
+		const results = await recommendFromMultiple([]);
+		expect(results).toEqual([]);
+		expect(core.getRecommendations).not.toHaveBeenCalled();
+	});
 
-        vi.mocked(core.searchPapers).mockResolvedValue({
-            total: 0,
-            offset: 0,
-            data: [],
-        } as any);
+	it("すべての解決に成功した場合、正しく推薦APIを呼び出す", async () => {
+		// mock resolveToS2Id indirectly by mocking getPaper since it relies on it
+		// and we provide simple S2 IDs which resolve directly
+		const { recommendFromMultiple } = await import("../src/recommend.js");
 
-        const results = await recommendFromMultiple(["title:bad1", "title:bad2"], ["neg1"]);
+		vi.mocked(core.getRecommendations).mockResolvedValueOnce({
+			recommendedPapers: [{ paperId: "rec1", title: "R1" } as any],
+		});
 
-        expect(results).toEqual([]);
-        expect(core.getRecommendations).not.toHaveBeenCalled();
-    });
+		const results = await recommendFromMultiple(["pos1", "pos2"], ["neg1"]);
+		expect(results).toHaveLength(1);
+		expect(results[0].paperId).toBe("rec1");
+		expect(core.getRecommendations).toHaveBeenCalledWith(
+			["pos1", "pos2"],
+			["neg1"],
+			{ limit: 20 },
+		);
+	});
+
+	it("解決に失敗したIDはフィルタリングされる", async () => {
+		const { recommendFromMultiple } = await import("../src/recommend.js");
+
+		// title search fails for "bad-title", works for "good-title"
+		vi.mocked(core.searchPapers).mockImplementation(async (query) => {
+			if (query === "bad-title") {
+				return { total: 0, offset: 0, data: [] } as any;
+			}
+			return { total: 1, offset: 0, data: [{ paperId: `s2-${query}` }] } as any;
+		});
+
+		vi.mocked(core.getRecommendations).mockResolvedValueOnce({
+			recommendedPapers: [{ paperId: "rec2", title: "R2" } as any],
+		});
+
+		const results = await recommendFromMultiple(
+			["title:good-title", "title:bad-title", "direct-id"],
+			["title:bad-title2", "neg-id"],
+		);
+
+		expect(results).toHaveLength(1);
+		expect(core.getRecommendations).toHaveBeenCalledWith(
+			["s2-good-title", "direct-id"],
+			["s2-bad-title2", "neg-id"],
+			{ limit: 20 },
+		);
+	});
+
+	it("解決後、positiveIdsが空になった場合は空配列を返す", async () => {
+		const { recommendFromMultiple } = await import("../src/recommend.js");
+
+		vi.mocked(core.searchPapers).mockResolvedValue({
+			total: 0,
+			offset: 0,
+			data: [],
+		} as any);
+
+		const results = await recommendFromMultiple(
+			["title:bad1", "title:bad2"],
+			["neg1"],
+		);
+
+		expect(results).toEqual([]);
+		expect(core.getRecommendations).not.toHaveBeenCalled();
+	});
 });

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -27,9 +27,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -38,11 +38,11 @@
     "@types/node": "^22.19.11",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^29.0.1",
     "rimraf": "^6.1.2",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         version: 8.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
-        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 4.1.4(vitest@4.1.4)
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -41,8 +41,8 @@ importers:
         specifier: ^6.1.2
         version: 6.1.2
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/author-profiler:
     dependencies:
@@ -69,8 +69,8 @@ importers:
         specifier: ^2.4.9
         version: 2.4.9
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -78,8 +78,8 @@ importers:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/bibtex:
     dependencies:
@@ -100,8 +100,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -109,8 +109,8 @@ importers:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/core:
     dependencies:
@@ -122,14 +122,14 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/drilldown:
     dependencies:
@@ -147,8 +147,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -156,8 +156,8 @@ importers:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/recommender:
     dependencies:
@@ -178,14 +178,14 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/scraper:
     dependencies:
@@ -203,14 +203,14 @@ importers:
         specifier: ^22.0.0
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/visualizer:
     dependencies:
@@ -228,8 +228,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -237,8 +237,8 @@ importers:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/web:
     dependencies:
@@ -316,8 +316,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -331,18 +331,14 @@ importers:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -622,105 +618,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -745,17 +725,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
-
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -793,28 +765,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -835,10 +803,6 @@ packages:
   '@notionhq/client@5.9.0':
     resolution: {integrity: sha512-TvAVMfwtVv61hsPrRfB9ehgzSjX6DaAi1ZRAnpg8xFjzaXhzhEfbO0PhBRm3ecSv1azDuO2kBuyQHh2/z7G4YQ==}
     engines: {node: '>=18'}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -874,79 +838,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1022,28 +973,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1153,15 +1100,6 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
-    peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
-    peerDependenciesMeta:
-      '@vitest/browser':
-        optional: true
-
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
@@ -1171,11 +1109,11 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: 7.3.2
@@ -1185,23 +1123,17 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
-
   '@vitest/pretty-format@4.1.4':
     resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
-
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
@@ -1210,21 +1142,9 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -1233,17 +1153,11 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
-
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.2:
     resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
@@ -1259,9 +1173,6 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1292,13 +1203,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1309,10 +1213,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1335,15 +1235,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1383,15 +1274,6 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -1452,10 +1334,6 @@ packages:
       picomatch:
         optional: true
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -1475,11 +1353,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@13.0.3:
     resolution: {integrity: sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==}
@@ -1522,15 +1395,8 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1540,16 +1406,9 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -1613,28 +1472,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -1651,9 +1506,6 @@ packages:
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
-
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -1674,9 +1526,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
@@ -1704,16 +1553,9 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -1770,14 +1612,6 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
@@ -1865,20 +1699,8 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -1890,30 +1712,11 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1945,10 +1748,6 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1959,10 +1758,6 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -2045,18 +1840,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
       vite: 7.3.2
@@ -2072,6 +1869,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -2111,23 +1912,10 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -2139,11 +1927,6 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -2396,18 +2179,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/cliui@9.0.0': {}
-
-  '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2462,9 +2234,6 @@ snapshots:
       - encoding
 
   '@notionhq/client@5.9.0': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -2689,26 +2458,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitest/coverage-v8@3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.4
@@ -2720,52 +2470,42 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+      vitest: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
-  '@vitest/expect@4.1.0':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
 
-  '@vitest/pretty-format@4.1.0':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.0':
+  '@vitest/runner@4.1.4':
     dependencies:
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.0':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.0': {}
-
-  '@vitest/utils@4.1.0':
-    dependencies:
-      '@vitest/pretty-format': 4.1.0
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -2775,27 +2515,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
   ansi-styles@5.2.0: {}
-
-  ansi-styles@6.2.3: {}
 
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
 
   assertion-error@2.0.1: {}
-
-  ast-v8-to-istanbul@0.3.12:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      estree-walker: 3.0.3
-      js-tokens: 10.0.0
 
   ast-v8-to-istanbul@1.0.0:
     dependencies:
@@ -2804,8 +2530,6 @@ snapshots:
       js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
-
-  balanced-match@1.0.2: {}
 
   balanced-match@4.0.2:
     dependencies:
@@ -2818,10 +2542,6 @@ snapshots:
       require-from-string: 2.0.2
 
   boolbase@1.0.0: {}
-
-  brace-expansion@2.0.3:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -2863,12 +2583,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -2876,12 +2590,6 @@ snapshots:
   commander@13.1.0: {}
 
   convert-source-map@2.0.0: {}
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -2908,10 +2616,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
 
   decimal.js@10.6.0: {}
 
@@ -2948,12 +2652,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  eastasianwidth@0.2.0: {}
-
-  emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -3027,11 +2725,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -3062,15 +2755,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@13.0.3:
     dependencies:
@@ -3113,11 +2797,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  is-fullwidth-code-point@3.0.0: {}
-
   is-potential-custom-element-name@1.0.1: {}
-
-  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -3127,24 +2807,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -3233,8 +2899,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
-  lru-cache@10.4.3: {}
-
   lru-cache@11.2.6: {}
 
   lru-cache@11.2.7: {}
@@ -3248,12 +2912,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  magicast@0.3.5:
-    dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
-      source-map-js: 1.2.1
 
   magicast@0.5.2:
     dependencies:
@@ -3279,13 +2937,7 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.0.3
-
   minipass@7.1.2: {}
-
-  ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
@@ -3341,13 +2993,6 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
-
-  path-key@3.1.1: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
 
   path-scurry@2.0.1:
     dependencies:
@@ -3476,15 +3121,7 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
   siginfo@2.0.0: {}
-
-  signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
 
@@ -3492,31 +3129,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
   std-env@4.0.0: {}
 
   std-env@4.1.0: {}
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
@@ -3535,12 +3150,6 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  test-exclude@7.0.2:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.5.0
-      minimatch: 10.2.4
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -3549,8 +3158,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-
-  tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.1.0: {}
 
@@ -3594,15 +3201,15 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
-  vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)):
+  vitest@4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -3618,6 +3225,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw
@@ -3651,26 +3259,10 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
🎯 **What:**
Updated `getDatabaseInfo` in `packages/recommender/src/notion-client.ts` to properly categorize and rethrow critical errors (e.g., `Unauthorized`, `RestrictedResource`) from the Notion API instead of silently swallowing them.

💡 **Why:**
Silently swallowing all errors when attempting to fetch the Notion workspace name makes it difficult to debug issues like invalid API tokens or permissions. By rethrowing critical errors, we fail fast and make the underlying problem obvious, improving the maintainability and debuggability of the application.

✅ **Verification:**
- Ran `pnpm dlx @biomejs/biome check --write` to ensure code formatting.
- Added a specific unit test in `packages/recommender/tests/notion-client.test.ts` to verify the new rethrow behavior for `Unauthorized` errors.
- Ran `pnpm test` successfully.

✨ **Result:**
The codebase is healthier because critical errors are properly surfaced to the user or caller, while non-critical errors still use the graceful fallback logic.

---
*PR created automatically by Jules for task [10391591391211297462](https://jules.google.com/task/10391591391211297462) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion APIの `users.me` 呼び出しで発生したエラーを無条件に握り潰していた `getDatabaseInfo` を変更し、`Unauthorized` と `RestrictedResource` を検知して再スローするようにしています。合わせてファイル全体のインデントが4スペースからタブに統一されました。

- `isNotionClientError` と `APIErrorCode` を使って致命的なエラーを識別し、`throw e` で呼び出し元に伝播させる処理を追加。
- `Unauthorized`（401: トークン無効）の再スローを確認する新規テストを追加。ただし `RestrictedResource`（403）は、ユーザー読み取り権限を付与していない正規のインテグレーションでも発生するため、再スローによって既存動作が壊れるリスクがあります。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

ユーザー読み取り権限を持たない既存の Notion インテグレーションが `getDatabaseInfo` 呼び出し時にクラッシュするようになるため、マージ前に `RestrictedResource` の扱いを再検討する必要があります。

`RestrictedResource`（403）の再スローにより、ユーザー情報へのアクセス権がないインテグレーション（限定スコープ）では以前は正常動作していた処理がエラーになります。`Unauthorized` の再スローは意図通りですが、`RestrictedResource` については後方互換性への影響を確認する必要があります。

`packages/recommender/src/notion-client.ts` の `RestrictedResource` 再スローロジックを重点的に確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/recommender/src/notion-client.ts | `getDatabaseInfo` にエラー再スロー処理を追加。`RestrictedResource`（403）の再スローは限定スコープのインテグレーションで既存動作を破壊する可能性あり。その他はインデント統一のフォーマット変更のみ。 |
| packages/recommender/tests/notion-client.test.ts | `Unauthorized` エラーの再スローを確認する新規テストを追加。アサーションが `.rejects.toThrow()` と弱く、`RestrictedResource` のカバレッジも欠けている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant getDatabaseInfo
    participant NotionAPI

    Caller->>getDatabaseInfo: getDatabaseInfo(databaseId)
    getDatabaseInfo->>NotionAPI: databases.retrieve(databaseId)
    NotionAPI-->>getDatabaseInfo: database object
    getDatabaseInfo->>NotionAPI: "users.me({})"
    alt Unauthorized (401)
        NotionAPI-->>getDatabaseInfo: APIResponseError (Unauthorized)
        getDatabaseInfo-->>Caller: throws (rethrow) NEW
    else RestrictedResource (403)
        NotionAPI-->>getDatabaseInfo: APIResponseError (RestrictedResource)
        getDatabaseInfo-->>Caller: throws (rethrow) - May break limited-scope integrations
    else Other error
        NotionAPI-->>getDatabaseInfo: Error
        getDatabaseInfo->>getDatabaseInfo: console.warn (fallback)
        getDatabaseInfo-->>Caller: "workspaceName = Notion Workspace"
    else Success
        NotionAPI-->>getDatabaseInfo: name: workspace
        getDatabaseInfo-->>Caller: databaseId, databaseName, workspaceName
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant getDatabaseInfo
    participant NotionAPI

    Caller->>getDatabaseInfo: getDatabaseInfo(databaseId)
    getDatabaseInfo->>NotionAPI: databases.retrieve(databaseId)
    NotionAPI-->>getDatabaseInfo: database object
    getDatabaseInfo->>NotionAPI: "users.me({})"
    alt Unauthorized (401)
        NotionAPI-->>getDatabaseInfo: APIResponseError (Unauthorized)
        getDatabaseInfo-->>Caller: throws (rethrow) NEW
    else RestrictedResource (403)
        NotionAPI-->>getDatabaseInfo: APIResponseError (RestrictedResource)
        getDatabaseInfo-->>Caller: throws (rethrow) - May break limited-scope integrations
    else Other error
        NotionAPI-->>getDatabaseInfo: Error
        getDatabaseInfo->>getDatabaseInfo: console.warn (fallback)
        getDatabaseInfo-->>Caller: "workspaceName = Notion Workspace"
    else Success
        NotionAPI-->>getDatabaseInfo: name: workspace
        getDatabaseInfo-->>Caller: databaseId, databaseName, workspaceName
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/recommender/src/notion-client.ts:144-151
**RestrictedResource の再スローが過剰になる可能性**

`RestrictedResource`（HTTP 403）は「統合がそのリソースへのアクセス権を持っていない」ことを意味します。`users.me` に対してこのエラーが返る典型的なケースは、ユーザー読み取り権限を付与していない Notion インテグレーションです。これは壊れた設定ではなく、意図的に制限されたスコープです。

この PR の変更以前は、そのような統合でも `workspaceName` が `"Notion Workspace"` にフォールバックされていました。変更後は `getDatabaseInfo` 全体が例外でクラッシュするため、データベースへの読み取りは可能なのにワークスペース名が取得できないだけという利用者が壊れることになります。`Unauthorized`（401）は確かに致命的なエラーですが、`RestrictedResource` については引き続きウォーニングログを出してフォールバックする方が後方互換性を保てます。

### Issue 2 of 3
packages/recommender/tests/notion-client.test.ts:132
**テストのアサーションが弱すぎる**

`.rejects.toThrow()` は「何らかのエラーが投げられた」ことしか確認しません。例えば `databases.retrieve` が失敗しても同じアサーションが通ってしまうため、「`Unauthorized` エラーが再スローされた」という本来の意図が検証されていません。作成した `error` インスタンスそのものが reject 値であることを確認するとより堅牢です。

```suggestion
        await expect(getDatabaseInfo("db-1", clientWithUsers as any)).rejects.toThrow(error);
```

### Issue 3 of 3
packages/recommender/tests/notion-client.test.ts:110-133
**`RestrictedResource` コードパスのテストが未整備**

実装では `Unauthorized` と `RestrictedResource` の両方を再スローしていますが、テストは `Unauthorized` のケースしかカバーしていません。`RestrictedResource` も同様に再スローされることを確認するテストを追加することで、両分岐のリグレッションを防ぎやすくなります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Improve error handling for Notion wor..."](https://github.com/hiroki-org/paper-tools/commit/64c5eb94a66f741aa39e5751ee6f5d447d90e1b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38997115)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->