### PR TITLE
🔒 Fix unbounded array processing vulnerability in bulk route

### DIFF
--- a/packages/web/src/app/api/bibtex/bulk/route.test.ts
+++ b/packages/web/src/app/api/bibtex/bulk/route.test.ts
@@ -80,6 +80,16 @@ describe("/api/bibtex/bulk POST", () => {
         expect(data.error).toContain("papers");
     });
 
+    it("papers が50件を超える場合は 400", async () => {
+        const papers = Array.from({ length: 51 }, (_, i) => ({ title: `Paper ${i}` }));
+        const req = makeRequest({ papers });
+        const res = await POST(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toContain("50件");
+    });
+
     it("個別失敗は errors に集約する", async () => {
         vi.mocked(bibtex.fetchBibtex).mockResolvedValueOnce(null as any);
 

--- a/packages/web/src/app/api/bibtex/bulk/route.ts
+++ b/packages/web/src/app/api/bibtex/bulk/route.ts
@@ -31,6 +31,9 @@ export async function POST(request: NextRequest) {
         if (papers.length === 0) {
             return NextResponse.json({ error: "papers は1件以上必要です" }, { status: 400 });
         }
+        if (papers.length > 50) {
+            return NextResponse.json({ error: "一度に処理できる論文は50件までです" }, { status: 400 });
+        }
 
         const format = parseFormat(body.format);
         const keyFormat = parseKeyFormat(body.keyFormat);


### PR DESCRIPTION
🎯 **What:** The bulk API route processed an arbitrary number of papers without any limits, which could lead to resource exhaustion.

⚠️ **Risk:** An attacker could send an extremely large payload containing thousands of papers, leading to a Denial of Service (DoS) attack by exhausting server memory or worker threads.

🛡️ **Solution:** Added a strict upper limit of 50 papers per request. Requests exceeding this limit immediately return a `400 Bad Request` error. Tests were also added to verify the length check is enforced.

---
*PR created automatically by Jules for task [1193711752625531299](https://jules.google.com/task/1193711752625531299) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

バルク処理APIルートに上限チェックを追加し、1リクエストあたり最大50件を超える論文を拒否することで、無制限の配列処理による DoS リスクを軽減します。

- `route.ts`: `papers.length > 50` のチェックを追加し、超過時に `400` を返すように変更。コードの変更は最小限で正しく動作している。
- `route.test.ts`: 51件送信時の400エラーを検証するテストを追加。境界値ちょうど（50件）が正常に処理されることを確認するテストは含まれていない。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

DoS対策として意図した変更は正しく機能しており、マージしても安全です。

上限チェックのロジック自体は正しく実装されており、テストも追加されています。マジックナンバー `50` がコードとエラーメッセージの両方にリテラルで分散していること、および境界値（ちょうど50件）の正常系テストが欠けている点が改善の余地として残っています。

特に注意が必要なファイルはありませんが、`route.ts` の定数化と `route.test.ts` の境界値テスト追加を検討してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/bibtex/bulk/route.ts | papers配列の上限チェック（50件）を追加。シンプルで正しい実装だが、マジックナンバー50がコードとエラーメッセージに分散している。 |
| packages/web/src/app/api/bibtex/bulk/route.test.ts | 51件での400エラーテストを追加。ただし境界値（ちょうど50件）が成功することを確認するテストが欠けている。 |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/web/src/app/api/bibtex/bulk/route.ts`, line 27-36 ([link](https://github.com/hiroki-org/paper-tools/blob/57d635a338360b1def9a8ebd12965885a6a5631e/packages/web/src/app/api/bibtex/bulk/route.ts#L27-L36)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> 上限値 `50` がチェック条件とエラーメッセージの両方にリテラルで記述されており、将来変更する際に片方だけ修正してしまう恐れがあります。名前付き定数に抽出することで一貫性を保てます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web/src/app/api/bibtex/bulk/route.ts
   Line: 27-36

   Comment:
   上限値 `50` がチェック条件とエラーメッセージの両方にリテラルで記述されており、将来変更する際に片方だけ修正してしまう恐れがあります。名前付き定数に抽出することで一貫性を保てます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web/src/app/api/bibtex/bulk/route.ts:27-36
上限値 `50` がチェック条件とエラーメッセージの両方にリテラルで記述されており、将来変更する際に片方だけ修正してしまう恐れがあります。名前付き定数に抽出することで一貫性を保てます。

```suggestion
const MAX_PAPERS_PER_REQUEST = 50;

export async function POST(request: NextRequest) {
    try {
        const body = (await request.json()) as BulkBody;
        const papers = Array.isArray(body.papers) ? body.papers : [];
        if (papers.length === 0) {
            return NextResponse.json({ error: "papers は1件以上必要です" }, { status: 400 });
        }
        if (papers.length > MAX_PAPERS_PER_REQUEST) {
            return NextResponse.json({ error: `一度に処理できる論文は${MAX_PAPERS_PER_REQUEST}件までです` }, { status: 400 });
        }
```

### Issue 2 of 2
packages/web/src/app/api/bibtex/bulk/route.test.ts:83-91
51件（超過）のエラーケースはテストされていますが、ちょうど50件（上限ぴったり）が正常に受け付けられることを確認するテストがありません。境界値テストを追加することで、`> 50` という条件が `>= 50` に誤変更された場合などを検知できます。

```suggestion
    it("papers が50件を超える場合は 400", async () => {
        const papers = Array.from({ length: 51 }, (_, i) => ({ title: `Paper ${i}` }));
        const req = makeRequest({ papers });
        const res = await POST(req);
        const data = await res.json();

        expect(res.status).toBe(400);
        expect(data.error).toContain("50件");
    });

    it("papers がちょうど50件の場合は 400 にならない", async () => {
        vi.mocked(bibtex.fetchBibtex).mockResolvedValue(null as any);
        const papers = Array.from({ length: 50 }, (_, i) => ({ title: `Paper ${i}` }));
        const req = makeRequest({ papers });
        const res = await POST(req);

        expect(res.status).toBe(200);
    });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix unbounded array processing vulner..."](https://github.com/hiroki-org/paper-tools/commit/57d635a338360b1def9a8ebd12965885a6a5631e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606222)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->