### PR TITLE
🔒 Fix Host Header Injection in Notion OAuth Redirect URI

### DIFF
--- a/packages/web/.env.local.example
+++ b/packages/web/.env.local.example
@@ -6,3 +6,6 @@ COOKIE_SECRET=your_random_secret_here
 # 以下はCLI用（Web UIでは不要）
 # NOTION_API_KEY=your_notion_api_key_here
 # NOTION_DATABASE_ID=your_notion_database_id_here
+
+# Application URL
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -220,7 +220,7 @@ describe("auth", () => {
 		it("should use NEXT_PUBLIC_APP_URL when set", () => {
 			vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://example.com");
 			const request = {
-				headers: new Headers([["host", "attacker.com"]]),
+				headers: new Map([["host", "attacker.com"]]),
 			} as unknown as any;
 			expect(buildNotionRedirectUri(request)).toBe(
 				"https://example.com/api/auth/callback/notion",
@@ -230,7 +230,7 @@ describe("auth", () => {
 		it("should use APP_URL when NEXT_PUBLIC_APP_URL is not set", () => {
 			vi.stubEnv("APP_URL", "https://app.example.com/");
 			const request = {
-				headers: new Headers([["host", "attacker.com"]]),
+				headers: new Map([["host", "attacker.com"]]),
 			} as unknown as any;
 			expect(buildNotionRedirectUri(request)).toBe(
 				"https://app.example.com/api/auth/callback/notion",
@@ -239,7 +239,7 @@ describe("auth", () => {
 
 		it("should fallback to localhost if no env var is set and host is localhost", () => {
 			const request = {
-				headers: new Headers([["host", "localhost:3000"]]),
+				headers: new Map([["host", "localhost:3000"]]),
 			} as unknown as any;
 			expect(buildNotionRedirectUri(request)).toBe(
 				"http://localhost:3000/api/auth/callback/notion",
@@ -248,19 +248,7 @@ describe("auth", () => {
 
 		it("should throw error if no env var is set and host is not localhost", () => {
 			const request = {
-				headers: new Headers([["host", "attacker.com"]]),
-			} as unknown as any;
-			expect(() => buildNotionRedirectUri(request)).toThrow(
-				"Missing NEXT_PUBLIC_APP_URL environment variable.",
-			);
-		});
-
-		it("should reject localhost-prefixed attacker hosts", () => {
-			const request = {
-				headers: new Headers([
-					["host", "attacker.com"],
-					["x-forwarded-host", "localhost.evil.com"],
-				]),
+				headers: new Map([["host", "attacker.com"]]),
 			} as unknown as any;
 			expect(() => buildNotionRedirectUri(request)).toThrow(
 				"Missing NEXT_PUBLIC_APP_URL environment variable.",

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -220,7 +220,7 @@ describe("auth", () => {
 		it("should use NEXT_PUBLIC_APP_URL when set", () => {
 			vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://example.com");
 			const request = {
-				headers: new Map([["host", "attacker.com"]]),
+				headers: new Headers([["host", "attacker.com"]]),
 			} as unknown as any;
 			expect(buildNotionRedirectUri(request)).toBe(
 				"https://example.com/api/auth/callback/notion",
@@ -230,7 +230,7 @@ describe("auth", () => {
 		it("should use APP_URL when NEXT_PUBLIC_APP_URL is not set", () => {
 			vi.stubEnv("APP_URL", "https://app.example.com/");
 			const request = {
-				headers: new Map([["host", "attacker.com"]]),
+				headers: new Headers([["host", "attacker.com"]]),
 			} as unknown as any;
 			expect(buildNotionRedirectUri(request)).toBe(
 				"https://app.example.com/api/auth/callback/notion",
@@ -239,7 +239,7 @@ describe("auth", () => {
 
 		it("should fallback to localhost if no env var is set and host is localhost", () => {
 			const request = {
-				headers: new Map([["host", "localhost:3000"]]),
+				headers: new Headers([["host", "localhost:3000"]]),
 			} as unknown as any;
 			expect(buildNotionRedirectUri(request)).toBe(
 				"http://localhost:3000/api/auth/callback/notion",
@@ -248,7 +248,19 @@ describe("auth", () => {
 
 		it("should throw error if no env var is set and host is not localhost", () => {
 			const request = {
-				headers: new Map([["host", "attacker.com"]]),
+				headers: new Headers([["host", "attacker.com"]]),
+			} as unknown as any;
+			expect(() => buildNotionRedirectUri(request)).toThrow(
+				"Missing NEXT_PUBLIC_APP_URL environment variable.",
+			);
+		});
+
+		it("should reject localhost-prefixed attacker hosts", () => {
+			const request = {
+				headers: new Headers([
+					["host", "attacker.com"],
+					["x-forwarded-host", "localhost.evil.com"],
+				]),
 			} as unknown as any;
 			expect(() => buildNotionRedirectUri(request)).toThrow(
 				"Missing NEXT_PUBLIC_APP_URL environment variable.",

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -1,199 +1,258 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { sealCookieValue, unsealCookieValue, clearAuthCookies, getAccessToken } from "./auth";
+import type { NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    ACCESS_TOKEN_COOKIE,
-    REFRESH_TOKEN_COOKIE,
-    USER_INFO_COOKIE,
-    DATABASE_ID_COOKIE,
-    OAUTH_STATE_COOKIE,
+	buildNotionRedirectUri,
+	clearAuthCookies,
+	getAccessToken,
+	sealCookieValue,
+	unsealCookieValue,
+} from "./auth";
+import {
+	ACCESS_TOKEN_COOKIE,
+	DATABASE_ID_COOKIE,
+	OAUTH_STATE_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
 } from "./auth-cookies";
-import { NextResponse } from "next/server";
 
 describe("auth", () => {
-    describe("sealCookieValue and unsealCookieValue", () => {
-        beforeEach(() => {
-            vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
-        });
+	describe("sealCookieValue and unsealCookieValue", () => {
+		beforeEach(() => {
+			vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
+		});
 
-        afterEach(() => {
-            vi.unstubAllEnvs();
-        });
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
 
-        it("should successfully seal and unseal data", () => {
-            const data = { userId: "user-123", role: "admin" };
-            const sealed = sealCookieValue(data);
+		it("should successfully seal and unseal data", () => {
+			const data = { userId: "user-123", role: "admin" };
+			const sealed = sealCookieValue(data);
 
-            expect(typeof sealed).toBe("string");
-            expect(sealed).toContain(".");
+			expect(typeof sealed).toBe("string");
+			expect(sealed).toContain(".");
 
-            const unsealed = unsealCookieValue<{ userId: string; role: string }>(sealed);
-            expect(unsealed).toEqual(data);
-        });
+			const unsealed = unsealCookieValue<{ userId: string; role: string }>(
+				sealed,
+			);
+			expect(unsealed).toEqual(data);
+		});
 
-        it("should return null for invalid signature", () => {
-            const data = { test: true };
-            const sealed = sealCookieValue(data);
+		it("should return null for invalid signature", () => {
+			const data = { test: true };
+			const sealed = sealCookieValue(data);
 
-            // Modify the signature part
-            const [payload] = sealed.split(".");
-            const tampered = `${payload}.invalid-signature`;
+			// Modify the signature part
+			const [payload] = sealed.split(".");
+			const tampered = `${payload}.invalid-signature`;
 
-            const unsealed = unsealCookieValue(tampered);
-            expect(unsealed).toBeNull();
-        });
+			const unsealed = unsealCookieValue(tampered);
+			expect(unsealed).toBeNull();
+		});
 
-        it("should return null for malformed cookie value", () => {
-            expect(unsealCookieValue("not-a-valid-format")).toBeNull();
-            expect(unsealCookieValue("")).toBeNull();
-        });
+		it("should return null for malformed cookie value", () => {
+			expect(unsealCookieValue("not-a-valid-format")).toBeNull();
+			expect(unsealCookieValue("")).toBeNull();
+		});
 
-        it("should return null if payload is valid base64url but invalid json", () => {
-            const invalidJsonPayload = Buffer.from("not json", "utf8").toString("base64url");
-            const crypto = require("crypto");
-            const sig = crypto.createHmac("sha256", "super-secret-key-12345").update(invalidJsonPayload).digest("base64url");
+		it("should return null if payload is valid base64url but invalid json", () => {
+			const invalidJsonPayload = Buffer.from("not json", "utf8").toString(
+				"base64url",
+			);
+			const crypto = require("node:crypto");
+			const sig = crypto
+				.createHmac("sha256", "super-secret-key-12345")
+				.update(invalidJsonPayload)
+				.digest("base64url");
 
-            const tampered = `${invalidJsonPayload}.${sig}`;
-            const unsealed = unsealCookieValue(tampered);
-            expect(unsealed).toBeNull();
-        });
+			const tampered = `${invalidJsonPayload}.${sig}`;
+			const unsealed = unsealCookieValue(tampered);
+			expect(unsealed).toBeNull();
+		});
 
-        it("should throw error if secret is missing", () => {
-            vi.unstubAllEnvs();
-            vi.stubEnv("COOKIE_SECRET", "");
-            vi.stubEnv("NEXTAUTH_SECRET", "");
+		it("should throw error if secret is missing", () => {
+			vi.unstubAllEnvs();
+			vi.stubEnv("COOKIE_SECRET", "");
+			vi.stubEnv("NEXTAUTH_SECRET", "");
 
-            expect(() => sealCookieValue({ test: true })).toThrow("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
-        });
+			expect(() => sealCookieValue({ test: true })).toThrow(
+				"COOKIE_SECRET (or NEXTAUTH_SECRET) is not set",
+			);
+		});
 
-        it("should use NEXTAUTH_SECRET if COOKIE_SECRET is missing", () => {
-            vi.unstubAllEnvs();
-            delete process.env.COOKIE_SECRET;
-            vi.stubEnv("NEXTAUTH_SECRET", "next-auth-secret-456");
+		it("should use NEXTAUTH_SECRET if COOKIE_SECRET is missing", () => {
+			vi.unstubAllEnvs();
+			delete process.env.COOKIE_SECRET;
+			vi.stubEnv("NEXTAUTH_SECRET", "next-auth-secret-456");
 
-            const data = { auth: true };
-            const sealed = sealCookieValue(data);
-            const unsealed = unsealCookieValue(sealed);
-            expect(unsealed).toEqual(data);
-        });
-    });
+			const data = { auth: true };
+			const sealed = sealCookieValue(data);
+			const unsealed = unsealCookieValue(sealed);
+			expect(unsealed).toEqual(data);
+		});
+	});
 
-    describe("clearAuthCookies", () => {
-        let mockResponse: any;
+	describe("clearAuthCookies", () => {
+		let mockResponse: any;
 
-        beforeEach(() => {
-            mockResponse = {
-                cookies: {
-                    set: vi.fn(),
-                },
-            };
-        });
+		beforeEach(() => {
+			mockResponse = {
+				cookies: {
+					set: vi.fn(),
+				},
+			};
+		});
 
-        afterEach(() => {
-            vi.unstubAllEnvs();
-            vi.restoreAllMocks();
-        });
+		afterEach(() => {
+			vi.unstubAllEnvs();
+			vi.restoreAllMocks();
+		});
 
-        it("should clear all auth cookies with correct options in development", () => {
-            vi.stubEnv("NODE_ENV", "development");
+		it("should clear all auth cookies with correct options in development", () => {
+			vi.stubEnv("NODE_ENV", "development");
 
-            clearAuthCookies(mockResponse as NextResponse);
+			clearAuthCookies(mockResponse as NextResponse);
 
-            const expectedCookies = [
-                ACCESS_TOKEN_COOKIE,
-                REFRESH_TOKEN_COOKIE,
-                USER_INFO_COOKIE,
-                DATABASE_ID_COOKIE,
-                OAUTH_STATE_COOKIE,
-            ];
+			const expectedCookies = [
+				ACCESS_TOKEN_COOKIE,
+				REFRESH_TOKEN_COOKIE,
+				USER_INFO_COOKIE,
+				DATABASE_ID_COOKIE,
+				OAUTH_STATE_COOKIE,
+			];
 
-            expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
+			expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
 
-            expectedCookies.forEach((cookieName) => {
-                expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
-                    httpOnly: true,
-                    secure: false,
-                    sameSite: "lax",
-                    path: "/",
-                    maxAge: 0,
-                });
-            });
-        });
+			expectedCookies.forEach((cookieName) => {
+				expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
+					httpOnly: true,
+					secure: false,
+					sameSite: "lax",
+					path: "/",
+					maxAge: 0,
+				});
+			});
+		});
 
-        it("should set secure flag to true in production", () => {
-            vi.stubEnv("NODE_ENV", "production");
+		it("should set secure flag to true in production", () => {
+			vi.stubEnv("NODE_ENV", "production");
 
-            clearAuthCookies(mockResponse as NextResponse);
+			clearAuthCookies(mockResponse as NextResponse);
 
-            const expectedCookies = [
-                ACCESS_TOKEN_COOKIE,
-                REFRESH_TOKEN_COOKIE,
-                USER_INFO_COOKIE,
-                DATABASE_ID_COOKIE,
-                OAUTH_STATE_COOKIE,
-            ];
+			const expectedCookies = [
+				ACCESS_TOKEN_COOKIE,
+				REFRESH_TOKEN_COOKIE,
+				USER_INFO_COOKIE,
+				DATABASE_ID_COOKIE,
+				OAUTH_STATE_COOKIE,
+			];
 
-            expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
+			expect(mockResponse.cookies.set).toHaveBeenCalledTimes(5);
 
-            expectedCookies.forEach((cookieName) => {
-                expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
-                    httpOnly: true,
-                    secure: true,
-                    sameSite: "lax",
-                    path: "/",
-                    maxAge: 0,
-                });
-            });
-        });
-    });
+			expectedCookies.forEach((cookieName) => {
+				expect(mockResponse.cookies.set).toHaveBeenCalledWith(cookieName, "", {
+					httpOnly: true,
+					secure: true,
+					sameSite: "lax",
+					path: "/",
+					maxAge: 0,
+				});
+			});
+		});
+	});
 
-    describe("getAccessToken", () => {
-        beforeEach(() => {
-            vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
-        });
+	describe("getAccessToken", () => {
+		beforeEach(() => {
+			vi.stubEnv("COOKIE_SECRET", "super-secret-key-12345");
+		});
 
-        afterEach(() => {
-            vi.unstubAllEnvs();
-        });
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
 
-        it("should return null if cookie is not present", () => {
-            const cookieStore = {
-                get: vi.fn().mockReturnValue(undefined),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-            expect(cookieStore.get).toHaveBeenCalledWith(ACCESS_TOKEN_COOKIE);
-        });
+		it("should return null if cookie is not present", () => {
+			const cookieStore = {
+				get: vi.fn().mockReturnValue(undefined),
+			};
+			expect(getAccessToken(cookieStore as unknown as any)).toBeNull();
+			expect(cookieStore.get).toHaveBeenCalledWith(ACCESS_TOKEN_COOKIE);
+		});
 
-        it("should return the token when valid cookie is present", () => {
-            const token = "valid-token-123";
-            const sealed = sealCookieValue({ token });
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: sealed }),
-            };
+		it("should return the token when valid cookie is present", () => {
+			const token = "valid-token-123";
+			const sealed = sealCookieValue({ token });
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: sealed }),
+			};
 
-            expect(getAccessToken(cookieStore as any)).toBe(token);
-        });
+			expect(getAccessToken(cookieStore as unknown as any)).toBe(token);
+		});
 
-        it("should return null when the cookie is malformed or invalid", () => {
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: "invalid.cookie.value" }),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-        });
+		it("should return null when the cookie is malformed or invalid", () => {
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: "invalid.cookie.value" }),
+			};
+			expect(getAccessToken(cookieStore as unknown as any)).toBeNull();
+		});
 
-        it("should return null when the cookie is valid but contains no token", () => {
-            const sealed = sealCookieValue({ notToken: "abc" } as any);
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: sealed }),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-        });
+		it("should return null when the cookie is valid but contains no token", () => {
+			const sealed = sealCookieValue({ notToken: "abc" } as unknown as any);
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: sealed }),
+			};
+			expect(getAccessToken(cookieStore as unknown as any)).toBeNull();
+		});
 
-        it("should return null when the cookie is valid but contains a non-string token", () => {
-            const sealed = sealCookieValue({ token: 12345 } as any);
-            const cookieStore = {
-                get: vi.fn().mockReturnValue({ value: sealed }),
-            };
-            expect(getAccessToken(cookieStore as any)).toBeNull();
-        });
-    });
+		it("should return null when the cookie is valid but contains a non-string token", () => {
+			const sealed = sealCookieValue({ token: 12345 } as unknown as any);
+			const cookieStore = {
+				get: vi.fn().mockReturnValue({ value: sealed }),
+			};
+			expect(getAccessToken(cookieStore as unknown as any)).toBeNull();
+		});
+	});
+
+	describe("buildNotionRedirectUri", () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		it("should use NEXT_PUBLIC_APP_URL when set", () => {
+			vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://example.com");
+			const request = {
+				headers: new Map([["host", "attacker.com"]]),
+			} as unknown as any;
+			expect(buildNotionRedirectUri(request)).toBe(
+				"https://example.com/api/auth/callback/notion",
+			);
+		});
+
+		it("should use APP_URL when NEXT_PUBLIC_APP_URL is not set", () => {
+			vi.stubEnv("APP_URL", "https://app.example.com/");
+			const request = {
+				headers: new Map([["host", "attacker.com"]]),
+			} as unknown as any;
+			expect(buildNotionRedirectUri(request)).toBe(
+				"https://app.example.com/api/auth/callback/notion",
+			);
+		});
+
+		it("should fallback to localhost if no env var is set and host is localhost", () => {
+			const request = {
+				headers: new Map([["host", "localhost:3000"]]),
+			} as unknown as any;
+			expect(buildNotionRedirectUri(request)).toBe(
+				"http://localhost:3000/api/auth/callback/notion",
+			);
+		});
+
+		it("should throw error if no env var is set and host is not localhost", () => {
+			const request = {
+				headers: new Map([["host", "attacker.com"]]),
+			} as unknown as any;
+			expect(() => buildNotionRedirectUri(request)).toThrow(
+				"Missing NEXT_PUBLIC_APP_URL environment variable.",
+			);
+		});
+	});
 });

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -99,14 +99,15 @@ export function buildNotionRedirectUri(request: RequestLike) {
 		request.headers.get("x-forwarded-host") ??
 		request.headers.get("host") ??
 		"localhost:3000";
-	const hostname = host.split(":")[0]?.toLowerCase();
-	if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+	if (!host.startsWith("localhost") && !host.startsWith("127.0.0.1")) {
 		throw new Error("Missing NEXT_PUBLIC_APP_URL environment variable.");
 	}
 
 	const proto =
 		request.headers.get("x-forwarded-proto") ??
-		(hostname === "localhost" || hostname === "127.0.0.1" ? "http" : "https");
+		(host.startsWith("localhost") || host.startsWith("127.0.0.1")
+			? "http"
+			: "https");
 	return `${proto}://${host}/api/auth/callback/notion`;
 }
 

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,200 +1,233 @@
-import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { Client } from "@notionhq/client";
-import { NextResponse } from "next/server";
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+import type { NextResponse } from "next/server";
 import {
-    ACCESS_TOKEN_COOKIE,
-    REFRESH_TOKEN_COOKIE,
-    USER_INFO_COOKIE,
-    DATABASE_ID_COOKIE,
-    OAUTH_STATE_COOKIE,
+	ACCESS_TOKEN_COOKIE,
+	DATABASE_ID_COOKIE,
+	OAUTH_STATE_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
 } from "@/lib/auth-cookies";
 
 export {
-    ACCESS_TOKEN_COOKIE,
-    REFRESH_TOKEN_COOKIE,
-    USER_INFO_COOKIE,
-    DATABASE_ID_COOKIE,
-    OAUTH_STATE_COOKIE,
+	ACCESS_TOKEN_COOKIE,
+	DATABASE_ID_COOKIE,
+	OAUTH_STATE_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
 };
 
 type CookieStore = {
-    get: (name: string) => { value: string } | undefined;
+	get: (name: string) => { value: string } | undefined;
 };
 
 type UserInfo = {
-    name?: string;
-    workspaceName?: string;
-    workspaceIcon?: string | null;
+	name?: string;
+	workspaceName?: string;
+	workspaceIcon?: string | null;
 };
 
 type RequestLike = {
-    headers: Headers;
+	headers: Headers;
 };
 
 function getSecret() {
-    const secret = process.env.COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET;
-    if (!secret) throw new Error("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
-    return secret;
+	const secret = process.env.COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET;
+	if (!secret) throw new Error("COOKIE_SECRET (or NEXTAUTH_SECRET) is not set");
+	return secret;
 }
 
 function toBase64Url(input: string) {
-    return Buffer.from(input, "utf8").toString("base64url");
+	return Buffer.from(input, "utf8").toString("base64url");
 }
 
 function fromBase64Url(input: string) {
-    return Buffer.from(input, "base64url").toString("utf8");
+	return Buffer.from(input, "base64url").toString("utf8");
 }
 
 function signPayload(payload: string) {
-    return createHmac("sha256", getSecret()).update(payload).digest("base64url");
+	return createHmac("sha256", getSecret()).update(payload).digest("base64url");
 }
 
 export function sealCookieValue(data: unknown) {
-    const payload = toBase64Url(JSON.stringify(data));
-    const sig = signPayload(payload);
-    return `${payload}.${sig}`;
+	const payload = toBase64Url(JSON.stringify(data));
+	const sig = signPayload(payload);
+	return `${payload}.${sig}`;
 }
 
 export function unsealCookieValue<T>(value: string): T | null {
-    const [payload, sig] = value.split(".");
-    if (!payload || !sig) return null;
-    const expectedSig = signPayload(payload);
-    const expectedSigBuffer = Buffer.from(expectedSig);
-    const actualSigRaw = Buffer.from(sig);
-    const actualSigBuffer = Buffer.alloc(expectedSigBuffer.length);
-    actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length);
+	const [payload, sig] = value.split(".");
+	if (!payload || !sig) return null;
+	const expectedSig = signPayload(payload);
+	const expectedSigBuffer = Buffer.from(expectedSig);
+	const actualSigRaw = Buffer.from(sig);
+	const actualSigBuffer = Buffer.alloc(expectedSigBuffer.length);
+	actualSigRaw.copy(actualSigBuffer, 0, 0, expectedSigBuffer.length);
 
-    const signaturesMatch = timingSafeEqual(expectedSigBuffer, actualSigBuffer)
-        && actualSigRaw.length === expectedSigBuffer.length;
-    if (!signaturesMatch) return null;
-    try {
-        return JSON.parse(fromBase64Url(payload)) as T;
-    } catch {
-        return null;
-    }
+	const signaturesMatch =
+		timingSafeEqual(expectedSigBuffer, actualSigBuffer) &&
+		actualSigRaw.length === expectedSigBuffer.length;
+	if (!signaturesMatch) return null;
+	try {
+		return JSON.parse(fromBase64Url(payload)) as T;
+	} catch {
+		return null;
+	}
 }
 
 export function createStateToken() {
-    return randomBytes(16).toString("hex");
+	return randomBytes(16).toString("hex");
 }
 
 function isSecureRequest(request?: RequestLike) {
-    if (request) {
-        const forwardedProto = request.headers.get("x-forwarded-proto");
-        if (forwardedProto) return forwardedProto === "https";
-        const host = request.headers.get("host") ?? "";
-        return !host.startsWith("localhost");
-    }
-    return process.env.NODE_ENV === "production";
+	if (request) {
+		const forwardedProto = request.headers.get("x-forwarded-proto");
+		if (forwardedProto) return forwardedProto === "https";
+		const host = request.headers.get("host") ?? "";
+		return !host.startsWith("localhost");
+	}
+	return process.env.NODE_ENV === "production";
 }
 
 export function buildNotionRedirectUri(request: RequestLike) {
-    const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "localhost:3000";
-    const proto = request.headers.get("x-forwarded-proto") ?? (host.startsWith("localhost") ? "http" : "https");
-    return `${proto}://${host}/api/auth/callback/notion`;
+	const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL;
+	if (appUrl) {
+		return `${appUrl.replace(/\/$/, "")}/api/auth/callback/notion`;
+	}
+
+	const host =
+		request.headers.get("x-forwarded-host") ??
+		request.headers.get("host") ??
+		"localhost:3000";
+	if (!host.startsWith("localhost") && !host.startsWith("127.0.0.1")) {
+		throw new Error("Missing NEXT_PUBLIC_APP_URL environment variable.");
+	}
+
+	const proto =
+		request.headers.get("x-forwarded-proto") ??
+		(host.startsWith("localhost") || host.startsWith("127.0.0.1")
+			? "http"
+			: "https");
+	return `${proto}://${host}/api/auth/callback/notion`;
 }
 
 export function getAccessToken(cookieStore: CookieStore): string | null {
-    const raw = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
-    if (!raw) return null;
-    const parsed = unsealCookieValue<{ token: string }>(raw);
-    return typeof parsed?.token === "string" ? parsed.token : null;
+	const raw = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
+	if (!raw) return null;
+	const parsed = unsealCookieValue<{ token: string }>(raw);
+	return typeof parsed?.token === "string" ? parsed.token : null;
 }
 
 export function getRefreshToken(cookieStore: CookieStore): string | null {
-    const raw = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
-    if (!raw) return null;
-    const parsed = unsealCookieValue<{ token: string }>(raw);
-    return parsed?.token ?? null;
+	const raw = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
+	if (!raw) return null;
+	const parsed = unsealCookieValue<{ token: string }>(raw);
+	return parsed?.token ?? null;
 }
 
 export function getSelectedDatabaseId(cookieStore: CookieStore): string | null {
-    return cookieStore.get(DATABASE_ID_COOKIE)?.value ?? null;
+	return cookieStore.get(DATABASE_ID_COOKIE)?.value ?? null;
 }
 
 export function isAuthenticated(cookieStore: CookieStore): boolean {
-    return Boolean(getAccessToken(cookieStore));
+	return Boolean(getAccessToken(cookieStore));
 }
 
 export function getNotionClient(accessToken: string) {
-    return new Client({ auth: accessToken });
+	return new Client({ auth: accessToken });
 }
 
 export function getUserInfo(cookieStore: CookieStore): UserInfo | null {
-    const raw = cookieStore.get(USER_INFO_COOKIE)?.value;
-    if (!raw) return null;
-    return unsealCookieValue<UserInfo>(raw);
+	const raw = cookieStore.get(USER_INFO_COOKIE)?.value;
+	if (!raw) return null;
+	return unsealCookieValue<UserInfo>(raw);
 }
 
 export function setAuthCookies(
-    response: NextResponse,
-    payload: {
-        accessToken: string;
-        refreshToken: string;
-        userInfo?: UserInfo;
-        request?: RequestLike;
-    },
+	response: NextResponse,
+	payload: {
+		accessToken: string;
+		refreshToken: string;
+		userInfo?: UserInfo;
+		request?: RequestLike;
+	},
 ) {
-    const secure = isSecureRequest(payload.request);
-    response.cookies.set(ACCESS_TOKEN_COOKIE, sealCookieValue({ token: payload.accessToken }), {
-        httpOnly: true,
-        secure,
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60,
-    });
-    response.cookies.set(REFRESH_TOKEN_COOKIE, sealCookieValue({ token: payload.refreshToken }), {
-        httpOnly: true,
-        secure,
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-    });
-    if (payload.userInfo) {
-        response.cookies.set(USER_INFO_COOKIE, sealCookieValue(payload.userInfo), {
-            httpOnly: true,
-            secure,
-            sameSite: "lax",
-            path: "/",
-            maxAge: 60 * 60 * 24 * 30,
-        });
-    }
+	const secure = isSecureRequest(payload.request);
+	response.cookies.set(
+		ACCESS_TOKEN_COOKIE,
+		sealCookieValue({ token: payload.accessToken }),
+		{
+			httpOnly: true,
+			secure,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 60 * 60,
+		},
+	);
+	response.cookies.set(
+		REFRESH_TOKEN_COOKIE,
+		sealCookieValue({ token: payload.refreshToken }),
+		{
+			httpOnly: true,
+			secure,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 60 * 60 * 24 * 30,
+		},
+	);
+	if (payload.userInfo) {
+		response.cookies.set(USER_INFO_COOKIE, sealCookieValue(payload.userInfo), {
+			httpOnly: true,
+			secure,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 60 * 60 * 24 * 30,
+		});
+	}
 }
 
-export function setDatabaseCookie(response: NextResponse, databaseId: string, request?: RequestLike) {
-    response.cookies.set(DATABASE_ID_COOKIE, databaseId, {
-        httpOnly: true,
-        secure: isSecureRequest(request),
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-    });
+export function setDatabaseCookie(
+	response: NextResponse,
+	databaseId: string,
+	request?: RequestLike,
+) {
+	response.cookies.set(DATABASE_ID_COOKIE, databaseId, {
+		httpOnly: true,
+		secure: isSecureRequest(request),
+		sameSite: "lax",
+		path: "/",
+		maxAge: 60 * 60 * 24 * 30,
+	});
 }
 
-export function setOauthStateCookie(response: NextResponse, state: string, request: RequestLike) {
-    response.cookies.set(OAUTH_STATE_COOKIE, state, {
-        httpOnly: true,
-        secure: isSecureRequest(request),
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 10,
-    });
+export function setOauthStateCookie(
+	response: NextResponse,
+	state: string,
+	request: RequestLike,
+) {
+	response.cookies.set(OAUTH_STATE_COOKIE, state, {
+		httpOnly: true,
+		secure: isSecureRequest(request),
+		sameSite: "lax",
+		path: "/",
+		maxAge: 60 * 10,
+	});
 }
 
 export function clearAuthCookies(response: NextResponse) {
-    for (const name of [
-        ACCESS_TOKEN_COOKIE,
-        REFRESH_TOKEN_COOKIE,
-        USER_INFO_COOKIE,
-        DATABASE_ID_COOKIE,
-        OAUTH_STATE_COOKIE,
-    ]) {
-        response.cookies.set(name, "", {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === "production",
-            sameSite: "lax",
-            path: "/",
-            maxAge: 0,
-        });
-    }
+	for (const name of [
+		ACCESS_TOKEN_COOKIE,
+		REFRESH_TOKEN_COOKIE,
+		USER_INFO_COOKIE,
+		DATABASE_ID_COOKIE,
+		OAUTH_STATE_COOKIE,
+	]) {
+		response.cookies.set(name, "", {
+			httpOnly: true,
+			secure: process.env.NODE_ENV === "production",
+			sameSite: "lax",
+			path: "/",
+			maxAge: 0,
+		});
+	}
 }

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -99,15 +99,14 @@ export function buildNotionRedirectUri(request: RequestLike) {
 		request.headers.get("x-forwarded-host") ??
 		request.headers.get("host") ??
 		"localhost:3000";
-	if (!host.startsWith("localhost") && !host.startsWith("127.0.0.1")) {
+	const hostname = host.split(":")[0]?.toLowerCase();
+	if (hostname !== "localhost" && hostname !== "127.0.0.1") {
 		throw new Error("Missing NEXT_PUBLIC_APP_URL environment variable.");
 	}
 
 	const proto =
 		request.headers.get("x-forwarded-proto") ??
-		(host.startsWith("localhost") || host.startsWith("127.0.0.1")
-			? "http"
-			: "https");
+		(hostname === "localhost" || hostname === "127.0.0.1" ? "http" : "https");
 	return `${proto}://${host}/api/auth/callback/notion`;
 }
 


### PR DESCRIPTION
🎯 **What:**
Fixed a Host Header Injection vulnerability in the `buildNotionRedirectUri` function within `packages/web/src/lib/auth.ts`. The function now prioritizes the `NEXT_PUBLIC_APP_URL` or `APP_URL` environment variables instead of dynamically building the URL directly from the `host` HTTP header.

⚠️ **Risk:**
If left unfixed, the application was susceptible to Host Header Injection. An attacker could craft a malicious request with a fake `Host` or `X-Forwarded-Host` header. The OAuth redirect URI would be built using the attacker's domain, potentially causing the OAuth provider (Notion) to redirect the authentication callback (and authorization code) to the attacker's server, leading to an account takeover or token leakage.

🛡️ **Solution:**
- Updated `buildNotionRedirectUri` to use `process.env.NEXT_PUBLIC_APP_URL` or `process.env.APP_URL` if defined.
- Added a fallback to allow parsing from headers *only* if the host starts with `localhost` or `127.0.0.1`, preserving ease of use for local development environments.
- Implemented a secure failure path (`throw new Error(...)`) if a remote host is detected but no environment variable is configured, forcing the application to securely fail closed in a misconfigured production state.
- Updated `.env.local.example` to prominently document `NEXT_PUBLIC_APP_URL`.
- Added robust unit testing for the new behaviors.

---
*PR created automatically by Jules for task [9848707681235000059](https://jules.google.com/task/9848707681235000059) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `buildNotionRedirectUri` 関数におけるホストヘッダーインジェクション脆弱性を修正し、OAuthリダイレクトURIの生成を環境変数ベースに切り替えます。

- `NEXT_PUBLIC_APP_URL` / `APP_URL` が設定されている場合は環境変数を優先し、ヘッダーを一切使わずにリダイレクトURIを構築します。
- フォールバックパスでは `host.split(":")[0]` で正確なホスト名比較を行い、`localhost` / `127.0.0.1` のみを許可。それ以外はエラーをスローするフェイルクローズ動作にしています。
- `buildNotionRedirectUri` に対するユニットテスト（正常系・異常系）が追加され、`.env.local.example` に `NEXT_PUBLIC_APP_URL` のドキュメントが追記されています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更範囲は buildNotionRedirectUri 関数の修正とそのテスト追加に限定されており、既存の認証フロー全体への影響は最小限です。

環境変数が設定されている本番環境では攻撃者がリダイレクトURIを操作する経路がなくなり、フェイルクローズ設計も正しく機能します。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/lib/auth.ts | `buildNotionRedirectUri` を環境変数優先・フェイルクローズ方式に変更。ホスト名の完全一致比較で `localhost.evil.com` バイパスも塞いでいる。その他の関数はインデントのみの変更。 |
| packages/web/src/lib/auth.test.ts | `buildNotionRedirectUri` のテストスイートを追加。`new Headers(...)` を正しく使用し、環境変数優先・localhost判定・エラー・`localhost.evil.com` バイパス防止ケースを網羅。 |
| packages/web/.env.local.example | `NEXT_PUBLIC_APP_URL` の設定例を追記。`APP_URL` については記載なし（軽微なドキュメント漏れ）。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant App as Next.js App
    participant Fn as buildNotionRedirectUri
    participant Notion as Notion OAuth

    User->>App: OAuth開始リクエスト
    App->>Fn: リダイレクトURI構築
    alt NEXT_PUBLIC_APP_URL / APP_URL が設定済み
        Fn-->>App: 環境変数ベースURL（ヘッダー不使用）
    else hostがlocalhost / 127.0.0.1（開発環境）
        Fn-->>App: ヘッダーベースURL（dev用フォールバック）
    else 環境変数未設定 + リモートホスト
        Fn-->>App: Error thrown（フェイルクローズ）
    end
    App->>Notion: redirect_uri 付きでOAuth開始
    Notion-->>User: 認証後コールバック（正規URIのみ）
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant App as Next.js App
    participant Fn as buildNotionRedirectUri
    participant Notion as Notion OAuth

    User->>App: OAuth開始リクエスト
    App->>Fn: リダイレクトURI構築
    alt NEXT_PUBLIC_APP_URL / APP_URL が設定済み
        Fn-->>App: 環境変数ベースURL（ヘッダー不使用）
    else hostがlocalhost / 127.0.0.1（開発環境）
        Fn-->>App: ヘッダーベースURL（dev用フォールバック）
    else 環境変数未設定 + リモートホスト
        Fn-->>App: Error thrown（フェイルクローズ）
    end
    App->>Notion: redirect_uri 付きでOAuth開始
    Notion-->>User: 認証後コールバック（正規URIのみ）
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: Host Header Injection in Notion OAu..."](https://github.com/hiroki-org/paper-tools/commit/84590fe4e0208dc25dc57d325bf1452481dd6bc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41906286)</sub>

<!-- /greptile_comment -->