### PR TITLE
🧹 Refactor extractImportantDates into smaller helper functions

### DIFF
--- a/packages/scraper/src/researchr-scraper.ts
+++ b/packages/scraper/src/researchr-scraper.ts
@@ -1,6 +1,11 @@
-import * as cheerio from "cheerio";
-import type { Conference, ConferenceTrack, ImportantDate, Paper } from "@paper-tools/core";
+import type {
+	Conference,
+	ConferenceTrack,
+	ImportantDate,
+	Paper,
+} from "@paper-tools/core";
 import { fetchWithRetry } from "@paper-tools/core";
+import * as cheerio from "cheerio";
 
 const RESEARCHR_BASE = "https://conf.researchr.org";
 
@@ -9,277 +14,311 @@ const RESEARCHR_BASE = "https://conf.researchr.org";
  * カンファレンス情報を取得する
  */
 export async function scrapeConference(
-    conferenceSlug: string,
+	conferenceSlug: string,
 ): Promise<Conference> {
-    const url = `${RESEARCHR_BASE}/home/${conferenceSlug}`;
-    const response = await fetchWithRetry(url);
-    const html = await response.text();
-    const $ = cheerio.load(html);
+	const url = `${RESEARCHR_BASE}/home/${conferenceSlug}`;
+	const response = await fetchWithRetry(url);
+	const html = await response.text();
+	const $ = cheerio.load(html);
 
-    // カンファレンス名を取得
-    const name = $("h1.banner-text, .conf-title, h1").first().text().trim() || conferenceSlug;
+	// カンファレンス名を取得
+	const name =
+		$("h1.banner-text, .conf-title, h1").first().text().trim() ||
+		conferenceSlug;
 
-    // フルネームを取得（メタタグやページタイトルから）
-    const fullName = $('meta[property="og:title"]').attr("content")
-        || $("title").text().trim()
-        || name;
+	// フルネームを取得（メタタグやページタイトルから）
+	const fullName =
+		$('meta[property="og:title"]').attr("content") ||
+		$("title").text().trim() ||
+		name;
 
-    // 日付情報を取得
-    const dateText = $(".conference-dates, .date-info, .banner-date").first().text().trim();
+	// 日付情報を取得
+	const dateText = $(".conference-dates, .date-info, .banner-date")
+		.first()
+		.text()
+		.trim();
 
-    // 場所情報を取得
-    const location = $(".conference-location, .location-info, .banner-location").first().text().trim()
-        || extractLocation($);
+	// 場所情報を取得
+	const location =
+		$(".conference-location, .location-info, .banner-location")
+			.first()
+			.text()
+			.trim() || extractLocation($);
 
-    // トラック情報を取得
-    const tracks = extractTracks($, conferenceSlug);
+	// トラック情報を取得
+	const tracks = extractTracks($, conferenceSlug);
 
-    // 重要な日付を取得
-    const importantDates = extractImportantDates($);
+	// 重要な日付を取得
+	const importantDates = extractImportantDates($);
 
-    // 年を抽出
-    const yearMatch = conferenceSlug.match(/(\d{4})/);
-    const year = yearMatch ? parseInt(yearMatch[1], 10) : new Date().getFullYear();
+	// 年を抽出
+	const yearMatch = conferenceSlug.match(/(\d{4})/);
+	const year = yearMatch
+		? parseInt(yearMatch[1], 10)
+		: new Date().getFullYear();
 
-    // URL
-    const confUrl = url;
+	// URL
+	const confUrl = url;
 
-    // 日付パース
-    const { startDate, endDate } = parseDateRange(dateText, year);
+	// 日付パース
+	const { startDate, endDate } = parseDateRange(dateText, year);
 
-    return {
-        name,
-        fullName,
-        year,
-        location: location || undefined,
-        startDate: startDate || undefined,
-        endDate: endDate || undefined,
-        url: confUrl,
-        tracks,
-        importantDates,
-    };
+	return {
+		name,
+		fullName,
+		year,
+		location: location || undefined,
+		startDate: startDate || undefined,
+		endDate: endDate || undefined,
+		url: confUrl,
+		tracks,
+		importantDates,
+	};
 }
 
 function extractLocation($: cheerio.CheerioAPI): string {
-    // ページ本文からよくある場所パターンを探す
-    const bodyText = $("body").text();
-    const locationPatterns = [
-        /held in ([^.]+)/i,
-        /will take place in ([^.]+)/i,
-        /location:\s*([^.\n]+)/i,
-    ];
-    for (const pattern of locationPatterns) {
-        const match = bodyText.match(pattern);
-        if (match) return match[1].trim();
-    }
-    return "";
+	// ページ本文からよくある場所パターンを探す
+	const bodyText = $("body").text();
+	const locationPatterns = [
+		/held in ([^.]+)/i,
+		/will take place in ([^.]+)/i,
+		/location:\s*([^.\n]+)/i,
+	];
+	for (const pattern of locationPatterns) {
+		const match = bodyText.match(pattern);
+		if (match) return match[1].trim();
+	}
+	return "";
 }
 
