### PR TITLE
🔒 Fix Host Header Injection in Notion OAuth Redirect URI

### DIFF
--- a/packages/author-profiler/package.json
+++ b/packages/author-profiler/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "^22.19.11",
     "@types/prompts": "^2.4.9",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "rimraf": "^6.1.2",
     "typescript": "^5.8.0",
     "vitest": "^4.1.0"

--- a/packages/bibtex/package.json
+++ b/packages/bibtex/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "rimraf": "^6.1.2",
     "typescript": "^5.8.0",
     "vitest": "^4.1.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   }

--- a/packages/drilldown/package.json
+++ b/packages/drilldown/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.0",
     "vitest": "^4.1.0"

--- a/packages/recommender/package.json
+++ b/packages/recommender/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.0"
   }

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.0"
   }

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.0",
     "vitest": "^4.1.0"

--- a/packages/web/.env.local.example
+++ b/packages/web/.env.local.example
@@ -6,3 +6,6 @@ COOKIE_SECRET=your_random_secret_here
 # 以下はCLI用（Web UIでは不要）
 # NOTION_API_KEY=your_notion_api_key_here
 # NOTION_DATABASE_ID=your_notion_database_id_here
+
+# Application URL (used for OAuth redirect callbacks)
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^22.19.11",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/coverage-v8": "^4.1.0",
     "jsdom": "^29.0.1",
     "rimraf": "^6.1.2",
     "tailwindcss": "^4.0.0",

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -1,257 +1,242 @@
-import type { NextResponse } from "next/server";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { sealCookieValue, unsealCookieValue, clearAuthCookies, getAccessToken, buildNotionRedirectUri } from "./auth";
 import {
-	buildNotionRedirectUri,
-	clearAuthCookies,
-	getAccessToken,
-	sealCookieValue,
-	unsealCookieValue,
-} from "./auth";
-import {
-	ACCESS_TOKEN_COOKIE,
-	DATABASE_ID_COOKIE,
-	OAUTH_STATE_COOKIE,
-	REFRESH_TOKEN_COOKIE,
-	USER_INFO_COOKIE,
+    ACCESS_TOKEN_COOKIE,
+    REFRESH_TOKEN_COOKIE,
+    USER_INFO_COOKIE,
+    DATABASE_ID_COOKIE,
+    OAUTH_STATE_COOKIE,
 } from "./auth-cookies";
+import { NextResponse } from "next/server";
 
 describe("auth", () => {
-	describe("sealCookieValue and unsealCookieValue", () => {
-		beforeEach(() => {
-			vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
-		});
+    describe("sealCookieValue and unsealCookieValue", () => {
+        beforeEach(() => {
+            vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
+        });
 
-		afterEach(() => {
-			vi.unstubAllEnvs();
-		});
+        afterEach(() => {
+            vi.unstubAllEnvs();
+        });
 
-		it("should successfully seal and unseal data", () => {
-			const data = { userId: "user-123", role: "admin" };
-			const sealed = sealCookieValue(data);
+        it("should successfully seal and unseal data", () => {
+            const data = { userId: "user-123", role: "admin" };
+            const sealed = sealCookieValue(data);
 
-			expect(typeof sealed).toBe("string");
-			expect(sealed).toContain(".");
+            expect(typeof sealed).toBe("string");
+            expect(sealed).toContain(".");
 
-			const unsealed = unsealCookieValue<{ userId: string; role: string }>(
-				sealed,
-			);
-			expect(unsealed).toEqual(data);
-		});
+            const unsealed = unsealCookieValue<{ userId: string; role: string }>(sealed);
+            expect(unsealed).toEqual(data);
+        });
 
-		it("should return null for invalid signature", () => {
-			const data = { test: true };
-			const sealed = sealCookieValue(data);
+        it("should return null for invalid signature", () => {
+            const data = { test: true };
+            const sealed = sealCookieValue(data);
 
-			// Modify the signature part
-			const [payload] = sealed.split(".");
-			const tampered = `${payload}.invalid-signature`;
+            // Modify the signature part
+            const [payload] = sealed.split(".");
+            const tampered = `${payload}.invalid-signature`;
 
-			const unsealed = unsealCookieValue(tampered);
-			expect(unsealed).toBeNull();
-		});
+            const unsealed = unsealCookieValue(tampered);
+            expect(unsealed).toBeNull();
+        });
 
-		it("should return null for malformed cookie value", () => {
-			expect(unsealCookieValue("not-a-valid-format")).toBeNull();
-			expect(unsealCookieValue("")).toBeNull();
-		});
+        it("should return null for malformed cookie value", () => {
+            expect(unsealCookieValue("not-a-valid-format")).toBeNull();
+            expect(unsealCookieValue("")).toBeNull();
+        });
 
-		it("should return null if payload is valid base64url but invalid json", () => {
-			const invalidJsonPayload = Buffer.from("not json", "utf8").toString(
-				"base64url",
-			);
-			const crypto = require("crypto");
-			const sig = crypto
-				.createHmac("sha256", "super-secret-key-12345")
-				.update(invalidJsonPayload)
-				.digest("base64url");
+        it("should return null if payload is valid base64url but invalid json", () => {
+            const invalidJsonPayload = Buffer.from("not json", "utf8").toString("base64url");
+            const crypto = require("crypto");
+            const sig = crypto.createHmac("sha256", "super-secret-key-12345").update(invalidJsonPayload).digest("base64url");
 
-			const tampered = `${invalidJsonPayload}.${sig}`;
-			const unsealed = unsealCookieValue(tampered);
-			expect(unsealed).toBeNull();
-		});
+            const tampered = `${invalidJsonPayload}.${sig}`;
+            const unsealed = unsealCookieValue(tampered);
+            expect(unsealed).toBeNull();
+        });
 
-		it("should throw error if secret is missing", () => {
-			vi.unstubAllEnvs();
-			vi.stubEnv("COOKIE_SECRET", "");
-			vi.stubEnv("NEXTAUTH_SECRET", "");
+        it("should throw error if secret is missing", () => {
+            vi.unstubAllEnvs();
+            vi.stubEnv("COOKIE_SECRET", "");
+            vi.stubEnv("NEXTAUTH_SECRET", "");
 
-			expect(() => sealCookieValue({ test: true })).toThrow(
-				"COOKIE_SECRET (or NEXTAUTH_SECRET) is not set",
-			);
-		});
+            expect(() => sealCookieValue({ test: true })).toThrow("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
+        });
 
-		it("should use NEXTAUTH_SECRET if COOKIE_SECRET is missing", () => {
-			vi.unstubAllEnvs();
-			delete process.env.COOKIE_SECRET;
-			vi.stubEnv("NEXTAUTH_SECRET", "next-auth-secret-456");
+        it("should use NEXTAUTH_SECRET if COOKIE_SECRET is missing", () => {
+            vi.unstubAllEnvs();
+            delete process.env.COOKIE_SECRET;
+            vi.stubEnv("NEXTAUTH_SECRET", "next-auth-secret-456");
 
-			const data = { auth: true };
-			const sealed = sealCookieValue(data);
-			const unsealed = unsealCookieValue(sealed);
-			expect(unsealed).toEqual(data);
-		});
-	});
+            const data = { auth: true };
+            const sealed = sealCookieValue(data);
+            const unsealed = unsealCookieValue(sealed);
+            expect(unsealed).toEqual(data);
+        });
+    });
 
-	describe("clearAuthCookies", () => {
-		let mockResponse: any;
+    describe("clearAuthCookies", () => {
+        let mockResponse: any;
 
-		beforeEach(() => {
-			mockResponse = {
-				cookies: {
-					set: vi.fn(),
-				},
-			};
-		});
+        beforeEach(() => {
+            mockResponse = {
+                cookies: {
+                    set: vi.fn(),
+                },
+            };
+        });
 
-		afterEach(() => {
-			vi.unstubAllEnvs();
-			vi.restoreAllMocks();
-		});
+        afterEach(() => {
+            vi.unstubAllEnvs();
+            vi.restoreAllMocks();
+        });
 
-		it("should clear all auth cookies with correct options in development", () => {
-			vi.stubEnv("NODE_ENV", "development");
+        it("should clear all auth cookies with correct options in development", () => {
+            vi.stubEnv("NODE_ENV", "development");
 
-			clearAuthCookies(mockResponse as NextResponse);
+            clearAuthCookies(mockResponse as NextResponse);
 
-			const expectedCookies = [
-				ACCESS_TOKEN_COOKIE,
-				REFRESH_TOKEN_COOKIE,
-				USER_INFO_COOKIE,
-				DATABASE_ID_COOKIE,
-				OAUTH_STATE_COOKIE,
-			];
+            const expectedCookies = [
+                ACCESS_TOKEN_COOKIE,
+                REFRESH_TOKEN_COOKIE,
+                USER_INFO_COOKIE,
+                DATABASE_ID_COOKIE,
+                OAUTH_STATE_COOKIE,
+            ];
 
-			expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
+            expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
 
-			expectedCookies.forEach((cookieName) => {
-				expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
-					httpOnly: true,
-					secure: false,
-					sameSite: "lax",
-					path: "/",
-					maxAge: 0,
-				});
-			});
-		});
+            expectedCookies.forEach((cookieName) => {
+                expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
+                    httpOnly: true,
+                    secure: false,
+                    sameSite: "lax",
+                    path: "/",
+                    maxAge: 0,
+                });
+            });
+        });
 
-		it("should set secure flag to true in production", () => {
-			vi.stubEnv("NODE_ENV", "production");
+        it("should set secure flag to true in production", () => {
+            vi.stubEnv("NODE_ENV", "production");
 
-			clearAuthCookies(mockResponse as NextResponse);
+            clearAuthCookies(mockResponse as NextResponse);
 
-			const expectedCookies = [
-				ACCESS_TOKEN_COOKIE,
-				REFRESH_TOKEN_COOKIE,
-				USER_INFO_COOKIE,
-				DATABASE_ID_COOKIE,
-				OAUTH_STATE_COOKIE,
-			];
+            const expectedCookies = [
+                ACCESS_TOKEN_COOKIE,
+                REFRESH_TOKEN_COOKIE,
+                USER_INFO_COOKIE,
+                DATABASE_ID_COOKIE,
+                OAUTH_STATE_COOKIE,
+            ];
 
-			expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
+            expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
 
-			expectedCookies.forEach((cookieName) => {
-				expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
-					httpOnly: true,
-					secure: true,
-					sameSite: "lax",
-					path: "/",
-					maxAge: 0,
-				});
-			});
-		});
-	});
+            expectedCookies.forEach((cookieName) => {
+                expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
+                    httpOnly: true,
+                    secure: true,
+                    sameSite: "lax",
+                    path: "/",
+                    maxAge: 0,
+                });
+            });
+        });
+    });
 
