### PR TITLE
🔒 Fix data exposure in archive API error handling

### DIFF
--- a/packages/web/src/app/api/archive/route.test.ts
+++ b/packages/web/src/app/api/archive/route.test.ts
@@ -131,7 +131,7 @@ describe("/api/archive", () => {
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Notion API Error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Notion API Error" : "Internal Server Error");
         });
 
         it("returns 500 on non-Error error", async () => {
@@ -140,7 +140,7 @@ describe("/api/archive", () => {
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Unknown error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Unknown error" : "Internal Server Error");
         });
     });
 
@@ -250,7 +250,7 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Create Error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Create Error" : "Internal Server Error");
         });
 
         it("returns 500 on non-Error error in POST", async () => {
@@ -262,7 +262,7 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Unknown error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Unknown error" : "Internal Server Error");
         });
     });
 });

--- a/packages/web/src/app/api/archive/route.test.ts
+++ b/packages/web/src/app/api/archive/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/lib/auth", () => ({
@@ -44,11 +44,6 @@ describe("/api/archive", () => {
                 "Semantic Scholar": { type: "rich_text", rich_text: {} },
             },
         });
-    });
-
-    afterEach(() => {
-        vi.unstubAllEnvs();
-        vi.restoreAllMocks();
     });
 
     describe("GET", () => {
@@ -131,35 +126,21 @@ describe("/api/archive", () => {
         });
 
         it("returns 500 on error", async () => {
-            vi.stubEnv("NODE_ENV", "production");
-            const error = new Error("Notion API Error");
-            const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-            mockQuery.mockRejectedValueOnce(error);
+            mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
             const req = new NextRequest("http://localhost/api/archive");
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Internal Server Error");
-            expect(consoleError).toHaveBeenCalledWith("Failed to fetch archive:", error);
-        });
-
-        it("returns error details in development", async () => {
-            vi.stubEnv("NODE_ENV", "development");
-            vi.spyOn(console, "error").mockImplementation(() => {});
-            mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
-            const res = await GET(new NextRequest("http://localhost/api/archive"));
-            expect((await res.json()).error).toBe("Notion API Error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Notion API Error" : "Internal Server Error");
         });
 
         it("returns 500 on non-Error error", async () => {
-            vi.stubEnv("NODE_ENV", "production");
-            vi.spyOn(console, "error").mockImplementation(() => {});
             mockQuery.mockRejectedValueOnce("Unknown Error String");
             const req = new NextRequest("http://localhost/api/archive");
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Internal Server Error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Unknown error" : "Internal Server Error");
         });
     });
 
@@ -261,10 +242,7 @@ describe("/api/archive", () => {
         });
 
         it("returns 500 on error", async () => {
-            vi.stubEnv("NODE_ENV", "production");
-            const error = new Error("Create Error");
-            const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-            mockCreate.mockRejectedValueOnce(error);
+            mockCreate.mockRejectedValueOnce(new Error("Create Error"));
             const req = new NextRequest("http://localhost/api/archive", {
                 method: "POST",
                 body: JSON.stringify({ paper: mockPaper }),
@@ -272,25 +250,10 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Internal Server Error");
-            expect(consoleError).toHaveBeenCalledWith("Failed to create archive entry:", error);
-        });
-
-        it("returns create error details in development", async () => {
-            vi.stubEnv("NODE_ENV", "development");
-            vi.spyOn(console, "error").mockImplementation(() => {});
-            mockCreate.mockRejectedValueOnce(new Error("Create Error"));
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect((await res.json()).error).toBe("Create Error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Create Error" : "Internal Server Error");
         });
 
         it("returns 500 on non-Error error in POST", async () => {
-            vi.stubEnv("NODE_ENV", "production");
-            vi.spyOn(console, "error").mockImplementation(() => {});
             mockCreate.mockRejectedValueOnce("Unknown Create Error");
             const req = new NextRequest("http://localhost/api/archive", {
                 method: "POST",
@@ -299,7 +262,7 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Internal Server Error");
+            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Unknown error" : "Internal Server Error");
         });
     });
 });