-function extractTracks($: cheerio.CheerioAPI, conferenceSlug: string): ConferenceTrack[] {
-    const tracks: ConferenceTrack[] = [];
-    const seen = new Set<string>();
+function extractTracks(
+	$: cheerio.CheerioAPI,
+	conferenceSlug: string,
+): ConferenceTrack[] {
+	const tracks: ConferenceTrack[] = [];
+	const seen = new Set<string>();
 
-    // ナビゲーションメニューやサイドバーからトラックリンクを探す
-    $('a[href*="/track/"], .nav-link, .track-link, .sidebar a').each((_i, el) => {
-        const text = $(el).text().trim();
-        const href = $(el).attr("href") || "";
-        if (text && !seen.has(text) && text.length > 2 && text.length < 100) {
-            seen.add(text);
-            const trackUrl = href.startsWith("http") ? href : `${RESEARCHR_BASE}${href}`;
-            tracks.push({ name: text, url: trackUrl });
-        }
-    });
+	// ナビゲーションメニューやサイドバーからトラックリンクを探す
+	$('a[href*="/track/"], .nav-link, .track-link, .sidebar a').each((_i, el) => {
+		const text = $(el).text().trim();
+		const href = $(el).attr("href") || "";
+		if (text && !seen.has(text) && text.length > 2 && text.length < 100) {
+			seen.add(text);
+			const trackUrl = href.startsWith("http")
+				? href
+				: `${RESEARCHR_BASE}${href}`;
+			tracks.push({ name: text, url: trackUrl });
+		}
+	});
 
-    // トラックが見つからなかった場合、セクション見出しから探す
-    if (tracks.length === 0) {
-        const trackKeywordsRegex = /track|workshop|tutorial|symposium/i;
-        $("h2, h3, h4").each((_i, el) => {
-            const text = $(el).text().trim();
-            if (
-                text &&
-                !seen.has(text) &&
-                trackKeywordsRegex.test(text)
-            ) {
-                seen.add(text);
-                tracks.push({ name: text });
-            }
-        });
-    }
+	// トラックが見つからなかった場合、セクション見出しから探す
+	if (tracks.length === 0) {
+		const trackKeywordsRegex = /track|workshop|tutorial|symposium/i;
+		$("h2, h3, h4").each((_i, el) => {
+			const text = $(el).text().trim();
+			if (text && !seen.has(text) && trackKeywordsRegex.test(text)) {
+				seen.add(text);
+				tracks.push({ name: text });
+			}
+		});
+	}
 
-    return tracks;
+	return tracks;
+}
+
+function extractDatesFromTables(
+	$: cheerio.CheerioAPI,
+	seen: Set<string>,
+): ImportantDate[] {
+	const dates: ImportantDate[] = [];
+
+	// テーブル形式の重要日程を探す
+	$("table").each((_i, table) => {
+		const tableText = $(table).text().toLowerCase();
+		if (
+			tableText.includes("date") ||
+			tableText.includes("deadline") ||
+			tableText.includes("submission") ||
+			tableText.includes("notification")
+		) {
+			$(table)
+				.find("tr")
+				.each((_j, row) => {
+					const cells = $(row).find("td, th");
+					if (cells.length >= 2) {
+						const description = $(cells[0]).text().trim();
+						const date = $(cells[1]).text().trim();
+						const key = `${description}:${date}`;
+						if (description && date && !seen.has(key)) {
+							seen.add(key);
+							dates.push({ date, description });
+						}
+					}
+				});
+		}
+	});
+
+	return dates;
+}
+
+function extractDatesFromLists(
+	$: cheerio.CheerioAPI,
+	seen: Set<string>,
+): ImportantDate[] {
+	const dates: ImportantDate[] = [];
+
+	$("li, .deadline, .important-date").each((_i, el) => {
+		const text = $(el).text().trim();
+		const datePatterns = [
+			/(.+?):\s*(\w+ \d{1,2},?\s*\d{4})/,
+			/(.+?)\s*[-–]\s*(\w+ \d{1,2},?\s*\d{4})/,
+			/(\w+ \d{1,2},?\s*\d{4})\s*[-–:]\s*(.+)/,
+		];
+		for (const pattern of datePatterns) {
+			const match = text.match(pattern);
+			if (match) {
+				const key = text;
+				if (!seen.has(key)) {
+					seen.add(key);
+					const isDateFirst = pattern.source.startsWith("(\\w+");
+					dates.push({
+						description: isDateFirst ? match[2].trim() : match[1].trim(),
+						date: isDateFirst ? match[1].trim() : match[2].trim(),
+					});
+				}
+				break;
+			}
+		}
+	});
+
+	return dates;
 }
 
 function extractImportantDates($: cheerio.CheerioAPI): ImportantDate[] {
-    const dates: ImportantDate[] = [];
-    const seen = new Set<string>();
+	const seen = new Set<string>();
 
-    // テーブル形式の重要日程を探す
-    $("table").each((_i, table) => {
-        const tableText = $(table).text().toLowerCase();
-        if (
-            tableText.includes("date") ||
-            tableText.includes("deadline") ||
-            tableText.includes("submission") ||
-            tableText.includes("notification")
-        ) {
-            $(table)
-                .find("tr")
-                .each((_j, row) => {
-                    const cells = $(row).find("td, th");
-                    if (cells.length >= 2) {
-                        const description = $(cells[0]).text().trim();
-                        const date = $(cells[1]).text().trim();
-                        const key = `${description}:${date}`;
-                        if (description && date && !seen.has(key)) {
-                            seen.add(key);
-                            dates.push({ date, description });
-                        }
-                    }
-                });
-        }
-    });
+	const tableDates = extractDatesFromTables($, seen);
+	if (tableDates.length > 0) {
+		return tableDates;
+	}
 
-    // リスト形式もチェック
-    if (dates.length === 0) {
-        $("li, .deadline, .important-date").each((_i, el) => {
-            const text = $(el).text().trim();
-            const datePatterns = [
-                /(.+?):\s*(\w+ \d{1,2},?\s*\d{4})/,
-                /(.+?)\s*[-–]\s*(\w+ \d{1,2},?\s*\d{4})/,
-                /(\w+ \d{1,2},?\s*\d{4})\s*[-–:]\s*(.+)/,
-            ];
-            for (const pattern of datePatterns) {
-                const match = text.match(pattern);
-                if (match) {
-                    const key = text;
-                    if (!seen.has(key)) {
-                        seen.add(key);
-                        const isDateFirst = pattern.source.startsWith("(\\w+");
-                        dates.push({
-                            description: isDateFirst ? match[2].trim() : match[1].trim(),
-                            date: isDateFirst ? match[1].trim() : match[2].trim(),
-                        });
-                    }
-                    break;
-                }
-            }
-        });
-    }
-
-    return dates;
+	return extractDatesFromLists($, seen);
 }
 
 function parseDateRange(
-    dateText: string,
-    _year: number,
+	dateText: string,
+	_year: number,
 ): { startDate?: string; endDate?: string } {
-    if (!dateText) return {};
+	if (!dateText) return {};
 
-    // "April 12-18, 2026" 形式
-    const rangeMatch = dateText.match(
-        /(\w+)\s+(\d{1,2})\s*[-–]\s*(\d{1,2}),?\s*(\d{4})/,
-    );
-    if (rangeMatch) {
-        const month = rangeMatch[1];
-        const startDay = rangeMatch[2];
-        const endDay = rangeMatch[3];
-        const yr = rangeMatch[4];
-        return {
-            startDate: `${month} ${startDay}, ${yr}`,
-            endDate: `${month} ${endDay}, ${yr}`,
-        };
-    }
+	// "April 12-18, 2026" 形式
+	const rangeMatch = dateText.match(
+		/(\w+)\s+(\d{1,2})\s*[-–]\s*(\d{1,2}),?\s*(\d{4})/,
+	);
+	if (rangeMatch) {
+		const month = rangeMatch[1];
+		const startDay = rangeMatch[2];
+		const endDay = rangeMatch[3];
+		const yr = rangeMatch[4];
+		return {
+			startDate: `${month} ${startDay}, ${yr}`,
+			endDate: `${month} ${endDay}, ${yr}`,
+		};
+	}
 
-    // "October 12 - October 16, 2026" 形式
-    const crossMonthMatch = dateText.match(
-        /(\w+)\s+(\d{1,2})\s*[-–]\s*(\w+)\s+(\d{1,2}),?\s*(\d{4})/,
-    );
-    if (crossMonthMatch) {
-        return {
-            startDate: `${crossMonthMatch[1]} ${crossMonthMatch[2]}, ${crossMonthMatch[5]}`,
-            endDate: `${crossMonthMatch[3]} ${crossMonthMatch[4]}, ${crossMonthMatch[5]}`,
-        };
-    }
+	// "October 12 - October 16, 2026" 形式
+	const crossMonthMatch = dateText.match(
+		/(\w+)\s+(\d{1,2})\s*[-–]\s*(\w+)\s+(\d{1,2}),?\s*(\d{4})/,
+	);
+	if (crossMonthMatch) {
+		return {
+			startDate: `${crossMonthMatch[1]} ${crossMonthMatch[2]}, ${crossMonthMatch[5]}`,
+			endDate: `${crossMonthMatch[3]} ${crossMonthMatch[4]}, ${crossMonthMatch[5]}`,
+		};
+	}
 
-    return {};
+	return {};
 }
 
 /**
  * conf.researchr.org のトラックページからAccepted Papersを取得する
  */
 export async function scrapeAcceptedPapers(trackUrl: string): Promise<Paper[]> {
-    let parsedUrl: URL;
-    try {
-        parsedUrl = new URL(trackUrl);
-    } catch {
-        throw new Error("Invalid URL provided");
-    }
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(trackUrl);
+	} catch {
+		throw new Error("Invalid URL provided");
+	}
 
-    if (parsedUrl.hostname !== "conf.researchr.org") {
-        throw new Error("URL must be a researchr.org domain");
-    }
+	if (parsedUrl.hostname !== "conf.researchr.org") {
+		throw new Error("URL must be a researchr.org domain");
+	}
 
-    if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
-        throw new Error("URL must use http or https protocol");
-    }
+	if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+		throw new Error("URL must use http or https protocol");
+	}
 
