### PR TITLE
🧹 Remove redundant any type assertion in Notion OAuth refresh route

### DIFF
--- a/packages/web/src/app/api/auth/refresh/route.ts
+++ b/packages/web/src/app/api/auth/refresh/route.ts
@@ -1,65 +1,74 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getRefreshToken, getUserInfo, setAuthCookies } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
-    const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
-    const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
-    if (!clientId || !clientSecret) {
-        return NextResponse.json({ error: "OAuth config is missing" }, { status: 500 });
-    }
+	const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
+	const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
+	if (!clientId || !clientSecret) {
+		return NextResponse.json(
+			{ error: "OAuth config is missing" },
+			{ status: 500 },
+		);
+	}
 
-    const refreshToken = getRefreshToken(request.cookies);
-    if (!refreshToken) {
-        return NextResponse.json({ error: "refresh_token not found" }, { status: 401 });
-    }
+	const refreshToken = getRefreshToken(request.cookies);
+	if (!refreshToken) {
+		return NextResponse.json(
+			{ error: "refresh_token not found" },
+			{ status: 401 },
+		);
+	}
 
-    try {
-        const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
-        const tokenRes = await fetch("https://api.notion.com/v1/oauth/token", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Notion-Version": "2025-09-03",
-                Authorization: `Basic ${basic}`,
-            },
-            body: JSON.stringify({
-                grant_type: "refresh_token",
-                refresh_token: refreshToken,
-            }),
-        });
-        const tokenResponse = (await tokenRes.json()) as {
-            access_token?: string;
-            refresh_token?: string;
-            workspace_name?: string | null;
-            workspace_icon?: string | null;
-            error?: string;
-        };
-        if (!tokenRes.ok || !tokenResponse.access_token) {
-            return NextResponse.json(
-                { error: tokenResponse.error ?? "Refresh failed" },
-                { status: tokenRes.status || 401 },
-            );
-        }
-        const nextRefreshToken = (tokenResponse as any).refresh_token as string | undefined;
-        if (!nextRefreshToken) {
-            return NextResponse.json({ error: "refresh_token missing in response" }, { status: 502 });
-        }
+	try {
+		const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+		const tokenRes = await fetch("https://api.notion.com/v1/oauth/token", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Notion-Version": "2025-09-03",
+				Authorization: `Basic ${basic}`,
+			},
+			body: JSON.stringify({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+			}),
+		});
+		const tokenResponse = (await tokenRes.json()) as {
+			access_token?: string;
+			refresh_token?: string;
+			workspace_name?: string | null;
+			workspace_icon?: string | null;
+			error?: string;
+		};
+		if (!tokenRes.ok || !tokenResponse.access_token) {
+			return NextResponse.json(
+				{ error: tokenResponse.error ?? "Refresh failed" },
+				{ status: tokenRes.status || 401 },
+			);
+		}
+		const nextRefreshToken = tokenResponse.refresh_token as string | undefined;
+		if (!nextRefreshToken) {
+			return NextResponse.json(
+				{ error: "refresh_token missing in response" },
+				{ status: 502 },
+			);
+		}
 
-        const userInfo = getUserInfo(request.cookies) ?? {
-            workspaceName: tokenResponse.workspace_name ?? undefined,
-            workspaceIcon: tokenResponse.workspace_icon,
-        };
+		const userInfo = getUserInfo(request.cookies) ?? {
+			workspaceName: tokenResponse.workspace_name ?? undefined,
+			workspaceIcon: tokenResponse.workspace_icon,
+		};
 
-        const response = NextResponse.json({ success: true });
-        setAuthCookies(response, {
-            accessToken: tokenResponse.access_token,
-            refreshToken: nextRefreshToken,
-            userInfo,
-            request,
-        });
-        return response;
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Refresh failed";
-        return NextResponse.json({ error: message }, { status: 401 });
-    }
+		const response = NextResponse.json({ success: true });
+		setAuthCookies(response, {
+			accessToken: tokenResponse.access_token,
+			refreshToken: nextRefreshToken,
+			userInfo,
+			request,
+		});
+		return response;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Refresh failed";
+		return NextResponse.json({ error: message }, { status: 401 });
+	}
 }