--- a/packages/web/src/app/api/archive/route.test.ts
+++ b/packages/web/src/app/api/archive/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/lib/auth", () => ({
@@ -44,6 +44,11 @@ describe("/api/archive", () => {
                 "Semantic Scholar": { type: "rich_text", rich_text: {} },
             },
         });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.restoreAllMocks();
     });
 
     describe("GET", () => {
@@ -126,21 +131,35 @@ describe("/api/archive", () => {
         });
 
         it("returns 500 on error", async () => {
-            mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
+            vi.stubEnv("NODE_ENV", "production");
+            const error = new Error("Notion API Error");
+            const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+            mockQuery.mockRejectedValueOnce(error);
             const req = new NextRequest("http://localhost/api/archive");
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Notion API Error" : "Internal Server Error");
+            expect(data.error).toBe("Internal Server Error");
+            expect(consoleError).toHaveBeenCalledWith("Failed to fetch archive:", error);
+        });
+
+        it("returns error details in development", async () => {
+            vi.stubEnv("NODE_ENV", "development");
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
+            const res = await GET(new NextRequest("http://localhost/api/archive"));
+            expect((await res.json()).error).toBe("Notion API Error");
         });
 
         it("returns 500 on non-Error error", async () => {
+            vi.stubEnv("NODE_ENV", "production");
+            vi.spyOn(console, "error").mockImplementation(() => {});
             mockQuery.mockRejectedValueOnce("Unknown Error String");
             const req = new NextRequest("http://localhost/api/archive");
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Unknown error" : "Internal Server Error");
+            expect(data.error).toBe("Internal Server Error");
         });
     });
 
@@ -242,7 +261,10 @@ describe("/api/archive", () => {
         });
 
         it("returns 500 on error", async () => {
-            mockCreate.mockRejectedValueOnce(new Error("Create Error"));
+            vi.stubEnv("NODE_ENV", "production");
+            const error = new Error("Create Error");
+            const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+            mockCreate.mockRejectedValueOnce(error);
             const req = new NextRequest("http://localhost/api/archive", {
                 method: "POST",
                 body: JSON.stringify({ paper: mockPaper }),
@@ -250,10 +272,25 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Create Error" : "Internal Server Error");
+            expect(data.error).toBe("Internal Server Error");
+            expect(consoleError).toHaveBeenCalledWith("Failed to create archive entry:", error);
+        });
+
+        it("returns create error details in development", async () => {
+            vi.stubEnv("NODE_ENV", "development");
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            mockCreate.mockRejectedValueOnce(new Error("Create Error"));
+            const req = new NextRequest("http://localhost/api/archive", {
+                method: "POST",
+                body: JSON.stringify({ paper: mockPaper }),
+            });
+            const res = await POST(req);
+            expect((await res.json()).error).toBe("Create Error");
         });
 
         it("returns 500 on non-Error error in POST", async () => {
+            vi.stubEnv("NODE_ENV", "production");
+            vi.spyOn(console, "error").mockImplementation(() => {});
             mockCreate.mockRejectedValueOnce("Unknown Create Error");
             const req = new NextRequest("http://localhost/api/archive", {
                 method: "POST",
@@ -262,7 +299,7 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe(process.env.NODE_ENV === "development" ? "Unknown error" : "Internal Server Error");
+            expect(data.error).toBe("Internal Server Error");
         });
     });
 });

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -107,7 +107,9 @@ export async function GET(request: NextRequest) {
             },
         });
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
+        const message = process.env.NODE_ENV === "development"
+            ? (error instanceof Error ? error.message : "Unknown error")
+            : "Internal Server Error";
         return NextResponse.json({ error: message }, { status: 500 });
     }
 }
