### PR TITLE
🧪 Add tests for runAction helper in drilldown CLI

### DIFF
--- a/packages/drilldown/src/cli.ts
+++ b/packages/drilldown/src/cli.ts
@@ -39,7 +39,7 @@ async function outputJson(data: unknown, output?: string): Promise<void> {
 /**
  * 非同期アクション実行のヘルパー関数
  */
-async function runAction(fn: () => Promise<void>): Promise<void> {
+export async function runAction(fn: () => Promise<void>): Promise<void> {
     try {
         await fn();
     } catch (error) {
@@ -161,4 +161,7 @@ program
         });
     });
 
-program.parse();
+
+if (process.env.NODE_ENV !== 'test') {
+    program.parse();
+}

--- a/packages/drilldown/tests/cli.test.ts
+++ b/packages/drilldown/tests/cli.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runAction } from '../src/cli.js';
+
+describe('runAction', () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+    let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        processExitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should catch Error and log its message', async () => {
+        const error = new Error('Test error message');
+        const fn = vi.fn().mockRejectedValue(error);
+
+        await runAction(fn);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Error:', 'Test error message');
+        expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should catch non-Error and log it directly', async () => {
+        const error = 'String error';
+        const fn = vi.fn().mockRejectedValue(error);
+
+        await runAction(fn);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Error:', 'String error');
+        expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added unit tests for the error handling path of the `runAction` helper function in the drilldown `cli.ts` file. Also updated the CLI entrypoint so it exports `runAction` and avoids calling `program.parse()` during unit tests.

📊 **Coverage:** Vitest now spies on `console.error` and `process.exit` and verifies that standard `Error` objects and generic thrown strings are appropriately logged before calling `process.exit(1)`.

✨ **Result:** Test coverage significantly increased for the CLI, bringing the module to 100% test passing while improving testability for future changes.

---
*PR created automatically by Jules for task [17329327163638331758](https://jules.google.com/task/17329327163638331758) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

drilldown CLI の `runAction` ヘルパーをエクスポートして単体テスト可能にし、テスト実行時に `program.parse()` が呼ばれないよう `NODE_ENV` チェックを追加した PR です。

- `runAction` を `export` に変更し、新規テストファイル `cli.test.ts` から直接インポートできるようにしています。
- Error オブジェクトと文字列スローの2つのエラーパスをスパイ (`console.error`, `process.exit`) を使って検証するテストを追加しています。ただし正常終了パスのテストは含まれていません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更範囲はテスト追加と小さなエクスポート修正のみで、既存の本番動作に直接影響する変更はありません。

runAction のエクスポートと program.parse() のガードはいずれも正しく動作します。NODE_ENV チェックは Vitest 環境では問題ありませんが、他ランナーでの使用を考えると改善の余地があります。また、成功パスのテストが欠落しているため、今後のリグレッションを見逃すリスクがあります。

packages/drilldown/src/cli.ts の NODE_ENV ガード（165–167行）と packages/drilldown/tests/cli.test.ts の成功パステスト欠落を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/src/cli.ts | runAction をエクスポートし、NODE_ENV==='test' 時に program.parse() をスキップする変更。機能自体は問題ないが、NODE_ENV チェックはやや脆弱。 |
| packages/drilldown/tests/cli.test.ts | runAction のエラーハンドリング（Error オブジェクト・文字列スロー）を検証する新規テストファイル。成功パスのカバレッジが欠落している。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as cli.test.ts
    participant RA as runAction (cli.ts)
    participant Fn as fn (mock)
    participant CE as console.error (spy)
    participant PE as process.exit (spy)

    Test->>RA: await runAction(fn)
    RA->>Fn: await fn()
    alt fn が Error をスロー
        Fn-->>RA: throw new Error('...')
        RA->>CE: console.error('Error:', error.message)
        RA->>PE: process.exit(1)
    else fn が文字列をスロー
        Fn-->>RA: throw 'String error'
        RA->>CE: console.error('Error:', 'String error')
        RA->>PE: process.exit(1)
    else fn が正常終了（未テスト）
        Fn-->>RA: resolve
        RA-->>Test: return
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as cli.test.ts
    participant RA as runAction (cli.ts)
    participant Fn as fn (mock)
    participant CE as console.error (spy)
    participant PE as process.exit (spy)

    Test->>RA: await runAction(fn)
    RA->>Fn: await fn()
    alt fn が Error をスロー
        Fn-->>RA: throw new Error('...')
        RA->>CE: console.error('Error:', error.message)
        RA->>PE: process.exit(1)
    else fn が文字列をスロー
        Fn-->>RA: throw 'String error'
        RA->>CE: console.error('Error:', 'String error')
        RA->>PE: process.exit(1)
    else fn が正常終了（未テスト）
        Fn-->>RA: resolve
        RA-->>Test: return
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/drilldown/tests/cli.test.ts:16-35
**成功パスのテストが欠落**

`runAction` のエラーハンドリングは検証されていますが、`fn` が正常に解決した場合（例外なし）のパスがテストされていません。`console.error` も `process.exit` も呼ばれないことを確認するテストが1件あると、今後のリグレッション検出に役立ちます。例えば `fn` が解決するモックを渡し、両スパイが呼ばれていないことを `expect(...).not.toHaveBeenCalled()` で確認するケースが該当します。

### Issue 2 of 2
packages/drilldown/src/cli.ts:165-167
**`NODE_ENV` チェックの脆弱性**

`process.env.NODE_ENV !== 'test'` は Vitest がデフォルトで `NODE_ENV=test` を設定するため現状は動作しますが、他のテストランナーや `--no-env` 相当のフラグを使うと `program.parse()` が実行されてしまいます。より堅牢な手法として、`import.meta.url` と `process.argv[1]` を比較してエントリポイントかどうかを判定するパターンがあります（例: `fileURLToPath(import.meta.url) === realpathSync(process.argv[1])`）。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add unit tests for runAction helpe..."](https://github.com/hiroki-org/paper-tools/commit/3ff52f1ad112d332afed83657fe3e94264d9b6b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606226)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->