-	describe("getAccessToken", () => {
-		beforeEach(() => {
-			vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
-		});
+    describe("getAccessToken", () => {
+        beforeEach(() => {
+            vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
+        });
 
-		afterEach(() => {
-			vi.unstubAllEnvs();
-		});
+        afterEach(() => {
+            vi.unstubAllEnvs();
+        });
 
-		it("should return null if cookie is not present", () => {
-			const cookieStore = {
-				get: vi.fn().mockReturnValue(undefined),
-			};
-			expect(getAccessToken(cookieStore as any)).toBeNull();
-			expect(cookieStore.get).toHaveBeenCalledWith(ACCESS_TOKEN_COOKIE);
-		});
+        it("should return null if cookie is not present", () => {
+            const cookieStore = {
+                get: vi.fn().mockReturnValue(undefined),
+            };
+            expect(getAccessToken(cookieStore as any)).toBeNull();
+            expect(cookieStore.get).toHaveBeenCalledWith(ACCESS_TOKEN_COOKIE);
+        });
 
-		it("should return the token when valid cookie is present", () => {
-			const token = "valid-token-123";
-			const sealed = sealCookieValue({ token });
-			const cookieStore = {
-				get: vi.fn().mockReturnValue({ value: sealed }),
-			};
+        it("should return the token when valid cookie is present", () => {
+            const token = "valid-token-123";
+            const sealed = sealCookieValue({ token });
+            const cookieStore = {
+                get: vi.fn().mockReturnValue({ value: sealed }),
+            };
 
-			expect(getAccessToken(cookieStore as any)).toBe(token);
-		});
+            expect(getAccessToken(cookieStore as any)).toBe(token);
+        });
 
-		it("should return null when the cookie is malformed or invalid", () => {
-			const cookieStore = {
-				get: vi.fn().mockReturnValue({ value: "invalid.cookie.value" }),
-			};
-			expect(getAccessToken(cookieStore as any)).toBeNull();
-		});
+        it("should return null when the cookie is malformed or invalid", () => {
+            const cookieStore = {
+                get: vi.fn().mockReturnValue({ value: "invalid.cookie.value" }),
+            };
+            expect(getAccessToken(cookieStore as any)).toBeNull();
+        });
 
-		it("should return null when the cookie is valid but contains no token", () => {
-			const sealed = sealCookieValue({ notToken: "abc" } as any);
-			const cookieStore = {
-				get: vi.fn().mockReturnValue({ value: sealed }),
-			};
-			expect(getAccessToken(cookieStore as any)).toBeNull();
-		});
+        it("should return null when the cookie is valid but contains no token", () => {
+            const sealed = sealCookieValue({ notToken: "abc" } as any);
+            const cookieStore = {
+                get: vi.fn().mockReturnValue({ value: sealed }),
+            };
+            expect(getAccessToken(cookieStore as any)).toBeNull();
+        });
 
-		it("should return null when the cookie is valid but contains a non-string token", () => {
-			const sealed = sealCookieValue({ token: 12345 } as any);
-			const cookieStore = {
-				get: vi.fn().mockReturnValue({ value: sealed }),
-			};
-			expect(getAccessToken(cookieStore as any)).toBeNull();
-		});
-	});
+        it("should return null when the cookie is valid but contains a non-string token", () => {
+            const sealed = sealCookieValue({ token: 12345 } as any);
+            const cookieStore = {
+                get: vi.fn().mockReturnValue({ value: sealed }),
+            };
+            expect(getAccessToken(cookieStore as any)).toBeNull();
+        });
+    });
 