-    const response = await fetchWithRetry(trackUrl);
-    const html = await response.text();
-    const $ = cheerio.load(html);
+	const response = await fetchWithRetry(trackUrl);
+	const html = await response.text();
+	const $ = cheerio.load(html);
 
-    const papers: Paper[] = [];
+	const papers: Paper[] = [];
 
-    // Accepted papers セクションを探す
-    $(".accepted-paper, .paper-entry, .paper-item, article.paper").each(
-        (_i, el) => {
-            const title =
-                $(el).find(".title, h3, h4, .paper-title").first().text().trim();
-            const authorText = $(el)
-                .find(".authors, .paper-authors, .author-list")
-                .first()
-                .text()
-                .trim();
+	// Accepted papers セクションを探す
+	$(".accepted-paper, .paper-entry, .paper-item, article.paper").each(
+		(_i, el) => {
+			const title = $(el)
+				.find(".title, h3, h4, .paper-title")
+				.first()
+				.text()
+				.trim();
+			const authorText = $(el)
+				.find(".authors, .paper-authors, .author-list")
+				.first()
+				.text()
+				.trim();
 
-            if (title) {
-                const authors = authorText
-                    ? authorText
-                        .replace(/, and /gi, ", ")
-                        .replace(/ and /gi, ", ")
-                        .split(/[,;]/)
-                        .map((a) => ({ name: a.trim() }))
-                    : [];
+			if (title) {
+				const authors = authorText
+					? authorText
+							.replace(/, and /gi, ", ")
+							.replace(/ and /gi, ", ")
+							.split(/[,;]/)
+							.map((a) => ({ name: a.trim() }))
+					: [];
 
-                papers.push({
-                    title,
-                    authors: authors.filter((a) => a.name.length > 0),
-                });
-            }
-        },
-    );
+				papers.push({
+					title,
+					authors: authors.filter((a) => a.name.length > 0),
+				});
+			}
+		},
+	);
 