### PR DESCRIPTION
🎯 **What:**
Removed a redundant `as any` type assertion when accessing `refresh_token` from the `tokenResponse` object in `packages/web/src/app/api/auth/refresh/route.ts`. 

💡 **Why:**
The `tokenResponse` object is already explicitly typed to include `refresh_token?: string;`. Bypassing this explicit type checking with `any` makes the code less robust and maintainable. Removing it improves type safety and code clarity.

✅ **Verification:**
1. Ran `pnpm dlx @biomejs/biome check packages/web/src/app/api/auth/refresh/route.ts --write` to ensure proper formatting and linting.
2. Verified unit tests in `packages/web` passing successfully via `pnpm vitest src/app/api/auth/refresh/route.test.ts`.

✨ **Result:**
Improved code health by enhancing type safety without altering any existing business logic or API behavior.

---
*PR created automatically by Jules for task [10245820180269102240](https://jules.google.com/task/10245820180269102240) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuth リフレッシュルートから `(tokenResponse as any).refresh_token` の冗長な `as any` 型アサーションを削除し、型安全性を向上させた変更です。あわせてインデントをスペース4つからタブへ統一し、`NextRequest` を type-only import に変更しています。

- `as any` を取り除いたことで型チェックが正しく機能するようになりました。ただし、`tokenResponse.refresh_token` はすでに `string | undefined` と型付けされているため、残存する `as string | undefined` キャストも同様に冗長です。
- フォーマット変更（インデント・長い行の折り返し）はビジネスロジックに影響せず、問題ありません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更内容はシンプルで、既存のビジネスロジックやAPI挙動への影響はありません。マージして問題ないと判断できます。

`as any` の除去自体は正しい改善ですが、同じ行に残存している `as string | undefined` キャストが依然として冗長であり、型安全性の改善が完全には達成できていません。フォーマット変更は適切です。

対象ファイルは `packages/web/src/app/api/auth/refresh/route.ts` のみ。残存キャストの除去を検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/refresh/route.ts | `as any` を削除して型安全性を改善。インデントとフォーマットも整理。残存する `as string | undefined` が依然として冗長。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Route as POST /api/auth/refresh
    participant Notion as Notion OAuth API

    Client->>Route: POST (with refresh_token cookie)
    Route->>Route: getRefreshToken(cookies)
    alt refresh_token なし
        Route-->>Client: 401 refresh_token not found
    end
    Route->>Notion: POST /v1/oauth/token (grant_type: refresh_token)
    alt 失敗 or access_token なし
        Notion-->>Route: error response
        Route-->>Client: 401/4xx Refresh failed
    end
    Notion-->>Route: "{ access_token, refresh_token, ... }"
    alt refresh_token なし
        Route-->>Client: 502 refresh_token missing in response
    end
    Route->>Route: setAuthCookies(accessToken, refreshToken)
    Route-->>Client: "200 { success: true }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Route as POST /api/auth/refresh
    participant Notion as Notion OAuth API

    Client->>Route: POST (with refresh_token cookie)
    Route->>Route: getRefreshToken(cookies)
    alt refresh_token なし
        Route-->>Client: 401 refresh_token not found
    end
    Route->>Notion: POST /v1/oauth/token (grant_type: refresh_token)
    alt 失敗 or access_token なし
        Notion-->>Route: error response
        Route-->>Client: 401/4xx Refresh failed
    end
    Notion-->>Route: "{ access_token, refresh_token, ... }"
    alt refresh_token なし
        Route-->>Client: 502 refresh_token missing in response
    end
    Route->>Route: setAuthCookies(accessToken, refreshToken)
    Route-->>Client: "200 { success: true }"
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web/src/app/api/auth/refresh/route.ts:49
`tokenResponse` はすでに `{ refresh_token?: string; ... }` として型付けされているため、`as string | undefined` のキャストは冗長です。`as any` を取り除いた今、この残存キャストも削除することで型安全性の改善を完結できます。

```suggestion
		const nextRefreshToken = tokenResponse.refresh_token;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove redundant any type assertion i..."](https://github.com/hiroki-org/paper-tools/commit/7377a034fba7808a8f76ab327f05a3926b7448ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41903131)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->