-	describe("buildNotionRedirectUri", () => {
-		afterEach(() => {
-			vi.unstubAllEnvs();
-		});
+    describe("buildNotionRedirectUri", () => {
+        afterEach(() => {
+            vi.unstubAllEnvs();
+        });
 
-		it("should use NEXT_PUBLIC_SITE_URL when available", () => {
-			vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://example.com");
-			const request = { headers: new Headers() } as any;
-			const uri = buildNotionRedirectUri(request);
-			expect(uri).toBe("https://example.com/api/auth/callback/notion");
-		});
+        it("should use NEXT_PUBLIC_SITE_URL when available", () => {
+            vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://example.com");
+            const request = { headers: new Headers() } as any;
+            const uri = buildNotionRedirectUri(request);
+            expect(uri).toBe("https://example.com/api/auth/callback/notion");
+        });
 
-		it("should strip trailing slashes from NEXT_PUBLIC_SITE_URL", () => {
-			vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://example.com/");
-			const request = { headers: new Headers() } as any;
-			const uri = buildNotionRedirectUri(request);
-			expect(uri).toBe("https://example.com/api/auth/callback/notion");
-		});
+        it("should strip trailing slashes from NEXT_PUBLIC_SITE_URL", () => {
+            vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://example.com/");
+            const request = { headers: new Headers() } as any;
+            const uri = buildNotionRedirectUri(request);
+            expect(uri).toBe("https://example.com/api/auth/callback/notion");
+        });
 
-		it("should fallback to localhost:3000 when NEXT_PUBLIC_SITE_URL is not set", () => {
-			delete process.env.NEXT_PUBLIC_SITE_URL;
-			const request = { headers: new Headers() } as any;
-			const uri = buildNotionRedirectUri(request);
-			expect(uri).toBe("http://localhost:3000/api/auth/callback/notion");
-		});
+        it("should fallback to localhost:3000 when NEXT_PUBLIC_SITE_URL is not set", () => {
+            delete process.env.NEXT_PUBLIC_SITE_URL;
+            const request = { headers: new Headers() } as any;
+            const uri = buildNotionRedirectUri(request);
+            expect(uri).toBe("http://localhost:3000/api/auth/callback/notion");
+        });
 
-		it("should ignore Host header and x-forwarded headers to prevent injection", () => {
-			vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://trusted.com");
-			const request = {
-				headers: new Headers({
-					host: "evil.com",
-					"x-forwarded-host": "attacker.com",
-					"x-forwarded-proto": "http",
-				}),
-			} as any;
+        it("should ignore Host header and x-forwarded headers to prevent injection", () => {
+            vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://trusted.com");
+            const request = {
+                headers: new Headers({
+                    "host": "evil.com",
+                    "x-forwarded-host": "attacker.com",
+                    "x-forwarded-proto": "http"
+                })
+            } as any;
 
-			const uri = buildNotionRedirectUri(request);
-			expect(uri).toBe("https://trusted.com/api/auth/callback/notion");
-			expect(uri).not.toContain("evil.com");
-			expect(uri).not.toContain("attacker.com");
-		});
-	});
+            const uri = buildNotionRedirectUri(request);
+            expect(uri).toBe("https://trusted.com/api/auth/callback/notion");
+            expect(uri).not.toContain("evil.com");
+            expect(uri).not.toContain("attacker.com");
+        });
+    });
 });

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -1,199 +1,257 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { sealCookieValue, unsealCookieValue, clearAuthCookies, getAccessToken } from "./auth";
+import type { NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    ACCESS_TOKEN_COOKIE,
-    REFRESH_TOKEN_COOKIE,
-    USER_INFO_COOKIE,
-    DATABASE_ID_COOKIE,
-    OAUTH_STATE_COOKIE,
+	buildNotionRedirectUri,
+	clearAuthCookies,
+	getAccessToken,
+	sealCookieValue,
+	unsealCookieValue,
+} from "./auth";
+import {
+	ACCESS_TOKEN_COOKIE,
+	DATABASE_ID_COOKIE,
+	OAUTH_STATE_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
 } from "./auth-cookies";
-import { NextResponse } from "next/server";
 
 describe("auth", () => {
-    describe("sealCookieValue and unsealCookieValue", () => {
-        beforeEach(() => {
-            vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
-        });
+	describe("sealCookieValue and unsealCookieValue", () => {
+		beforeEach(() => {
+			vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
+		});
 
-        afterEach(() => {
-            vi.unstubAllEnvs();
-        });
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
 
-        it("should successfully seal and unseal data", () => {
-            const data = { userId: "user-123", role: "admin" };
-            const sealed = sealCookieValue(data);
+		it("should successfully seal and unseal data", () => {
+			const data = { userId: "user-123", role: "admin" };
+			const sealed = sealCookieValue(data);
 
-            expect(typeof sealed).toBe("string");
-            expect(sealed).toContain(".");
+			expect(typeof sealed).toBe("string");
+			expect(sealed).toContain(".");
 
-            const unsealed = unsealCookieValue<{ userId: string; role: string }>(sealed);
-            expect(unsealed).toEqual(data);
-        });
+			const unsealed = unsealCookieValue<{ userId: string; role: string }>(
+				sealed,
+			);
+			expect(unsealed).toEqual(data);
+		});
 
-        it("should return null for invalid signature", () => {
-            const data = { test: true };
-            const sealed = sealCookieValue(data);
+		it("should return null for invalid signature", () => {
+			const data = { test: true };
+			const sealed = sealCookieValue(data);
 
-            // Modify the signature part
-            const [payload] = sealed.split(".");
-            const tampered = `${payload}.invalid-signature`;
+			// Modify the signature part
+			const [payload] = sealed.split(".");
+			const tampered = `${payload}.invalid-signature`;
 
-            const unsealed = unsealCookieValue(tampered);
-            expect(unsealed).toBeNull();
-        });
+			const unsealed = unsealCookieValue(tampered);
+			expect(unsealed).toBeNull();
+		});
 
-        it("should return null for malformed cookie value", () => {
-            expect(unsealCookieValue("not-a-valid-format")).toBeNull();
-            expect(unsealCookieValue("")).toBeNull();
-        });
+		it("should return null for malformed cookie value", () => {
+			expect(unsealCookieValue("not-a-valid-format")).toBeNull();
+			expect(unsealCookieValue("")).toBeNull();
+		});
 
-        it("should return null if payload is valid base64url but invalid json", () => {
-            const invalidJsonPayload = Buffer.from("not json", "utf8").toString("base64url");
-            const crypto = require("crypto");
-            const sig = crypto.createHmac("sha256", "super-secret-key-12345").update(invalidJsonPayload).digest("base64url");
+		it("should return null if payload is valid base64url but invalid json", () => {
+			const invalidJsonPayload = Buffer.from("not json", "utf8").toString(
+				"base64url",
+			);
+			const crypto = require("crypto");
+			const sig = crypto
+				.createHmac("sha256", "super-secret-key-12345")
+				.update(invalidJsonPayload)
+				.digest("base64url");
 
-            const tampered = `${invalidJsonPayload}.${sig}`;
-            const unsealed = unsealCookieValue(tampered);
-            expect(unsealed).toBeNull();
-        });
+			const tampered = `${invalidJsonPayload}.${sig}`;
+			const unsealed = unsealCookieValue(tampered);
+			expect(unsealed).toBeNull();
+		});
 
-        it("should throw error if secret is missing", () => {
-            vi.unstubAllEnvs();
-            vi.stubEnv("COOKIE_SECRET", "");
-            vi.stubEnv("NEXTAUTH_SECRET", "");
+		it("should throw error if secret is missing", () => {
+			vi.unstubAllEnvs();
+			vi.stubEnv("COOKIE_SECRET", "");
+			vi.stubEnv("NEXTAUTH_SECRET", "");
 
-            expect(() => sealCookieValue({ test: true })).toThrow("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
-        });
+			expect(() => sealCookieValue({ test: true })).toThrow(
+				"COOKIE_SECRET (or NEXTAUTH_SECRET) is not set",
+			);
+		});
 
-        it("should use NEXTAUTH_SECRET if COOKIE_SECRET is missing", () => {
-            vi.unstubAllEnvs();
-            delete process.env.COOKIE_SECRET;
-            vi.stubEnv("NEXTAUTH_SECRET", "next-auth-secret-456");
+		it("should use NEXTAUTH_SECRET if COOKIE_SECRET is missing", () => {
+			vi.unstubAllEnvs();
+			delete process.env.COOKIE_SECRET;
+			vi.stubEnv("NEXTAUTH_SECRET", "next-auth-secret-456");
 
-            const data = { auth: true };
-            const sealed = sealCookieValue(data);
-            const unsealed = unsealCookieValue(sealed);
-            expect(unsealed).toEqual(data);
-        });
-    });
+			const data = { auth: true };
+			const sealed = sealCookieValue(data);
+			const unsealed = unsealCookieValue(sealed);
+			expect(unsealed).toEqual(data);
+		});
+	});
 
-    describe("clearAuthCookies", () => {
-        let mockResponse: any;
+	describe("clearAuthCookies", () => {
+		let mockResponse: any;
 
-        beforeEach(() => {
-            mockResponse = {
-                cookies: {
-                    set: vi.fn(),
-                },
-            };
-        });
+		beforeEach(() => {
+			mockResponse = {
+				cookies: {
+					set: vi.fn(),
+				},
+			};
+		});
 
-        afterEach(() => {
-            vi.unstubAllEnvs();
-            vi.restoreAllMocks();
-        });
+		afterEach(() => {
+			vi.unstubAllEnvs();
+			vi.restoreAllMocks();
+		});
 
-        it("should clear all auth cookies with correct options in development", () => {
-            vi.stubEnv("NODE_ENV", "development");
+		it("should clear all auth cookies with correct options in development", () => {
+			vi.stubEnv("NODE_ENV", "development");
 
-            clearAuthCookies(mockResponse as NextResponse);
+			clearAuthCookies(mockResponse as NextResponse);
 
-            const expectedCookies = [
-                ACCESS_TOKEN_COOKIE,
-                REFRESH_TOKEN_COOKIE,
-                USER_INFO_COOKIE,
-                DATABASE_ID_COOKIE,
-                OAUTH_STATE_COOKIE,
-            ];
+			const expectedCookies = [
+				ACCESS_TOKEN_COOKIE,
+				REFRESH_TOKEN_COOKIE,
+				USER_INFO_COOKIE,
+				DATABASE_ID_COOKIE,
+				OAUTH_STATE_COOKIE,
+			];
 
-            expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
+			expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
 
-            expectedCookies.forEach((cookieName) => {
-                expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
-                    httpOnly: true,
-                    secure: false,
-                    sameSite: "lax",
-                    path: "/",
-                    maxAge: 0,
-                });
-            });
-        });
+			expectedCookies.forEach((cookieName) => {
+				expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
+					httpOnly: true,
+					secure: false,
+					sameSite: "lax",
+					path: "/",
+					maxAge: 0,
+				});
+			});
+		});
 
-        it("should set secure flag to true in production", () => {
-            vi.stubEnv("NODE_ENV", "production");
+		it("should set secure flag to true in production", () => {
+			vi.stubEnv("NODE_ENV", "production");
 
-            clearAuthCookies(mockResponse as NextResponse);
+			clearAuthCookies(mockResponse as NextResponse);
 
-            const expectedCookies = [
-                ACCESS_TOKEN_COOKIE,
-                REFRESH_TOKEN_COOKIE,
-                USER_INFO_COOKIE,
-                DATABASE_ID_COOKIE,
-                OAUTH_STATE_COOKIE,
-            ];
+			const expectedCookies = [
+				ACCESS_TOKEN_COOKIE,
+				REFRESH_TOKEN_COOKIE,
+				USER_INFO_COOKIE,
+				DATABASE_ID_COOKIE,
+				OAUTH_STATE_COOKIE,
+			];
 
-            expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
+			expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
 
-            expectedCookies.forEach((cookieName) => {
-                expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
-                    httpOnly: true,
-                    secure: true,
-                    sameSite: "lax",
-                    path: "/",
-                    maxAge: 0,
-                });
-            });
-        });
-    });
+			expectedCookies.forEach((cookieName) => {
+				expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
+					httpOnly: true,
+					secure: true,
+					sameSite: "lax",
+					path: "/",
+					maxAge: 0,
+				});
+			});
+		});
+	});
 