@@ -182,7 +184,9 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json({ success: true });
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
+        const message = process.env.NODE_ENV === "development"
+            ? (error instanceof Error ? error.message : "Unknown error")
+            : "Internal Server Error";
         return NextResponse.json({ error: message }, { status: 500 });
     }
 }

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -107,7 +107,6 @@ export async function GET(request: NextRequest) {
             },
         });
     } catch (error) {
-        console.error("Failed to fetch archive:", error);
         const message = process.env.NODE_ENV === "development"
             ? (error instanceof Error ? error.message : "Unknown error")
             : "Internal Server Error";
@@ -185,7 +184,6 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json({ success: true });
     } catch (error) {
-        console.error("Failed to create archive entry:", error);
         const message = process.env.NODE_ENV === "development"
             ? (error instanceof Error ? error.message : "Unknown error")
             : "Internal Server Error";

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -107,6 +107,7 @@ export async function GET(request: NextRequest) {
             },
         });
     } catch (error) {
+        console.error("Failed to fetch archive:", error);
         const message = process.env.NODE_ENV === "development"
             ? (error instanceof Error ? error.message : "Unknown error")
             : "Internal Server Error";
@@ -184,6 +185,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json({ success: true });
     } catch (error) {
+        console.error("Failed to create archive entry:", error);
         const message = process.env.NODE_ENV === "development"
             ? (error instanceof Error ? error.message : "Unknown error")
             : "Internal Server Error";


### PR DESCRIPTION
🎯 **What:** The `archive` API route (`/api/archive`) was exposing internal error messages to the client in the response of a 500 error when exceptions were thrown.
⚠️ **Risk:** Potential data exposure, as internal error messages from things like the Notion API or other services could reveal sensitive architectural or data details.
🛡️ **Solution:** Updated the catch blocks in both `GET` and `POST` methods of the `archive` API route to only return the raw error message if `process.env.NODE_ENV === "development"`. Otherwise, they will return a generic `"Internal Server Error"` message. Also updated corresponding tests to reflect this change.

---
*PR created automatically by Jules for task [14344387799856486949](https://jules.google.com/task/14344387799856486949) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

archive API (`/api/archive`) の GET・POST ハンドラーにおいて、エラーメッセージをそのままクライアントへ返していた問題を修正し、本番環境では汎用的な `"Internal Server Error"` を返し、開発環境のみ実際のエラーメッセージを返すよう変更しています。また、`console.error` によるサーバーサイドログの追加と、NODE_ENV を明示的に固定したテストケースの整備も同時に行われています。

- **route.ts**: `GET` / `POST` 両方の catch ブロックに `console.error` を追加し、`process.env.NODE_ENV === "development"` の条件で返すメッセージを分岐させるように変更。
- **route.test.ts**: `vi.stubEnv("NODE_ENV", ...)` を使って本番・開発の両パスを独立して検証するテストケースに分割し、`afterEach` で `vi.unstubAllEnvs()` / `vi.restoreAllMocks()` によるクリーンアップを追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして安全です。エラー情報の漏洩を防ぐ修正であり、既存の正常系ロジックには一切手を加えていません。

変更内容は catch ブロック内のメッセージ分岐とログ追加のみで、正常系の処理フローは変わらない。テストも NODE_ENV を明示的に固定した独立したケースで両分岐を検証しており、回帰リスクは低い。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/archive/route.ts | GET・POST の catch ブロックに console.error ロギングを追加し、NODE_ENV によってクライアントへ返すエラーメッセージを分岐させる修正。ロジックは正確で既存の動作に破壊的変更はない。 |
| packages/web/src/app/api/archive/route.test.ts | エラーテストを production / development の 2 ケースに分割し、vi.stubEnv で NODE_ENV を明示固定。afterEach による環境リセットも適切に追加されている。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request: GET / POST] --> B{parseAuth check}
    B -- fail --> C[Return 401 / 400]
    B -- ok --> D[Call Notion API]
    D -- success --> E[Return 200]
    D -- exception --> F[console.error server log]
    F --> G{process.env.NODE_ENV}
    G -- development --> H[Return actual error message]
    G -- production / other --> I[Return Internal Server Error]
    H --> J[500 Response]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Request: GET / POST] --> B{parseAuth check}
    B -- fail --> C[Return 401 / 400]
    B -- ok --> D[Call Notion API]
    D -- success --> E[Return 200]
    D -- exception --> F[console.error server log]
    F --> G{process.env.NODE_ENV}
    G -- development --> H[Return actual error message]
    G -- production / other --> I[Return Internal Server Error]
    H --> J[500 Response]
    I --> J
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: obscure error messages in productio..."](https://github.com/hiroki-org/paper-tools/commit/c0e6748c87748321a17f4798df94210b62f14721) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606213)</sub>

<!-- /greptile_comment -->