-    // テーブル形式のリストもチェック
-    if (papers.length === 0) {
-        $("table tr").each((_i, row) => {
-            const cells = $(row).find("td");
-            if (cells.length >= 1) {
-                const title = $(cells[0]).text().trim();
-                const authorText = cells.length >= 2 ? $(cells[1]).text().trim() : "";
-                if (title && title.length > 10) {
-                    const authors = authorText
-                        ? authorText
-                            .replace(/, and /gi, ", ")
-                            .replace(/ and /gi, ", ")
-                            .split(/[,;]/)
-                            .map((a) => ({ name: a.trim() }))
-                        : [];
-                    papers.push({
-                        title,
-                        authors: authors.filter((a) => a.name.length > 0),
-                    });
-                }
-            }
-        });
-    }
+	// テーブル形式のリストもチェック
+	if (papers.length === 0) {
+		$("table tr").each((_i, row) => {
+			const cells = $(row).find("td");
+			if (cells.length >= 1) {
+				const title = $(cells[0]).text().trim();
+				const authorText = cells.length >= 2 ? $(cells[1]).text().trim() : "";
+				if (title && title.length > 10) {
+					const authors = authorText
+						? authorText
+								.replace(/, and /gi, ", ")
+								.replace(/ and /gi, ", ")
+								.split(/[,;]/)
+								.map((a) => ({ name: a.trim() }))
+						: [];
+					papers.push({
+						title,
+						authors: authors.filter((a) => a.name.length > 0),
+					});
+				}
+			}
+		});
+	}
 
