### PR TITLE
🧪 [testing] add edge case tests for recommender pagination

### DIFF
--- a/packages/recommender/package.json
+++ b/packages/recommender/package.json
@@ -30,6 +30,6 @@
     "@types/node": "^22.19.11",
     "@vitest/coverage-v8": "^4.1.4",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/recommender/package.json
+++ b/packages/recommender/package.json
@@ -30,6 +30,6 @@
     "@types/node": "^22.19.11",
     "@vitest/coverage-v8": "^4.1.4",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -106,10 +106,13 @@ describe("notion-client", () => {
     });
 });
 describe("additional coverage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it("queryPapers should handle pagination with next_cursor", async () => {
         const { queryPapers } = await import("../src/notion-client.js");
 
-        mockClient.databases.query.mockReset(); // Make sure to reset to clear any previous calls
         mockClient.databases.query
             .mockResolvedValueOnce({
                 results: [
@@ -162,7 +165,6 @@ describe("additional coverage", () => {
     it("queryPapers should terminate if has_more is true but next_cursor is null", async () => {
         const { queryPapers } = await import("../src/notion-client.js");
 
-        mockClient.databases.query.mockReset(); // Make sure to reset to clear any previous calls
         mockClient.databases.query.mockResolvedValueOnce({
             results: [
                 {
@@ -180,6 +182,7 @@ describe("additional coverage", () => {
 
         expect(papers.length).toBe(1);
         expect(papers[0].title).toBe("Page 1");
+        expect(papers[0].pageId).toBe("page-1");
         expect(mockClient.databases.query).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -106,6 +106,83 @@ describe("notion-client", () => {
     });
 });
 describe("additional coverage", () => {
+    it("queryPapers should handle pagination with next_cursor", async () => {
+        const { queryPapers } = await import("../src/notion-client.js");
+
+        mockClient.databases.query.mockReset(); // Make sure to reset to clear any previous calls
+        mockClient.databases.query
+            .mockResolvedValueOnce({
+                results: [
+                    {
+                        id: "page-1",
+                        properties: {
+                            "タイトル": { type: "title", title: [{ plain_text: "Page 1" }] },
+                            "DOI": { type: "rich_text", rich_text: [{ plain_text: "10.1000/page1" }] },
+                        },
+                    },
+                ],
+                has_more: true,
+                next_cursor: "cursor-2",
+            })
+            .mockResolvedValueOnce({
+                results: [
+                    {
+                        id: "page-2",
+                        properties: {
+                            "タイトル": { type: "title", title: [{ plain_text: "Page 2" }] },
+                            "DOI": { type: "rich_text", rich_text: [{ plain_text: "10.1000/page2" }] },
+                        },
+                    },
+                ],
+                has_more: false,
+                next_cursor: null,
+            });
+
+        const papers = await queryPapers("db-1", mockClient as any);
+
+        expect(papers.length).toBe(2);
+        expect(papers[0].title).toBe("Page 1");
+        expect(papers[0].pageId).toBe("page-1");
+        expect(papers[1].title).toBe("Page 2");
+        expect(papers[1].pageId).toBe("page-2");
+
+        expect(mockClient.databases.query).toHaveBeenCalledTimes(2);
+        expect(mockClient.databases.query).toHaveBeenNthCalledWith(1, {
+            database_id: "db-1",
+            start_cursor: undefined,
+            page_size: 100,
+        });
+        expect(mockClient.databases.query).toHaveBeenNthCalledWith(2, {
+            database_id: "db-1",
+            start_cursor: "cursor-2",
+            page_size: 100,
+        });
+    });
+
+    it("queryPapers should terminate if has_more is true but next_cursor is null", async () => {
+        const { queryPapers } = await import("../src/notion-client.js");
+
+        mockClient.databases.query.mockReset(); // Make sure to reset to clear any previous calls
+        mockClient.databases.query.mockResolvedValueOnce({
+            results: [
+                {
+                    id: "page-1",
+                    properties: {
+                        "タイトル": { type: "title", title: [{ plain_text: "Page 1" }] },
+                    },
+                },
+            ],
+            has_more: true,
+            next_cursor: null,
+        });
+
+        const papers = await queryPapers("db-1", mockClient as any);
+
+        expect(papers.length).toBe(1);
+        expect(papers[0].title).toBe("Page 1");
+        expect(mockClient.databases.query).toHaveBeenCalledTimes(1);
+    });
+
     it("getDatabaseInfo should return database info correctly", async () => {
         const { getDatabaseInfo } = await import("../src/notion-client.js");
         mockClient.databases.retrieve.mockResolvedValueOnce({

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -106,13 +106,10 @@ describe("notion-client", () => {
     });
 });
 describe("additional coverage", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
-
     it("queryPapers should handle pagination with next_cursor", async () => {
         const { queryPapers } = await import("../src/notion-client.js");
 
+        mockClient.databases.query.mockReset(); // Make sure to reset to clear any previous calls
         mockClient.databases.query
             .mockResolvedValueOnce({
                 results: [
@@ -165,6 +162,7 @@ describe("additional coverage", () => {
     it("queryPapers should terminate if has_more is true but next_cursor is null", async () => {
         const { queryPapers } = await import("../src/notion-client.js");
 
+        mockClient.databases.query.mockReset(); // Make sure to reset to clear any previous calls
         mockClient.databases.query.mockResolvedValueOnce({
             results: [
                 {
@@ -182,7 +180,6 @@ describe("additional coverage", () => {
 
         expect(papers.length).toBe(1);
         expect(papers[0].title).toBe("Page 1");
-        expect(papers[0].pageId).toBe("page-1");
         expect(mockClient.databases.query).toHaveBeenCalledTimes(1);
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,13 +179,13 @@ importers:
         version: 22.19.11
       '@vitest/coverage-v8':
         specifier: ^4.1.4
-        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 4.1.4(vitest@4.1.4)
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/scraper:
     dependencies:
@@ -1112,8 +1112,22 @@ packages:
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
   '@vitest/mocker@4.1.0':
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: 7.3.2
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: 7.3.2
@@ -1132,11 +1146,20 @@ packages:
   '@vitest/runner@4.1.0':
     resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
   '@vitest/snapshot@4.1.0':
     resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
   '@vitest/spy@4.1.0':
     resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
@@ -1881,6 +1904,47 @@ packages:
       jsdom:
         optional: true
 
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: 7.3.2
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -2472,6 +2536,20 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2481,9 +2559,26 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -2502,6 +2597,11 @@ snapshots:
       '@vitest/utils': 4.1.0
       pathe: 2.0.3
 
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
   '@vitest/snapshot@4.1.0':
     dependencies:
       '@vitest/pretty-format': 4.1.0
@@ -2509,7 +2609,16 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@4.1.0': {}
+
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -3235,6 +3344,35 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,13 +179,13 @@ importers:
         version: 22.19.11
       '@vitest/coverage-v8':
         specifier: ^4.1.4
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)))
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.4
-        version: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
   packages/scraper:
     dependencies:
@@ -1112,22 +1112,8 @@ packages:
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
-  '@vitest/expect@4.1.4':
-    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
-
   '@vitest/mocker@4.1.0':
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: 7.3.2
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/mocker@4.1.4':
-    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: 7.3.2
@@ -1146,20 +1132,11 @@ packages:
   '@vitest/runner@4.1.0':
     resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
-  '@vitest/runner@4.1.4':
-    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
-
   '@vitest/snapshot@4.1.0':
     resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
-  '@vitest/snapshot@4.1.4':
-    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
-
   '@vitest/spy@4.1.0':
     resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
-
-  '@vitest/spy@4.1.4':
-    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
@@ -1904,47 +1881,6 @@ packages:
       jsdom:
         optional: true
 
-  vitest@4.1.4:
-    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.4
-      '@vitest/browser-preview': 4.1.4
-      '@vitest/browser-webdriverio': 4.1.4
-      '@vitest/coverage-istanbul': 4.1.4
-      '@vitest/coverage-v8': 4.1.4
-      '@vitest/ui': 4.1.4
-      happy-dom: '*'
-      jsdom: '*'
-      vite: 7.3.2
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -2536,20 +2472,6 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.0(@types/node@22.19.11)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
 
-  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.4
-      ast-v8-to-istanbul: 1.0.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 4.0.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
-
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2559,26 +2481,9 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/expect@4.1.4':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      chai: 6.2.2
-      tinyrainbow: 3.1.0
-
   '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
-
-  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
-    dependencies:
-      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -2597,11 +2502,6 @@ snapshots:
       '@vitest/utils': 4.1.0
       pathe: 2.0.3
 
-  '@vitest/runner@4.1.4':
-    dependencies:
-      '@vitest/utils': 4.1.4
-      pathe: 2.0.3
-
   '@vitest/snapshot@4.1.0':
     dependencies:
       '@vitest/pretty-format': 4.1.0
@@ -2609,16 +2509,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.4':
-    dependencies:
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/utils': 4.1.4
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
   '@vitest/spy@4.1.0': {}
-
-  '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -3344,35 +3235,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
-      jsdom: 29.0.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.4(@types/node@22.19.11)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)):
-    dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.19.11
-      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
🎯 **What:**
Added missing edge case tests for recommender pagination in `queryPapers` within `notion-client.ts`. The newly added tests cover scenarios where `queryPapers` continues fetching subsequent pages sequentially when `has_more` is true, and properly terminates when `has_more` is true but `next_cursor` is missing/null.

📊 **Coverage:**
- Added test coverage for successful cursor traversal with multiple paginated API responses.
- Added test coverage for loop termination under malformed conditions (`has_more` without `next_cursor`).

✨ **Result:**
Branch coverage for `notion-client.ts` improved, ensuring that the critical `do...while` pagination loop accumulates records properly without getting stuck in infinite loops.

---
*PR created automatically by Jules for task [10212226533897603881](https://jules.google.com/task/10212226533897603881) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `queryPapers` のページネーションループ（`do...while`）を対象に、2つのエッジケーステストを `additional coverage` ブロックへ追加します。同時に、これまで欠落していた `beforeEach(() => { vi.clearAllMocks() })` も追加されており、前回レビューで指摘されていたモック分離の問題が解消されています。

- 正常なカーソル引き継ぎ：`has_more: true` + `next_cursor` 有りの場合に2回のAPIコールが正しい引数で行われ、結果が結合されることを検証
- 異常終了ガード：`has_more: true` でも `next_cursor: null` の場合にループが1回で終了することを検証（無限ループ防止）
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストファイルのみの変更で、プロダクションコードへの影響はありません。マージしても安全です。

変更はテストファイルのみで、新規追加された2つのテストはページネーションの期待動作を正確に反映しています。前回指摘の beforeEach 欠落と pageId アサーション不足もともに解消されており、コードの正確性に問題は見当たりません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/recommender/tests/notion-client.test.ts | ページネーションのエッジケーステストを2件追加（正常なカーソル引き継ぎと、has_more=true/next_cursor=null でのループ終了）。beforeEach の追加により既存テストとのモック分離も改善された。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[queryPapers 呼び出し] --> B[cursor = undefined]
    B --> C[databases.query 実行\nstart_cursor: cursor]
    C --> D{has_more?}
    D -- false --> E[cursor = undefined]
    D -- true --> F{next_cursor != null?}
    F -- はい --> G[cursor = next_cursor]
    F -- いいえ null --> E
    G --> H{while cursor?}
    E --> H
    H -- true --> C
    H -- false --> I[papers を返す]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[queryPapers 呼び出し] --> B[cursor = undefined]
    B --> C[databases.query 実行\nstart_cursor: cursor]
    C --> D{has_more?}
    D -- false --> E[cursor = undefined]
    D -- true --> F{next_cursor != null?}
    F -- はい --> G[cursor = next_cursor]
    F -- いいえ null --> E
    G --> H{while cursor?}
    E --> H
    H -- true --> C
    H -- false --> I[papers を返す]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: isolate recommender pagination cas..."](https://github.com/hiroki-org/paper-tools/commit/a88a856f8fa720f65e0334c30f326aa82f467a16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606132)</sub>

<!-- /greptile_comment -->