-    describe("getAccessToken", () => {
-        beforeEach(() => {
-            vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
-        });
+	describe("getAccessToken", () => {
+		beforeEach(() => {
+			vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
+		});
 
-        afterEach(() => {
-            vi.unstubAllEnvs();
-        });
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
 
-        it("should return null if cookie is not present", () => {
-            const cookieStore = {
-                get: vi.fn().mockReturnValue(undefined),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-            expect(cookieStore.get).toHaveBeenCalledWith(ACCESS_TOKEN_COOKIE);
-        });
+		it("should return null if cookie is not present", () => {
+			const cookieStore = {
+				get: vi.fn().mockReturnValue(undefined),
+			};
+			expect(getAccessToken(cookieStore as any)).toBeNull();
+			expect(cookieStore.get).toHaveBeenCalledWith(ACCESS_TOKEN_COOKIE);
+		});
 
-        it("should return the token when valid cookie is present", () => {
-            const token = "valid-token-123";
-            const sealed = sealCookieValue({ token });
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: sealed }),
-            };
+		it("should return the token when valid cookie is present", () => {
+			const token = "valid-token-123";
+			const sealed = sealCookieValue({ token });
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: sealed }),
+			};
 
-            expect(getAccessToken(cookieStore as any)).toBe(token);
-        });
+			expect(getAccessToken(cookieStore as any)).toBe(token);
+		});
 
-        it("should return null when the cookie is malformed or invalid", () => {
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: "invalid.cookie.value" }),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-        });
+		it("should return null when the cookie is malformed or invalid", () => {
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: "invalid.cookie.value" }),
+			};
+			expect(getAccessToken(cookieStore as any)).toBeNull();
+		});
 
-        it("should return null when the cookie is valid but contains no token", () => {
-            const sealed = sealCookieValue({ notToken: "abc" } as any);
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: sealed }),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-        });
+		it("should return null when the cookie is valid but contains no token", () => {
+			const sealed = sealCookieValue({ notToken: "abc" } as any);
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: sealed }),
+			};
+			expect(getAccessToken(cookieStore as any)).toBeNull();
+		});
 
-        it("should return null when the cookie is valid but contains a non-string token", () => {
-            const sealed = sealCookieValue({ token: 12345 } as any);
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: sealed }),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-        });
-    });
+		it("should return null when the cookie is valid but contains a non-string token", () => {
+			const sealed = sealCookieValue({ token: 12345 } as any);
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: sealed }),
+			};
+			expect(getAccessToken(cookieStore as any)).toBeNull();
+		});
+	});
+
+	describe("buildNotionRedirectUri", () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		it("should use NEXT_PUBLIC_SITE_URL when available", () => {
+			vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://example.com");
+			const request = { headers: new Headers() } as any;
+			const uri = buildNotionRedirectUri(request);
+			expect(uri).toBe("https://example.com/api/auth/callback/notion");
+		});
+
+		it("should strip trailing slashes from NEXT_PUBLIC_SITE_URL", () => {
+			vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://example.com/");
+			const request = { headers: new Headers() } as any;
+			const uri = buildNotionRedirectUri(request);
+			expect(uri).toBe("https://example.com/api/auth/callback/notion");
+		});
+
+		it("should fallback to localhost:3000 when NEXT_PUBLIC_SITE_URL is not set", () => {
+			delete process.env.NEXT_PUBLIC_SITE_URL;
+			const request = { headers: new Headers() } as any;
+			const uri = buildNotionRedirectUri(request);
+			expect(uri).toBe("http://localhost:3000/api/auth/callback/notion");
+		});
+
+		it("should ignore Host header and x-forwarded headers to prevent injection", () => {
+			vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://trusted.com");
+			const request = {
+				headers: new Headers({
+					host: "evil.com",
+					"x-forwarded-host": "attacker.com",
+					"x-forwarded-proto": "http",
+				}),
+			} as any;
+
+			const uri = buildNotionRedirectUri(request);
+			expect(uri).toBe("https://trusted.com/api/auth/callback/notion");
+			expect(uri).not.toContain("evil.com");
+			expect(uri).not.toContain("attacker.com");
+		});
+	});
 });

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,200 +1,218 @@
-import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { Client } from "@notionhq/client";
-import { NextResponse } from "next/server";
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+import type { NextResponse } from "next/server";
 import {
-    ACCESS_TOKEN_COOKIE,
-    REFRESH_TOKEN_COOKIE,
-    USER_INFO_COOKIE,
-    DATABASE_ID_COOKIE,
-    OAUTH_STATE_COOKIE,
+	ACCESS_TOKEN_COOKIE,
+	DATABASE_ID_COOKIE,
+	OAUTH_STATE_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
 } from "@/lib/auth-cookies";
 
 export {
-    ACCESS_TOKEN_COOKIE,
-    REFRESH_TOKEN_COOKIE,
-    USER_INFO_COOKIE,
-    DATABASE_ID_COOKIE,
-    OAUTH_STATE_COOKIE,
+	ACCESS_TOKEN_COOKIE,
+	DATABASE_ID_COOKIE,
+	OAUTH_STATE_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
 };
 
 type CookieStore = {
-    get: (name: string) => { value: string } | undefined;
+	get: (name: string) => { value: string } | undefined;
 };
 
 type UserInfo = {
-    name?: string;
-    workspaceName?: string;
-    workspaceIcon?: string | null;
+	name?: string;
+	workspaceName?: string;
+	workspaceIcon?: string | null;
 };
 
 type RequestLike = {
-    headers: Headers;
+	headers: Headers;
 };
 
 function getSecret() {
-    const secret = process.env.COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET;
-    if (!secret) throw new Error("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
-    return secret;
+	const secret = process.env.COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET;
+	if (!secret) throw new Error("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
+	return secret;
 }
 
 function toBase64Url(input: string) {
-    return Buffer.from(input, "utf8").toString("base64url");
+	return Buffer.from(input, "utf8").toString("base64url");
 }
 
 function fromBase64Url(input: string) {
-    return Buffer.from(input, "base64url").toString("utf8");
+	return Buffer.from(input, "base64url").toString("utf8");
 }
 
 function signPayload(payload: string) {
-    return createHmac("sha256", getSecret()).update(payload).digest("base64url");
+	return createHmac("sha256", getSecret()).update(payload).digest("base64url");
 }
 
 export function sealCookieValue(data: unknown) {
-    const payload = toBase64Url(JSON.stringify(data));
-    const sig = signPayload(payload);
-    return `${payload}.${sig}`;
+	const payload = toBase64Url(JSON.stringify(data));
+	const sig = signPayload(payload);
+	return `${payload}.${sig}`;
 }
 
 export function unsealCookieValue<T>(value: string): T | null {
-    const [payload, sig] = value.split(".");
-    if (!payload || !sig) return null;
-    const expectedSig = signPayload(payload);
-    const expectedSigBuffer = Buffer.from(expectedSig);
-    const actualSigRaw = Buffer.from(sig);
-    const actualSigBuffer = Buffer.alloc(expectedSigBuffer.length);
-    actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length);
+	const [payload, sig] = value.split(".");
+	if (!payload || !sig) return null;
+	const expectedSig = signPayload(payload);
+	const expectedSigBuffer = Buffer.from(expectedSig);
+	const actualSigRaw = Buffer.from(sig);
+	const actualSigBuffer = Buffer.alloc(expectedSigBuffer.length);
+	actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length);
 
-    const signaturesMatch = timingSafeEqual(expectedSigBuffer, actualSigBuffer)
-        && actualSigRaw.length === expectedSigBuffer.length;
-    if (!signaturesMatch) return null;
-    try {
-        return JSON.parse(fromBase64Url(payload)) as T;
-    } catch {
-        return null;
-    }
+	const signaturesMatch =
+		timingSafeEqual(expectedSigBuffer, actualSigBuffer) &&
+		actualSigRaw.length === expectedSigBuffer.length;
+	if (!signaturesMatch) return null;
+	try {
+		return JSON.parse(fromBase64Url(payload)) as T;
+	} catch {
+		return null;
+	}
 }
 
 export function createStateToken() {
-    return randomBytes(16).toString("hex");
+	return randomBytes(16).toString("hex");
 }
 
 function isSecureRequest(request?: RequestLike) {
-    if (request) {
-        const forwardedProto = request.headers.get("x-forwarded-proto");
-        if (forwardedProto) return forwardedProto === "https";
-        const host = request.headers.get("host") ?? "";
-        return !host.startsWith("localhost");
-    }
-    return process.env.NODE_ENV === "production";
+	if (request) {
+		const forwardedProto = request.headers.get("x-forwarded-proto");
+		if (forwardedProto) return forwardedProto === "https";
+		const host = request.headers.get("host") ?? "";
+		return !host.startsWith("localhost");
+	}
+	return process.env.NODE_ENV === "production";
 }
 
