### PR TITLE
🧪 Add edge case tests for toCorePaper function

### DIFF
--- a/packages/author-profiler/src/tests/profile-builder.test.ts
+++ b/packages/author-profiler/src/tests/profile-builder.test.ts
@@ -35,6 +35,25 @@ describe("profile-builder helpers", () => {
         });
     });
 
+    it("toCorePaper handles missing optional fields like authors", () => {
+        const mapped = toCorePaper({
+            title: "Partial Paper",
+        } as any);
+
+        expect(mapped).toEqual({
+            title: "Partial Paper",
+            authors: [],
+            doi: undefined,
+            year: undefined,
+            venue: undefined,
+            abstract: undefined,
+            url: undefined,
+            citationCount: undefined,
+            referenceCount: undefined,
+            keywords: undefined,
+        });
+    });
+
     it("mergeAffiliations deduplicates by name/year", () => {
         const merged = mergeAffiliations(
             [


### PR DESCRIPTION
🎯 **What:**
Added a test case for the `toCorePaper` mapping function in `packages/author-profiler/src/services/profile-builder.ts` to verify its behavior when handling inputs with missing optional fields. 

📊 **Coverage:**
The new test case covers the edge conditions in `toCorePaper`, specifically ensuring that the mapping handles undefined inputs gracefully, such as mapping `paper.authors` (which resolves to an empty array `[]` when authors are missing) and leaving other omitted fields undefined.

✨ **Result:**
Improved the branch coverage and robustness for `toCorePaper` and the author profiler services, providing a stronger test safety net.

---
*PR created automatically by Jules for task [14858592133327339696](https://jules.google.com/task/14858592133327339696) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `toCorePaper` 関数に対して、`authors` などのオプションフィールドが欠落している場合のエッジケーステストを追加するものです。実装本体への変更はなく、テストファイル1ファイルのみが変更されています。

- `paper.authors` が `undefined` の場合に `?? []` フォールバックが正しく `[]` を返すことを検証するテストケースを追加
- `externalIds`、`year`、`venue` など他のオプションフィールドが `undefined` になることもアサートしており、`toCorePaper` の分岐カバレッジを向上させている
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更であり、本体コードへの影響はなく、マージしても安全です。

`toEqual` を使用して `undefined` 値をアサートしている箇所で、意図した通りの厳密な検証になっていない可能性があります。現在の実装では全フィールドが明示的に返されるため実害はありませんが、将来的なリグレッション検出力が若干低下します。

packages/author-profiler/src/tests/profile-builder.test.ts — `toEqual` を `toStrictEqual` に変更することを検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/author-profiler/src/tests/profile-builder.test.ts | toCorePaper のエッジケーステストを追加。toEqual が undefined プロパティを無視するため、欠落フィールドの検証が意図より弱い可能性がある。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["toCorePaper(paper: S2Paper)"] --> B{paper.authors?}
    B -- "undefined/null" --> C["authors: []"]
    B -- "存在する" --> D["authors: paper.authors.map(a => name)"]
    A --> E{paper.externalIds?}
    E -- "undefined" --> F["doi: undefined"]
    E -- "存在する" --> G["doi: paper.externalIds.DOI"]
    A --> H["year / venue / abstract / url\ncitationCount / referenceCount / keywords\n(undefined if not present)"]
    C --> I["Paper オブジェクトを返す"]
    D --> I
    F --> I
    G --> I
    H --> I

    subgraph 新テスト
        T1["入力: { title: 'Partial Paper' }"] --> A
        I --> T2["toStrictEqual 推奨\n(現在は toEqual)"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["toCorePaper(paper: S2Paper)"] --> B{paper.authors?}
    B -- "undefined/null" --> C["authors: []"]
    B -- "存在する" --> D["authors: paper.authors.map(a => name)"]
    A --> E{paper.externalIds?}
    E -- "undefined" --> F["doi: undefined"]
    E -- "存在する" --> G["doi: paper.externalIds.DOI"]
    A --> H["year / venue / abstract / url\ncitationCount / referenceCount / keywords\n(undefined if not present)"]
    C --> I["Paper オブジェクトを返す"]
    D --> I
    F --> I
    G --> I
    H --> I

    subgraph 新テスト
        T1["入力: { title: 'Partial Paper' }"] --> A
        I --> T2["toStrictEqual 推奨\n(現在は toEqual)"]
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/author-profiler/src/tests/profile-builder.test.ts:43-54
Vitest の `toEqual` は、**期待オブジェクト内の `undefined` プロパティを「存在しない」と同一視して無視します**。つまり `doi: undefined` などのアサーションは実質的にノーオペレーションとなり、実装が `doi` キーを省略して返すように変更されても、このテストはそのまま通過してしまいます。欠落フィールドの undefined を厳密に検証したい（「キーが存在するが undefined」と「キーが存在しない」を区別したい）場合は、`toStrictEqual` を使用してください。なお、既存のハッピーパステスト（9〜36行目）は全フィールドに具体的な値があるため問題になりませんが、このエッジケーステストのように undefined を意図的にアサートする場面では `toStrictEqual` がより適切です。

```suggestion
        expect(mapped).toStrictEqual({
            title: "Partial Paper",
            authors: [],
            doi: undefined,
            year: undefined,
            venue: undefined,
            abstract: undefined,
            url: undefined,
            citationCount: undefined,
            referenceCount: undefined,
            keywords: undefined,
        });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add test case for toCorePaper func..."](https://github.com/hiroki-org/paper-tools/commit/795bff5bd601aa5826daa01fc166186925a4c395) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41904562)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->