-    return papers;
+	return papers;
 }

--- a/packages/scraper/tests/researchr-scraper.test.ts
+++ b/packages/scraper/tests/researchr-scraper.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-const { scrapeConference, scrapeAcceptedPapers } = await import("../src/researchr-scraper.js");
+const { scrapeConference, scrapeAcceptedPapers } = await import(
+	"../src/researchr-scraper.js"
+);
 
 const CONFERENCE_HTML = `
 <!DOCTYPE html>
@@ -53,52 +55,127 @@ const ACCEPTED_PAPERS_HTML = `
 `;
 
 describe("Researchr Scraper", () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-  });
+	it("should extract important dates from tables", async () => {
+		const htmlWithTable = `
+      <html>
+        <head><title>Test Conf 2024</title></head>
+        <body>
+          <h1 class="conf-title">Test Conference 2024</h1>
+          <div class="conference-dates">October 12-16, 2024</div>
+          <div class="conference-location">Tokyo, Japan</div>
+          <div class="track"><a href="/track/main">Main Track</a></div>
+          <table>
+            <tr>
+              <td>Abstract Submission Deadline</td>
+              <td>March 15, 2024</td>
+            </tr>
+            <tr>
+              <td>Notification of Acceptance</td>
+              <td>May 1, 2024</td>
+            </tr>
+          </table>
+        </body>
+      </html>
+    `;
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			text: async () => htmlWithTable,
+		});
 
-  it("scrapeConference should fetch and parse conference page", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      text: async () => CONFERENCE_HTML,
-    });
+		const result = await scrapeConference("testconf-2024");
+		expect(result.importantDates).toEqual([
+			{ description: "Abstract Submission Deadline", date: "March 15, 2024" },
+			{ description: "Notification of Acceptance", date: "May 1, 2024" },
+		]);
+	});
 
-    const conference = await scrapeConference("icse-2026");
-    expect(conference).toBeDefined();
-    expect(conference.name).toBe("ICSE 2026");
-    expect(conference.year).toBe(2026);
-    expect(conference.tracks.length).toBeGreaterThan(0);
-  });
+	it("should extract important dates from lists", async () => {
+		const htmlWithList = `
+      <html>
+        <head><title>Test Conf 2024</title></head>
+        <body>
+          <h1 class="conf-title">Test Conference 2024</h1>
+          <div class="conference-dates">October 12-16, 2024</div>
+          <div class="conference-location">Tokyo, Japan</div>
+          <div class="track"><a href="/track/main">Main Track</a></div>
+          <ul>
+            <li class="important-date">Submission: March 15, 2024</li>
+            <li class="important-date">March 16, 2024: Notification</li>
+          </ul>
+        </body>
+      </html>
+    `;
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			text: async () => htmlWithList,
+		});
 
-  it("scrapeConference should throw on HTTP error", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-    });
+		const result = await scrapeConference("testconf-2024");
+		expect(result.importantDates).toEqual([
+			{ description: "Submission", date: "March 15, 2024" },
+			{ description: "Notification", date: "March 16, 2024" },
+		]);
+	});
 
-    await expect(scrapeConference("nonexistent-conf")).rejects.toThrow();
-  });
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
 
-  it("scrapeAcceptedPapers should reject invalid URLs", async () => {
-    await expect(scrapeAcceptedPapers("invalid-url")).rejects.toThrow("Invalid URL provided");
-    await expect(scrapeAcceptedPapers("http://malicious.com/track/1")).rejects.toThrow("URL must be a researchr.org domain");
-    await expect(scrapeAcceptedPapers("javascript:alert(1)")).rejects.toThrow("URL must be a researchr.org domain");
-  });
+	it("scrapeConference should fetch and parse conference page", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			text: async () => CONFERENCE_HTML,
+		});
 
-  it("scrapeAcceptedPapers should fetch and parse accepted papers", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      text: async () => ACCEPTED_PAPERS_HTML,
-    });
+		const conference = await scrapeConference("icse-2026");
+		expect(conference).toBeDefined();
+		expect(conference.name).toBe("ICSE 2026");
+		expect(conference.year).toBe(2026);
+		expect(conference.tracks.length).toBeGreaterThan(0);
+	});
 
-    const papers = await scrapeAcceptedPapers("https://conf.researchr.org/track/icse-2026/research-track");
-    expect(papers).toBeDefined();
-    expect(Array.isArray(papers)).toBe(true);
-    expect(papers.length).toBe(2);
-    expect(papers[0]?.title).toBe("Automated Bug Detection with AI");
-    expect(papers[0]?.authors.map((a) => a.name)).toEqual(["Alice Smith", "Bob Jones"]);
-  });
+	it("scrapeConference should throw on HTTP error", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: false,
+			status: 404,
+			statusText: "Not Found",
+		});
+
+		await expect(scrapeConference("nonexistent-conf")).rejects.toThrow();
+	});
+
+	it("scrapeAcceptedPapers should reject invalid URLs", async () => {
+		await expect(scrapeAcceptedPapers("invalid-url")).rejects.toThrow(
+			"Invalid URL provided",
+		);
+		await expect(
+			scrapeAcceptedPapers("http://malicious.com/track/1"),
+		).rejects.toThrow("URL must be a researchr.org domain");
+		await expect(scrapeAcceptedPapers("javascript:alert(1)")).rejects.toThrow(
+			"URL must be a researchr.org domain",
+		);
+	});
+
+	it("scrapeAcceptedPapers should fetch and parse accepted papers", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			text: async () => ACCEPTED_PAPERS_HTML,
+		});
+
+		const papers = await scrapeAcceptedPapers(
+			"https://conf.researchr.org/track/icse-2026/research-track",
+		);
+		expect(papers).toBeDefined();
+		expect(Array.isArray(papers)).toBe(true);
+		expect(papers.length).toBe(2);
+		expect(papers[0]?.title).toBe("Automated Bug Detection with AI");
+		expect(papers[0]?.authors.map((a) => a.name)).toEqual([
+			"Alice Smith",
+			"Bob Jones",
+		]);
+	});
 });

--- a/test2.cjs
+++ b/test2.cjs
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+const path = 'packages/scraper/tests/researchr-scraper.test.ts';
+let code = fs.readFileSync(path, 'utf8');
+
+const regex = /describe\("scrapeConference", \(\) => {/;
+const count = (code.match(regex) || []).length;
+console.log(count);


### PR DESCRIPTION
🧹 Refactor extractImportantDates into smaller helper functions

🎯 **What:**
Extracted the `extractImportantDates` logic in `researchr-scraper.ts` into two separate helper functions: `extractDatesFromTables` and `extractDatesFromLists`. 

💡 **Why:**
The original `extractImportantDates` function was overly long, combining the logic for parsing tables and lists into a single method. Extracting these concerns into their own functions significantly improves readability and makes the codebase easier to maintain. The main function now serves purely as a delegator.

✅ **Verification:**
- Validated all types using `tsc`.
- Formatted and linted the file using `@biomejs/biome`.
- Ran the `packages/scraper` test suite via `vitest` which all continue to pass.

✨ **Result:**
The `extractImportantDates` function has been reduced to a simple orchestrator delegating to smaller, more digestible functions while perfectly preserving the existing logic.

---
*PR created automatically by Jules for task [9413684718015965805](https://jules.google.com/task/9413684718015965805) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `researchr-scraper.ts` 内の `extractImportantDates` 関数を、テーブル解析用の `extractDatesFromTables` とリスト解析用の `extractDatesFromLists` という2つのヘルパー関数に分割するリファクタリングです。元の関数はデリゲーターとしてのみ機能するようになりました。

- **動作の等価性が保たれています**: `seen` セットは参照渡しで両ヘルパー関数に共有され、元の「テーブルで日付が見つかればリストはスキップ」というフォールバックロジックも `tableDates.length > 0` の早期リターンで正確に再現されています。
- **フォーマット変更**: インデントがスペース4つからタブ形式に変更され、インポートの順序も整理されています（biome によるフォーマット）。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

純粋なリファクタリングであり、既存ロジックの動作は完全に保たれています。安全にマージ可能です。

テーブル解析とリスト解析のロジックが忠実にヘルパー関数へ抽出されており、seen セットの参照渡しによって重複排除の動作も維持されています。フォールバックの条件（テーブル結果が空の場合のみリスト解析を実行）も正確に再現されています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/scraper/src/researchr-scraper.ts | extractImportantDates を extractDatesFromTables / extractDatesFromLists に分割。seen セットの参照渡しと条件分岐ロジックが元の動作を完全に保持しており、バグの導入なし。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractImportantDates] --> B[seen = new Set]
    B --> C[extractDatesFromTables]
    C --> D{tableDates.length > 0?}
    D -- Yes --> E[return tableDates]
    D -- No --> F[extractDatesFromLists]
    F --> G[return listDates]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[extractImportantDates] --> B[seen = new Set]
    B --> C[extractDatesFromTables]
    C --> D{tableDates.length > 0?}
    D -- Yes --> E[return tableDates]
    D -- No --> F[extractDatesFromLists]
    F --> G[return listDates]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Refactor \`extractImportantDates\` into sm..."](https://github.com/hiroki-org/paper-tools/commit/6bb283254421563144a8279fe4dcc91df38cd75b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606211)</sub>

<!-- /greptile_comment -->