### PR TITLE
🔒 Fix Missing Input Validation in POST /api/archive

### DIFF
--- a/packages/web/src/app/api/archive/route.test.ts
+++ b/packages/web/src/app/api/archive/route.test.ts
@@ -253,6 +253,37 @@ describe("/api/archive", () => {
             expect(data.error).toBe("Create Error");
         });
 
+
+        it("ignores non-string tags and processes valid ones gracefully", async () => {
+            vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValueOnce({
+                object: "data_source",
+                id: "fake-ds-id",
+                title: [{ plain_text: "Fake Database" }],
+                properties: {
+                    "Name": { type: "title", title: {} },
+                    "DOI": { type: "rich_text", rich_text: {} },
+                    "Semantic Scholar": { type: "rich_text", rich_text: {} },
+                    "Tags": { type: "multi_select", multi_select: {} },
+                },
+            });
+            const req = new NextRequest("http://localhost/api/archive", {
+                method: "POST",
+                body: JSON.stringify({ paper: mockPaper, tags: [{}, 123, "valid tag", null, "   another tag   "] }),
+            });
+            await POST(req);
+
+            expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+                properties: expect.objectContaining({
+                    "Tags": {
+                        multi_select: [
+                            { name: "valid tag" },
+                            { name: "another tag" }
+                        ]
+                    }
+                }),
+            }));
+        });
+
         it("returns 500 on non-Error error in POST", async () => {
             mockCreate.mockRejectedValueOnce("Unknown Create Error");
             const req = new NextRequest("http://localhost/api/archive", {

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -161,6 +161,7 @@ export async function POST(request: NextRequest) {
             if (tagsType === "multi_select") {
                 const tagMap = new Map<string, string>();
                 for (const rawTag of body.tags) {
+                    if (typeof rawTag !== "string") continue;
                     const normalized = rawTag.trim();
                     if (!normalized) continue;
                     const dedupeKey = normalized.toLowerCase();


### PR DESCRIPTION
🎯 **What:**
Added proper type validation for the tags array when processing `POST /api/archive` requests to ensure tags are actually strings before processing them.

⚠️ **Risk:**
Without this validation, the endpoint could crash with an unhandled exception (and return a 500 status code) if a malicious or malformed payload provided non-string values inside the tags array, such as `tags: [{}]`, because it immediately called `.trim()` on the item. This could be abused.

🛡️ **Solution:**
Added a `typeof rawTag !== "string"` check within the tag processing loop. Invalid tags are skipped, preventing the exception and correctly passing only valid strings to Notion. A corresponding unit test was also added to ensure non-string tags are handled properly and valid tags are processed correctly from mixed arrays.

---
*PR created automatically by Jules for task [8772432624329292267](https://jules.google.com/task/8772432624329292267) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`POST /api/archive` のタグ処理ループに `typeof rawTag !== "string"` チェックを1行追加し、非文字列値（オブジェクト、数値、null 等）が送られた際の未ハンドル例外（500エラー）を修正しました。

- **route.ts**: タグループの先頭に型チェックを追加し、非文字列はスキップするよう変更。既存のトリム・空文字・重複除去ロジックはそのまま維持されています。
- **route.test.ts**: `[{}, 123, "valid tag", null, "   another tag   "]` という混合配列を送信し、有効な文字列タグのみが Notion に渡されることを検証するテストケースを追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は最小限かつ正確で、タグ処理ループの一点に限定されたバグ修正です。マージして問題ありません。

追加されたのは1行の型ガードのみで、既存ロジックへの影響はありません。テストも追加されており、修正の意図が明確に検証されています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/archive/route.ts | タグ処理ループに `typeof rawTag !== "string"` チェックを1行追加し、非文字列値でのクラッシュを修正。変更は最小限かつ正確。 |
| packages/web/src/app/api/archive/route.test.ts | 混合型配列のテストケースを追加。`mockCreate` の呼び出し引数は検証しているが、HTTP レスポンスのステータスコードを検証していない。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant POST as POST /api/archive
    participant Auth as parseAuth
    participant Notion as Notion API

    Client->>POST: "POST { paper, tags: [混合型配列] }"
    POST->>Auth: "アクセストークン & DB ID 確認"
    Auth-->>POST: OK
    POST->>Notion: resolveNotionDataSource
    Notion-->>POST: dataSource (properties含む)
    POST->>POST: tags配列をループ処理
    Note over POST: typeof rawTag !== "string" → スキップ<br/>string → trim → 空文字チェック → 重複除去
    POST->>Notion: "pages.create({ properties })"
    Notion-->>POST: 成功
    POST-->>Client: "{ success: true }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant POST as POST /api/archive
    participant Auth as parseAuth
    participant Notion as Notion API

    Client->>POST: "POST { paper, tags: [混合型配列] }"
    POST->>Auth: "アクセストークン & DB ID 確認"
    Auth-->>POST: OK
    POST->>Notion: resolveNotionDataSource
    Notion-->>POST: dataSource (properties含む)
    POST->>POST: tags配列をループ処理
    Note over POST: typeof rawTag !== "string" → スキップ<br/>string → trim → 空文字チェック → 重複除去
    POST->>Notion: "pages.create({ properties })"
    Notion-->>POST: 成功
    POST-->>Client: "{ success: true }"
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-archive-tag..."](https://github.com/hiroki-org/paper-tools/commit/830971fa758503b946a00a27e609f841911d06cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41903604)</sub>

<!-- /greptile_comment -->