### PR TITLE
🧹 Fix 'any' type usage in Notion databases route

### DIFF
--- a/packages/web/src/app/api/databases/route.ts
+++ b/packages/web/src/app/api/databases/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
+import type { DatabaseObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 import { getAccessToken, getNotionClient } from "@/lib/auth";
 
 type DbItem = {
@@ -28,7 +29,7 @@ export async function GET(request: NextRequest) {
 
             for (const result of response.results) {
                 if (result.object !== "data_source") continue;
-                const ds = result as any;
+                const ds = result as unknown as DatabaseObjectResponse;
 
                 const title = (ds.title ?? [])
                     .map((item: { plain_text?: string }) => item.plain_text ?? "")

--- a/submit.sh
+++ b/submit.sh
@@ -1,0 +1,1 @@
+echo "Submitting PR..."


### PR DESCRIPTION
🎯 **What:** Replace `any` type assertion with `DatabaseObjectResponse` from Notion SDK.
💡 **Why:** To improve code maintainability, provide proper typing for the search result object, and resolve the Biome `lint/suspicious/noExplicitAny` warning.
✅ **Verification:** Verified that full Vitest suite passes and Biome linting checks pass successfully.
✨ **Result:** Enhanced type safety for Notion database/data source objects without runtime side effects.

---
*PR created automatically by Jules for task [6374968166628817423](https://jules.google.com/task/6374968166628817423) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは Notion データベース取得ルート (`route.ts`) で `as any` 型アサーションを `DatabaseObjectResponse` 型に置き換え、Biome の `noExplicitAny` 警告を解消します。ただし、Jules が自動生成した `submit.sh` が誤ってコミットに含まれており、削除が必要です。

- **型の改善**: `result as any` → `result as unknown as DatabaseObjectResponse` に変更し、型情報を明示化。ただし内部ビルドパス (`@notionhq/client/build/src/api-endpoints`) からのインポートと二重型アサーションの問題が残る。
- **不要ファイルの混入**: `submit.sh`（`echo "Submitting PR..."` のみ）が Jules の自動生成物として誤ってコミットされており、削除が必要。
- **推奨アプローチ**: Notion SDK の公開 API である `isFullDatabase()` 型ガードを使うことで、内部パスへの依存と二重アサーションを両方解消できる。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

意図しない `submit.sh` の混入があり、マージ前に削除が必要です。型の改善は正しい方向ですが、内部ビルドパスへの依存が残っています。

Jules が自動生成した `submit.sh` が誤ってコミットに含まれており、リポジトリに不要なファイルが混入します。型変更自体は概ね正しい方向ですが、`@notionhq/client/build/src/api-endpoints` という内部パスへの依存と `as unknown as` の二重アサーションが残っており、SDK バージョンアップ時に壊れるリスクがあります。

`submit.sh` は削除が必須です。`route.ts` の内部インポートパスと型アサーションも見直しを推奨します。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/databases/route.ts | `any` 型を `DatabaseObjectResponse` に変更したが、内部ビルドパスからのインポートと二重型アサーション (`as unknown as`) の使用が残っている。`isFullDatabase` 型ガードへの置き換えが推奨される。 |
| submit.sh | Jules の自動生成ファイルであり、リポジトリに含まれるべきではない無意味なスクリプト。削除が必要。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant GET /api/databases
    participant NotionSDK

    Client->>GET /api/databases: GET リクエスト
    GET /api/databases->>GET /api/databases: getAccessToken(cookies)
    alt トークンなし
        GET /api/databases-->>Client: 401 Unauthorized
    else トークンあり
        GET /api/databases->>NotionSDK: notion.search({ filter: "data_source" })
        NotionSDK-->>GET /api/databases: results[]
        loop 各 result
            GET /api/databases->>GET /api/databases: result.object !== "data_source" → skip
            Note over GET /api/databases: result as unknown as DatabaseObjectResponse (変更箇所)
            GET /api/databases->>GET /api/databases: title / description / icon を抽出
            GET /api/databases->>GET /api/databases: databases.push(DbItem)
        end
        GET /api/databases-->>Client: 200 { databases }
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant GET /api/databases
    participant NotionSDK

    Client->>GET /api/databases: GET リクエスト
    GET /api/databases->>GET /api/databases: getAccessToken(cookies)
    alt トークンなし
        GET /api/databases-->>Client: 401 Unauthorized
    else トークンあり
        GET /api/databases->>NotionSDK: notion.search({ filter: "data_source" })
        NotionSDK-->>GET /api/databases: results[]
        loop 各 result
            GET /api/databases->>GET /api/databases: result.object !== "data_source" → skip
            Note over GET /api/databases: result as unknown as DatabaseObjectResponse (変更箇所)
            GET /api/databases->>GET /api/databases: title / description / icon を抽出
            GET /api/databases->>GET /api/databases: databases.push(DbItem)
        end
        GET /api/databases-->>Client: 200 { databases }
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
submit.sh:1
**Jules の自動生成ファイルが誤ってコミットされています**

このファイル (`submit.sh`) は Jules（Google の AI コード生成ツール）がPRを提出する際に使用した内部スクリプトであり、リポジトリには含まれるべきではありません。`echo "Submitting PR..."` という内容はプロダクションコードに何の価値も持たず、削除してください。

### Issue 2 of 3
packages/web/src/app/api/databases/route.ts:2-3
**内部ビルドパスからのインポートは脆弱です**

`@notionhq/client/build/src/api-endpoints` は Notion SDK のプライベートな内部ビルドパスです。SDK バージョンアップ時にパスが変更・削除されるリスクがあります。Notion SDK は `isFullDatabase` などのユーティリティ関数を公開 API として提供しているため、型ガードを使う方がより堅牢です。

```suggestion
import { isFullDatabase } from "@notionhq/client";
import { getAccessToken, getNotionClient } from "@/lib/auth";
```

### Issue 3 of 3
packages/web/src/app/api/databases/route.ts:30-32
**`as unknown as` による二重型アサーションは型安全性を損ないます**

`result as unknown as DatabaseObjectResponse` は `as any` の代替としてリンターの警告を回避していますが、型チェックを実質的にバイパスしています。Notion SDK が公開している `isFullDatabase(result)` 型ガードを使うことで、ランタイムでの型確認と TypeScript の型の絞り込みを両立できます。

```suggestion
            for (const result of response.results) {
                if (!isFullDatabase(result)) continue;
                const ds = result;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Fix &#39;any&#39; type usage in Notion databa..."](https://github.com/hiroki-org/paper-tools/commit/d822f942b2028bb976ef783ec6eb9a902f7292d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38999928)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->