-export function buildNotionRedirectUri(request: RequestLike) {
-    const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "localhost:3000";
-    const proto = request.headers.get("x-forwarded-proto") ?? (host.startsWith("localhost") ? "http" : "https");
-    return `${proto}://${host}/api/auth/callback/notion`;
+export function buildNotionRedirectUri(_request: RequestLike) {
+	const baseUrl =
+		process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ??
+		"http://localhost:3000";
+	return `${baseUrl}/api/auth/callback/notion`;
 }
 
 export function getAccessToken(cookieStore: CookieStore): string | null {
-    const raw = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
-    if (!raw) return null;
-    const parsed = unsealCookieValue<{ token: string }>(raw);
-    return typeof parsed?.token === "string" ? parsed.token : null;
+	const raw = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
+	if (!raw) return null;
+	const parsed = unsealCookieValue<{ token: string }>(raw);
+	return typeof parsed?.token === "string" ? parsed.token : null;
 }
 
 export function getRefreshToken(cookieStore: CookieStore): string | null {
-    const raw = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
-    if (!raw) return null;
-    const parsed = unsealCookieValue<{ token: string }>(raw);
-    return parsed?.token ?? null;
+	const raw = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
+	if (!raw) return null;
+	const parsed = unsealCookieValue<{ token: string }>(raw);
+	return parsed?.token ?? null;
 }
 
 export function getSelectedDatabaseId(cookieStore: CookieStore): string | null {
-    return cookieStore.get(DATABASE_ID_COOKIE)?.value ?? null;
+	return cookieStore.get(DATABASE_ID_COOKIE)?.value ?? null;
 }
 
 export function isAuthenticated(cookieStore: CookieStore): boolean {
-    return Boolean(getAccessToken(cookieStore));
+	return Boolean(getAccessToken(cookieStore));
 }
 
 export function getNotionClient(accessToken: string) {
-    return new Client({ auth: accessToken });
+	return new Client({ auth: accessToken });
 }
 
 export function getUserInfo(cookieStore: CookieStore): UserInfo | null {
-    const raw = cookieStore.get(USER_INFO_COOKIE)?.value;
-    if (!raw) return null;
-    return unsealCookieValue<UserInfo>(raw);
+	const raw = cookieStore.get(USER_INFO_COOKIE)?.value;
+	if (!raw) return null;
+	return unsealCookieValue<UserInfo>(raw);
 }
 
 export function setAuthCookies(
-    response: NextResponse,
-    payload: {
-        accessToken: string;
-        refreshToken: string;
-        userInfo?: UserInfo;
-        request?: RequestLike;
-    },
+	response: NextResponse,
+	payload: {
+		accessToken: string;
+		refreshToken: string;
+		userInfo?: UserInfo;
+		request?: RequestLike;
+	},
 ) {
-    const secure = isSecureRequest(payload.request);
-    response.cookies.set(ACCESS_TOKEN_COOKIE, sealCookieValue({ token: payload.accessToken }), {
-        httpOnly: true,
-        secure,
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60,
-    });
-    response.cookies.set(REFRESH_TOKEN_COOKIE, sealCookieValue({ token: payload.refreshToken }), {
-        httpOnly: true,
-        secure,
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-    });
-    if (payload.userInfo) {
-        response.cookies.set(USER_INFO_COOKIE, sealCookieValue(payload.userInfo), {
-            httpOnly: true,
-            secure,
-            sameSite: "lax",
-            path: "/",
-            maxAge: 60 * 60 * 24 * 30,
-        });
-    }
+	const secure = isSecureRequest(payload.request);
+	response.cookies.set(
+		ACCESS_TOKEN_COOKIE,
+		sealCookieValue({ token: payload.accessToken }),
+		{
+			httpOnly: true,
+			secure,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 60 * 60,
+		},
+	);
+	response.cookies.set(
+		REFRESH_TOKEN_COOKIE,
+		sealCookieValue({ token: payload.refreshToken }),
+		{
+			httpOnly: true,
+			secure,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 60 * 60 * 24 * 30,
+		},
+	);
+	if (payload.userInfo) {
+		response.cookies.set(USER_INFO_COOKIE, sealCookieValue(payload.userInfo), {
+			httpOnly: true,
+			secure,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 60 * 60 * 24 * 30,
+		});
+	}
 }
 
-export function setDatabaseCookie(response: NextResponse, databaseId: string, request?: RequestLike) {
-    response.cookies.set(DATABASE_ID_COOKIE, databaseId, {
-        httpOnly: true,
-        secure: isSecureRequest(request),
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-    });
+export function setDatabaseCookie(
+	response: NextResponse,
+	databaseId: string,
+	request?: RequestLike,
+) {
+	response.cookies.set(DATABASE_ID_COOKIE, databaseId, {
+		httpOnly: true,
+		secure: isSecureRequest(request),
+		sameSite: "lax",
+		path: "/",
+		maxAge: 60 * 60 * 24 * 30,
+	});
 }
 
-export function setOauthStateCookie(response: NextResponse, state: string, request: RequestLike) {
-    response.cookies.set(OAUTH_STATE_COOKIE, state, {
-        httpOnly: true,
-        secure: isSecureRequest(request),
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 10,
-    });
+export function setOauthStateCookie(
+	response: NextResponse,
+	state: string,
+	request: RequestLike,
+) {
+	response.cookies.set(OAUTH_STATE_COOKIE, state, {
+		httpOnly: true,
+		secure: isSecureRequest(request),
+		sameSite: "lax",
+		path: "/",
+		maxAge: 60 * 10,
+	});
 }
 
 export function clearAuthCookies(response: NextResponse) {
-    for (const name of [
-        ACCESS_TOKEN_COOKIE,
-        REFRESH_TOKEN_COOKIE,
-        USER_INFO_COOKIE,
-        DATABASE_ID_COOKIE,
-        OAUTH_STATE_COOKIE,
-    ]) {
-        response.cookies.set(name, "", {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === "production",
-            sameSite: "lax",
-            path: "/",
-            maxAge: 0,
-        });
-    }
+	for (const name of [
+		ACCESS_TOKEN_COOKIE,
+		REFRESH_TOKEN_COOKIE,
+		USER_INFO_COOKIE,
+		DATABASE_ID_COOKIE,
+		OAUTH_STATE_COOKIE,
+	]) {
+		response.cookies.set(name, "", {
+			httpOnly: true,
+			secure: process.env.NODE_ENV === "production",
+			sameSite: "lax",
+			path: "/",
+			maxAge: 0,
+		});
+	}
 }

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,218 +1,199 @@
-import { Client } from "@notionhq/client";
 import { createHmac, randomBytes, timingSafeEqual } from "crypto";
-import type { NextResponse } from "next/server";
+import { Client } from "@notionhq/client";
+import { NextResponse } from "next/server";
 import {
-	ACCESS_TOKEN_COOKIE,
-	DATABASE_ID_COOKIE,
-	OAUTH_STATE_COOKIE,
-	REFRESH_TOKEN_COOKIE,
-	USER_INFO_COOKIE,
+    ACCESS_TOKEN_COOKIE,
+    REFRESH_TOKEN_COOKIE,
+    USER_INFO_COOKIE,
+    DATABASE_ID_COOKIE,
+    OAUTH_STATE_COOKIE,
 } from "@/lib/auth-cookies";
 
 export {
-	ACCESS_TOKEN_COOKIE,
-	DATABASE_ID_COOKIE,
-	OAUTH_STATE_COOKIE,
-	REFRESH_TOKEN_COOKIE,
-	USER_INFO_COOKIE,
+    ACCESS_TOKEN_COOKIE,
+    REFRESH_TOKEN_COOKIE,
+    USER_INFO_COOKIE,
+    DATABASE_ID_COOKIE,
+    OAUTH_STATE_COOKIE,
 };
 
 type CookieStore = {
-	get: (name: string) => { value: string } | undefined;
+    get: (name: string) => { value: string } | undefined;
 };
 
 type UserInfo = {
-	name?: string;
-	workspaceName?: string;
-	workspaceIcon?: string | null;
+    name?: string;
+    workspaceName?: string;
+    workspaceIcon?: string | null;
 };
 
 type RequestLike = {
-	headers: Headers;
+    headers: Headers;
 };
 
 function getSecret() {
-	const secret = process.env.COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET;
-	if (!secret) throw new Error("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
-	return secret;
+    const secret = process.env.COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET;
+    if (!secret) throw new Error("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
+    return secret;
 }
 
 function toBase64Url(input: string) {
-	return Buffer.from(input, "utf8").toString("base64url");
+    return Buffer.from(input, "utf8").toString("base64url");
 }
 
 function fromBase64Url(input: string) {
-	return Buffer.from(input, "base64url").toString("utf8");
+    return Buffer.from(input, "base64url").toString("utf8");
 }
 
 function signPayload(payload: string) {
-	return createHmac("sha256", getSecret()).update(payload).digest("base64url");
+    return createHmac("sha256", getSecret()).update(payload).digest("base64url");
 }
 
 export function sealCookieValue(data: unknown) {
-	const payload = toBase64Url(JSON.stringify(data));
-	const sig = signPayload(payload);
-	return `${payload}.${sig}`;
+    const payload = toBase64Url(JSON.stringify(data));
+    const sig = signPayload(payload);
+    return `${payload}.${sig}`;
 }
 
 export function unsealCookieValue<T>(value: string): T | null {
-	const [payload, sig] = value.split(".");
-	if (!payload || !sig) return null;
-	const expectedSig = signPayload(payload);
-	const expectedSigBuffer = Buffer.from(expectedSig);
-	const actualSigRaw = Buffer.from(sig);
-	const actualSigBuffer = Buffer.alloc(expectedSigBuffer.length);
-	actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length);
+    const [payload, sig] = value.split(".");
+    if (!payload || !sig) return null;
+    const expectedSig = signPayload(payload);
+    const expectedSigBuffer = Buffer.from(expectedSig);
+    const actualSigRaw = Buffer.from(sig);
+    const actualSigBuffer = Buffer.alloc(expectedSigBuffer.length);
+    actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length);
 
-	const signaturesMatch =
-		timingSafeEqual(expectedSigBuffer, actualSigBuffer) &&
-		actualSigRaw.length === expectedSigBuffer.length;
-	if (!signaturesMatch) return null;
-	try {
-		return JSON.parse(fromBase64Url(payload)) as T;
-	} catch {
-		return null;
-	}
+    const signaturesMatch = timingSafeEqual(expectedSigBuffer, actualSigBuffer)
+        && actualSigRaw.length === expectedSigBuffer.length;
+    if (!signaturesMatch) return null;
+    try {
+        return JSON.parse(fromBase64Url(payload)) as T;
+    } catch {
+        return null;
+    }
 }
 
 export function createStateToken() {
-	return randomBytes(16).toString("hex");
+    return randomBytes(16).toString("hex");
 }
 
 function isSecureRequest(request?: RequestLike) {
-	if (request) {
-		const forwardedProto = request.headers.get("x-forwarded-proto");
-		if (forwardedProto) return forwardedProto === "https";
-		const host = request.headers.get("host") ?? "";
-		return !host.startsWith("localhost");
-	}
-	return process.env.NODE_ENV === "production";
+    if (request) {
+        const forwardedProto = request.headers.get("x-forwarded-proto");
+        if (forwardedProto) return forwardedProto === "https";
+        const host = request.headers.get("host") ?? "";
+        return !host.startsWith("localhost");
+    }
+    return process.env.NODE_ENV === "production";
 }
 
 export function buildNotionRedirectUri(_request: RequestLike) {
-	const baseUrl =
-		process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ??
-		"http://localhost:3000";
-	return `${baseUrl}/api/auth/callback/notion`;
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
+    return `${baseUrl}/api/auth/callback/notion`;
 }
 
 export function getAccessToken(cookieStore: CookieStore): string | null {
-	const raw = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
-	if (!raw) return null;
-	const parsed = unsealCookieValue<{ token: string }>(raw);
-	return typeof parsed?.token === "string" ? parsed.token : null;
+    const raw = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
+    if (!raw) return null;
+    const parsed = unsealCookieValue<{ token: string }>(raw);
+    return typeof parsed?.token === "string" ? parsed.token : null;
 }
 
 export function getRefreshToken(cookieStore: CookieStore): string | null {
-	const raw = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
-	if (!raw) return null;
-	const parsed = unsealCookieValue<{ token: string }>(raw);
-	return parsed?.token ?? null;
+    const raw = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
+    if (!raw) return null;
+    const parsed = unsealCookieValue<{ token: string }>(raw);
+    return parsed?.token ?? null;
 }
 
 export function getSelectedDatabaseId(cookieStore: CookieStore): string | null {
-	return cookieStore.get(DATABASE_ID_COOKIE)?.value ?? null;
+    return cookieStore.get(DATABASE_ID_COOKIE)?.value ?? null;
 }
 
 export function isAuthenticated(cookieStore: CookieStore): boolean {
-	return Boolean(getAccessToken(cookieStore));
+    return Boolean(getAccessToken(cookieStore));
 }
 
 export function getNotionClient(accessToken: string) {
-	return new Client({ auth: accessToken });
+    return new Client({ auth: accessToken });
 }
 
 export function getUserInfo(cookieStore: CookieStore): UserInfo | null {
-	const raw = cookieStore.get(USER_INFO_COOKIE)?.value;
-	if (!raw) return null;
-	return unsealCookieValue<UserInfo>(raw);
+    const raw = cookieStore.get(USER_INFO_COOKIE)?.value;
+    if (!raw) return null;
+    return unsealCookieValue<UserInfo>(raw);
 }
 
 export function setAuthCookies(
-	response: NextResponse,
-	payload: {
-		accessToken: string;
-		refreshToken: string;
-		userInfo?: UserInfo;
-		request?: RequestLike;
-	},
+    response: NextResponse,
+    payload: {
+        accessToken: string;
+        refreshToken: string;
+        userInfo?: UserInfo;
+        request?: RequestLike;
+    },
 ) {
-	const secure = isSecureRequest(payload.request);
-	response.cookies.set(
-		ACCESS_TOKEN_COOKIE,
-		sealCookieValue({ token: payload.accessToken }),
-		{
-			httpOnly: true,
-			secure,
-			sameSite: "lax",
-			path: "/",
-			maxAge: 60 * 60,
-		},
-	);
-	response.cookies.set(
-		REFRESH_TOKEN_COOKIE,
-		sealCookieValue({ token: payload.refreshToken }),
-		{
-			httpOnly: true,
-			secure,
-			sameSite: "lax",
-			path: "/",
-			maxAge: 60 * 60 * 24 * 30,
-		},
-	);
-	if (payload.userInfo) {
-		response.cookies.set(USER_INFO_COOKIE, sealCookieValue(payload.userInfo), {
-			httpOnly: true,
-			secure,
-			sameSite: "lax",
-			path: "/",
-			maxAge: 60 * 60 * 24 * 30,
-		});
-	}
+    const secure = isSecureRequest(payload.request);
+    response.cookies.set(ACCESS_TOKEN_COOKIE, sealCookieValue({ token: payload.accessToken }), {
+        httpOnly: true,
+        secure,
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 60,
+    });
+    response.cookies.set(REFRESH_TOKEN_COOKIE, sealCookieValue({ token: payload.refreshToken }), {
+        httpOnly: true,
+        secure,
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 60 * 24 * 30,
+    });
+    if (payload.userInfo) {
+        response.cookies.set(USER_INFO_COOKIE, sealCookieValue(payload.userInfo), {
+            httpOnly: true,
+            secure,
+            sameSite: "lax",
+            path: "/",
+            maxAge: 60 * 60 * 24 * 30,
+        });
+    }
 }
 
-export function setDatabaseCookie(
-	response: NextResponse,
-	databaseId: string,
-	request?: RequestLike,
-) {
-	response.cookies.set(DATABASE_ID_COOKIE, databaseId, {
-		httpOnly: true,
-		secure: isSecureRequest(request),
-		sameSite: "lax",
-		path: "/",
-		maxAge: 60 * 60 * 24 * 30,
-	});
+export function setDatabaseCookie(response: NextResponse, databaseId: string, request?: RequestLike) {
+    response.cookies.set(DATABASE_ID_COOKIE, databaseId, {
+        httpOnly: true,
+        secure: isSecureRequest(request),
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 60 * 24 * 30,
+    });
 }
 
-export function setOauthStateCookie(
-	response: NextResponse,
-	state: string,
-	request: RequestLike,
-) {
-	response.cookies.set(OAUTH_STATE_COOKIE, state, {
-		httpOnly: true,
-		secure: isSecureRequest(request),
-		sameSite: "lax",
-		path: "/",
-		maxAge: 60 * 10,
-	});
+export function setOauthStateCookie(response: NextResponse, state: string, request: RequestLike) {
+    response.cookies.set(OAUTH_STATE_COOKIE, state, {
+        httpOnly: true,
+        secure: isSecureRequest(request),
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 10,
+    });
 }
 
 export function clearAuthCookies(response: NextResponse) {
-	for (const name of [
-		ACCESS_TOKEN_COOKIE,
-		REFRESH_TOKEN_COOKIE,
-		USER_INFO_COOKIE,
-		DATABASE_ID_COOKIE,
-		OAUTH_STATE_COOKIE,
-	]) {
-		response.cookies.set(name, "", {
-			httpOnly: true,
-			secure: process.env.NODE_ENV === "production",
-			sameSite: "lax",
-			path: "/",
-			maxAge: 0,
-		});
-	}
+    for (const name of [
+        ACCESS_TOKEN_COOKIE,
+        REFRESH_TOKEN_COOKIE,
+        USER_INFO_COOKIE,
+        DATABASE_ID_COOKIE,
+        OAUTH_STATE_COOKIE,
+    ]) {
+        response.cookies.set(name, "", {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: "lax",
+            path: "/",
+            maxAge: 0,
+        });
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^2.4.9
         version: 2.4.9
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -100,8 +100,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -122,8 +122,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -147,8 +147,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -178,8 +178,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -203,8 +203,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -228,8 +228,8 @@ importers:
         specifier: ^22.19.11
         version: 22.19.11
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -316,8 +316,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -339,10 +339,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -622,105 +618,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -745,17 +725,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
-
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -793,28 +765,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -835,10 +803,6 @@ packages:
   '@notionhq/client@5.9.0':
     resolution: {integrity: sha512-TvAVMfwtVv61hsPrRfB9ehgzSjX6DaAi1ZRAnpg8xFjzaXhzhEfbO0PhBRm3ecSv1azDuO2kBuyQHh2/z7G4YQ==}
     engines: {node: '>=18'}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -874,79 +838,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1022,28 +973,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1153,15 +1100,6 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
-    peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
-    peerDependenciesMeta:
-      '@vitest/browser':
-        optional: true
-
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
@@ -1210,21 +1148,9 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -1233,17 +1159,11 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
-
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.2:
     resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
@@ -1259,9 +1179,6 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1292,13 +1209,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1309,10 +1219,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1335,15 +1241,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1383,15 +1280,6 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -1452,10 +1340,6 @@ packages:
       picomatch:
         optional: true
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -1475,11 +1359,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@13.0.3:
     resolution: {integrity: sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==}
@@ -1522,15 +1401,8 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1540,16 +1412,9 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -1613,28 +1478,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -1651,9 +1512,6 @@ packages:
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
-
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -1674,9 +1532,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
@@ -1704,16 +1559,9 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -1770,14 +1618,6 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
@@ -1865,20 +1705,8 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -1890,30 +1718,11 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1945,10 +1754,6 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1959,10 +1764,6 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -2111,23 +1912,10 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -2139,11 +1927,6 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -2396,18 +2179,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/cliui@9.0.0': {}
-
-  '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2462,9 +2234,6 @@ snapshots:
       - encoding
 
   '@notionhq/client@5.9.0': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -2689,25 +2458,6 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitest/coverage-v8@3.2.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/coverage-v8@4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -2775,27 +2525,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
   ansi-styles@5.2.0: {}
-
-  ansi-styles@6.2.3: {}
 
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
 
   assertion-error@2.0.1: {}
-
-  ast-v8-to-istanbul@0.3.12:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      estree-walker: 3.0.3
-      js-tokens: 10.0.0
 
   ast-v8-to-istanbul@1.0.0:
     dependencies:
@@ -2804,8 +2540,6 @@ snapshots:
       js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
-
-  balanced-match@1.0.2: {}
 
   balanced-match@4.0.2:
     dependencies:
@@ -2818,10 +2552,6 @@ snapshots:
       require-from-string: 2.0.2
 
   boolbase@1.0.0: {}
-
-  brace-expansion@2.0.3:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -2863,12 +2593,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -2876,12 +2600,6 @@ snapshots:
   commander@13.1.0: {}
 
   convert-source-map@2.0.0: {}
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -2908,10 +2626,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
 
   decimal.js@10.6.0: {}
 
@@ -2948,12 +2662,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  eastasianwidth@0.2.0: {}
-
-  emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -3027,11 +2735,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -3062,15 +2765,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@13.0.3:
     dependencies:
@@ -3113,11 +2807,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  is-fullwidth-code-point@3.0.0: {}
-
   is-potential-custom-element-name@1.0.1: {}
-
-  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -3127,24 +2817,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -3233,8 +2909,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
-  lru-cache@10.4.3: {}
-
   lru-cache@11.2.6: {}
 
   lru-cache@11.2.7: {}
@@ -3248,12 +2922,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  magicast@0.3.5:
-    dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
-      source-map-js: 1.2.1
 
   magicast@0.5.2:
     dependencies:
@@ -3279,13 +2947,7 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.0.3
-
   minipass@7.1.2: {}
-
-  ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
@@ -3341,13 +3003,6 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
-
-  path-key@3.1.1: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
 
   path-scurry@2.0.1:
     dependencies:
@@ -3476,15 +3131,7 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
   siginfo@2.0.0: {}
-
-  signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
 
@@ -3492,31 +3139,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
   std-env@4.0.0: {}
 
   std-env@4.1.0: {}
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
@@ -3535,12 +3160,6 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  test-exclude@7.0.2:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.5.0
-      minimatch: 10.2.4
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -3549,8 +3168,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-
-  tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.1.0: {}
 
@@ -3651,26 +3268,10 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
🎯 **What:**
Fixes a Host Header Injection vulnerability in `buildNotionRedirectUri` where the redirect URI was constructed using dynamic incoming request headers.

⚠️ **Risk:**
Attackers could manipulate the `Host` or `X-Forwarded-Host` headers to point to a malicious server. When an innocent user initiates the OAuth flow, they could be redirected to the attacker's server upon completion, leaking the authorization code and compromising the account.

🛡️ **Solution:**
Changed `buildNotionRedirectUri` to construct the redirect URI using a static environment variable (`NEXT_PUBLIC_SITE_URL`) instead of trusting request headers. Added fallback to `http://localhost:3000` for development and added comprehensive tests to ensure `host` headers are safely ignored. Documented the required configuration in `.env.local.example`.

---
*PR created automatically by Jules for task [13223891966270956902](https://jules.google.com/task/13223891966270956902) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuth のリダイレクト URI 構築において、リクエストヘッダー（`host` / `x-forwarded-host`）を信頼していた Host Header Injection 脆弱性を修正します。`buildNotionRedirectUri` を静的環境変数 `NEXT_PUBLIC_SITE_URL` ベースに変更し、ヘッダー操作による悪意のあるリダイレクト先への誘導を防止します。

- `buildNotionRedirectUri` がリクエストヘッダーを参照せず `NEXT_PUBLIC_SITE_URL` 環境変数のみを使用するよう変更され、不正リダイレクトのリスクが排除された。
- テストスイートに `buildNotionRedirectUri` の4つのケース（通常・スラッシュ除去・フォールバック・ヘッダー無視）が追加された。
- `.env.local.example` に `NEXT_PUBLIC_SITE_URL` の設定例が追記されたが、`??` 演算子が空文字列をフォールバックしない点に欠陥がある（空文字列セット時に相対パスが生成される）。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

セキュリティ修正の方向性は正しいが、`NEXT_PUBLIC_SITE_URL` が空文字列の場合に OAuth リダイレクト URI が壊れるコードパスがあるため、マージ前に修正が望ましい。

`buildNotionRedirectUri` の `??` 演算子が空文字列をフォールバックしないため、`NEXT_PUBLIC_SITE_URL=""` が設定されると `/api/auth/callback/notion` という相対パスが生成され、認証フロー全体が機能しなくなる。また `isSecureRequest` が引き続き攻撃者操作可能な `x-forwarded-proto` ヘッダーに依存している点も残存しており、複数の懸念が重なっている。

`packages/web/src/lib/auth.ts` — `buildNotionRedirectUri` の空文字列ハンドリングと `isSecureRequest` のヘッダー依存について確認が必要。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/lib/auth.ts | `buildNotionRedirectUri` をリクエストヘッダーから静的環境変数 `NEXT_PUBLIC_SITE_URL` ベースに変更。ただし `??` 演算子が空文字列をフォールバックしないため、`NEXT_PUBLIC_SITE_URL=""` 時に壊れたリダイレクト URI が生成される欠陥がある。また `_request` パラメータが残存するデッドコードになっている。 |
| packages/web/src/lib/auth.test.ts | `buildNotionRedirectUri` 向けの新テストを追加。`NEXT_PUBLIC_SITE_URL` の利用・トレイリングスラッシュ除去・フォールバック・ヘッダー無視の4ケースをカバーしており適切。 |
| packages/web/.env.local.example | `NEXT_PUBLIC_SITE_URL` の設定例を追加。コメントが英語になっており、既存の日本語コメントと統一されていない。 |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as ユーザー
    participant App as Next.js App
    participant Env as 環境変数(NEXT_PUBLIC_SITE_URL)
    participant Notion as Notion OAuth

    U->>App: OAuth ログイン開始
    App->>Env: NEXT_PUBLIC_SITE_URL を読み取り
    Env-->>App: https://example.com（静的値）
    App->>App: buildNotionRedirectUri() → https://example.com/api/auth/callback/notion
    App->>Notion: "redirect_uri=https://example.com/... でリダイレクト"
    Notion-->>U: 認可コード付きコールバック
    U->>App: "/api/auth/callback/notion?code=..."
    App->>Notion: アクセストークン取得
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as ユーザー
    participant App as Next.js App
    participant Env as 環境変数(NEXT_PUBLIC_SITE_URL)
    participant Notion as Notion OAuth

    U->>App: OAuth ログイン開始
    App->>Env: NEXT_PUBLIC_SITE_URL を読み取り
    Env-->>App: https://example.com（静的値）
    App->>App: buildNotionRedirectUri() → https://example.com/api/auth/callback/notion
    App->>Notion: "redirect_uri=https://example.com/... でリダイレクト"
    Notion-->>U: 認可コード付きコールバック
    U->>App: "/api/auth/callback/notion?code=..."
    App->>Notion: アクセストークン取得
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/web/src/lib/auth.ts:93-95
`NEXT_PUBLIC_SITE_URL` が空文字列（`""`）にセットされている場合、`??` 演算子は `null`/`undefined` のみをフォールバックとして扱うため、`baseUrl` が `""` になってしまいます。その結果、リダイレクト URI が `/api/auth/callback/notion` という相対パスになり、OAuth プロバイダーが URI を拒否して認証フローが完全に破綻します。`||` を使って空文字列もフォールバック対象にするのが安全です。

```suggestion
	const baseUrl =
		process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
		"http://localhost:3000";
```

### Issue 2 of 4
packages/web/src/lib/auth.ts:92
`buildNotionRedirectUri` はリクエストヘッダーを一切参照しなくなったため、`_request` パラメータはデッドコードです。将来の開発者がリクエストオブジェクトの内容が影響を持つと誤解する可能性があります。パラメータを削除してシグネチャをシンプルにすることをお勧めします（呼び出し元も合わせて更新が必要です）。

```suggestion
export function buildNotionRedirectUri() {
```

### Issue 3 of 4
packages/web/.env.local.example:10-11
ファイル内の既存コメントはすべて日本語で記述されているため、新たに追加されたコメントも日本語に統一するとよいでしょう。

```suggestion
# アプリケーションURL（OAuth リダイレクトコールバックで使用）
NEXT_PUBLIC_SITE_URL=http://localhost:3000
```

### Issue 4 of 4
packages/web/src/lib/auth.ts:82-90
**`isSecureRequest` が引き続き `x-forwarded-proto` ヘッダーを信頼している**

`buildNotionRedirectUri` の修正とは別に、`isSecureRequest` 関数は攻撃者が操作可能な `x-forwarded-proto` および `host` ヘッダーに基づいてクッキーの `secure` フラグを決定し続けています。`x-forwarded-proto: http` を偽造されると本番環境でも `secure: false` になり、認証クッキーが HTTP 経由で送信されうる状態になります。これは本 PR 以前から存在する問題ですが、`NEXT_PUBLIC_SITE_URL` を使って `proto` を導出するよう合わせて修正することが望ましいです。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix Host Header Injection in Notion O..."](https://github.com/hiroki-org/paper-tools/commit/e4c936701ad864fa328d54cb7561342fe2785a00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38999984)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->