### PR TITLE
🧪 Test internal serialization functions

### DIFF
--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -10,6 +10,7 @@ import {
 import { NextResponse } from "next/server";
 
 describe("auth", () => {
+
     describe("sealCookieValue and unsealCookieValue", () => {
         beforeEach(() => {
             vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
@@ -55,6 +56,49 @@ describe("auth", () => {
             const tampered = `${invalidJsonPayload}.${sig}`;
             const unsealed = unsealCookieValue(tampered);
             expect(unsealed).toBeNull();
+        });
+
+        it("should handle sealCookieValue for different data types", () => {
+            const types = [
+                "string",
+                123,
+                true,
+                null,
+                [1, 2, 3],
+                { complex: { nested: true } }
+            ];
+
+            types.forEach(data => {
+                const sealed = sealCookieValue(data);
+                expect(unsealCookieValue(sealed)).toEqual(data);
+            });
+        });
+
+        it("should return null for malformed cookie value missing dot", () => {
+            expect(unsealCookieValue("nodothere")).toBeNull();
+        });
+
+        it("should return null for signatures of different length", () => {
+            const data = { test: true };
+            const sealed = sealCookieValue(data);
+
+            const [payload, sig] = sealed.split(".");
+            const tampered = `${payload}.${sig}A`; // Add an extra character
+
+            expect(unsealCookieValue(tampered)).toBeNull();
+        });
+
+        it("should return null for signatures of same length but invalid", () => {
+            const data = { test: true };
+            const sealed = sealCookieValue(data);
+
+            const [payload, sig] = sealed.split(".");
+            // change the last character
+            const lastChar = sig.charAt(sig.length - 1);
+            const newLastChar = lastChar === 'a' ? 'b' : 'a';
+            const tampered = `${payload}.${sig.slice(0, -1)}${newLastChar}`;
+
+            expect(unsealCookieValue(tampered)).toBeNull();
         });
 
         it("should throw error if secret is missing", () => {


### PR DESCRIPTION
🎯 **What:**
Added comprehensive unit tests for `sealCookieValue` and `unsealCookieValue` in `packages/web/src/lib/auth.test.ts`.

📊 **Coverage:**
- Tests the ability of `sealCookieValue` and `unsealCookieValue` to properly handle various data types correctly (strings, numbers, booleans, null, arrays, objects).
- Tests parsing of malformed cookie values that lack the required formatting, specifically those missing the separating dot (`.`).
- Covers edge cases regarding cookie tampering such as signatures of different lengths.
- Addresses the vulnerability of signatures being tampered with by changing characters but keeping the same length.

✨ **Result:**
Test coverage of the core authentication flow, and particularly the robust token signing logic, has been greatly improved and expanded to cover various edge cases not covered before.

---
*PR created automatically by Jules for task [7587703202339603828](https://jules.google.com/task/7587703202339603828) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `sealCookieValue` と `unsealCookieValue` の内部シリアライゼーション関数に対するユニットテストを追加します。データ型の多様性、署名改ざん（長さ違い・同長別内容）、不正フォーマットなどのエッジケースをカバーすることが目的です。

- **データ型 round-trip テスト**: `null` は `unsealCookieValue` の失敗戻り値と区別できないため、成功したかどうかが確認できません。
- **冗長テスト**: `\"should return null for malformed cookie value missing dot\"` は既存テストと同じコードパスを踏むため重複しています。
- **署名改ざんテスト**: 長さ違い・同長別内容の 2 ケースはいずれも有効で新たなカバレッジを提供しています。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はありません。ただし `null` の round-trip テストはシールが壊れていても検知できないため、テストとして意図した検証ができていません。

`null` を `forEach` ループ内で他のデータ型と同列に検証しているため、`unsealCookieValue` が「正常に null を復元した」のか「署名検証失敗で null を返した」のかを区別できません。テスト自体は常にパスしますが、このケースのシール/アンシールサイクルが正しく動作しているかの保証になりません。プロダクションコードへの変更はなく、他のテストケースは正しく機能しています。

packages/web/src/lib/auth.test.ts — `null` の round-trip テストの修正と重複テストの整理が必要です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/lib/auth.test.ts | sealCookieValue / unsealCookieValue のユニットテストを追加。null の round-trip テストで成功/失敗を区別できない問題、既存テストとの重複、forEach の使用という 3 点の課題あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as テストケース
    participant Seal as sealCookieValue
    participant Unseal as unsealCookieValue
    participant HMAC as HMAC-SHA256

    Test->>Seal: data (任意の型)
    Seal->>HMAC: JSON.stringify(data) → base64url → sign
    HMAC-->>Seal: signature (base64url)
    Seal-->>Test: payload.signature

    Test->>Unseal: payload.signature (or tampered)
    Unseal->>HMAC: signPayload(payload)
    HMAC-->>Unseal: expectedSig
    Unseal->>Unseal: "timingSafeEqual(expected, actual) && length check"
    alt 署名一致
        Unseal-->>Test: JSON.parse(fromBase64Url(payload)) → T
    else 署名不一致 / 不正フォーマット / JSONパース失敗
        Unseal-->>Test: null
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as テストケース
    participant Seal as sealCookieValue
    participant Unseal as unsealCookieValue
    participant HMAC as HMAC-SHA256

    Test->>Seal: data (任意の型)
    Seal->>HMAC: JSON.stringify(data) → base64url → sign
    HMAC-->>Seal: signature (base64url)
    Seal-->>Test: payload.signature

    Test->>Unseal: payload.signature (or tampered)
    Unseal->>HMAC: signPayload(payload)
    HMAC-->>Unseal: expectedSig
    Unseal->>Unseal: "timingSafeEqual(expected, actual) && length check"
    alt 署名一致
        Unseal-->>Test: JSON.parse(fromBase64Url(payload)) → T
    else 署名不一致 / 不正フォーマット / JSONパース失敗
        Unseal-->>Test: null
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/web/src/lib/auth.test.ts:61-75
**`null` の round-trip テストが成功失敗を区別できない**

`types` 配列に `null` が含まれています。`unsealCookieValue` は「正常に `null` を復元した場合」にも「署名検証に失敗した場合」にも `null` を返します。そのため `expect(unsealCookieValue(sealed)).toEqual(null)` は常に `true` になり、シールが壊れていても検出できません。`null` を別のテストケースに分離するか、`null` を `types` 配列から除外して目的を明確にすることを検討してください。

### Issue 2 of 3
packages/web/src/lib/auth.test.ts:77-79
**既存テストと重複するテストケース**

このテストは `"nodothere"` がドットを含まないことを検証していますが、46〜49 行目に既存の `should return null for malformed cookie value` テストがあり、そこで `"not-a-valid-format"` (ドットなし) と `""` の両方が既にカバーされています。`unsealCookieValue` 内の `!sig` チェックを通じて同一のコードパスを通るため、このテストは重複しています。削除することでテストスイートをシンプルに保てます。

### Issue 3 of 3
packages/web/src/lib/auth.test.ts:61-75
**`forEach` ではなく `it.each` を使うと失敗時の診断が容易になる**

現在の `forEach` ループでは、テスト失敗時にどのデータ型が原因かがエラーメッセージから分かりにくくなります。Vitest の `it.each` を使うことで、各データ型が独立したテストケースとして実行され、失敗時の特定が容易になります。また、`null` の round-trip 問題（上のコメント参照）の解消もあわせて対応できます。

```suggestion
        it.each([
            ["string", "string"],
            ["number", 123],
            ["boolean", true],
            ["array", [1, 2, 3]],
            ["nested object", { complex: { nested: true } }],
        ])("should handle sealCookieValue for %s", (_label, data) => {
            const sealed = sealCookieValue(data);
            expect(unsealCookieValue(sealed)).toEqual(data);
        });

        it("should return null when sealing and unsealing null (ambiguous case)", () => {
            // null は unsealCookieValue のエラー戻り値と区別できないため個別に記述
            const sealed = sealCookieValue(null);
            expect(typeof sealed).toBe("string");
            expect(sealed).toContain(".");
            expect(unsealCookieValue(sealed)).toBeNull();
        });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add unit tests for sealCookieValue and u..."](https://github.com/hiroki-org/paper-tools/commit/45b6e74420e5c473b6e0e35a753ea21e0ed45519) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38999042)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->