### PR TITLE
🔒 Fix missing runtime type validation for databaseId

### DIFF
--- a/packages/web/src/app/api/databases/select/route.test.ts
+++ b/packages/web/src/app/api/databases/select/route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+    getAccessToken: vi.fn(),
+    getNotionClient: vi.fn(),
+    setDatabaseCookie: vi.fn(),
+}));
+
+vi.mock("@/lib/notion-data-source", () => ({
+    resolveNotionDataSource: vi.fn(),
+}));
+
+const auth = await import("@/lib/auth");
+const notionDataSource = await import("@/lib/notion-data-source");
+const { POST } = await import("./route");
+
+function makeRequest(body: any) {
+    return new NextRequest("http://localhost/api/databases/select", {
+        method: "POST",
+        headers: {
+            cookie: "access_token=dummy_token",
+            "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+describe("/api/databases/select POST", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("Unauthorized 401 when access token is missing", async () => {
+        vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
+
+        const res = await POST(makeRequest({ databaseId: "test_db" }));
+        const data = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(data.error).toBe("Unauthorized");
+    });
+
+    it("Returns 400 if databaseId is not a string", async () => {
+        vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
+
+        const res = await POST(makeRequest({ databaseId: 123 }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toBe("databaseId must be a string");
+    });
+
+    it("Returns 400 if databaseId is missing", async () => {
+        vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
+
+        const res = await POST(makeRequest({}));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toBe("databaseId must be a string");
+    });
+
+    it("Returns 400 if databaseId is empty or whitespace", async () => {
+        vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
+
+        const res = await POST(makeRequest({ databaseId: "   " }));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toBe("databaseId is required");
+    });
+
+    it("Successfully selects a database", async () => {
+        vi.mocked(auth.getAccessToken).mockReturnValueOnce("valid_token");
+        vi.mocked(auth.getNotionClient).mockReturnValueOnce({} as any);
+
+        vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValueOnce({
+            id: "db1",
+            properties: {
+                title: { type: "title" },
+                doi: { type: "rich_text" }
+            }
+        } as any);
+
+        const res = await POST(makeRequest({ databaseId: " db1 " }));
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.success).toBe(true);
+        expect(data.warnings).toEqual([]);
+        expect(auth.setDatabaseCookie).toHaveBeenCalled();
+    });
+});

--- a/packages/web/src/app/api/databases/select/route.ts
+++ b/packages/web/src/app/api/databases/select/route.ts
@@ -29,7 +29,12 @@ export async function POST(request: NextRequest) {
 
     try {
         const body = (await request.json()) as SelectBody;
-        const databaseId = body.databaseId?.trim();
+
+        if (typeof body.databaseId !== "string") {
+            return NextResponse.json({ error: "databaseId must be a string" }, { status: 400 });
+        }
+
+        const databaseId = body.databaseId.trim();
         if (!databaseId) {
             return NextResponse.json({ error: "databaseId is required" }, { status: 400 });
         }


### PR DESCRIPTION
🎯 **What:** The `databaseId` input in the `/api/databases/select` endpoint was lacking a runtime type check before calling `.trim()`.

⚠️ **Risk:** If a malicious user sent a payload where `databaseId` was not a string (e.g., a number or an object), the server would attempt to call `.trim()` on it, leading to an unhandled `TypeError`. This could cause the endpoint to crash or return an unexpected 500 status code.

🛡️ **Solution:** Added a runtime type check (`typeof body.databaseId !== "string"`) to ensure `databaseId` is a string before calling `.trim()`. If it's not a string, a 400 Bad Request response is returned. Additionally, comprehensive unit tests were added to verify that valid and invalid payloads are handled securely.

---
*PR created automatically by Jules for task [11455249831224813907](https://jules.google.com/task/11455249831224813907) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `/api/databases/select` エンドポイントにおいて、`databaseId` が文字列以外の値（数値やオブジェクトなど）で送信された場合に `.trim()` を呼び出すと発生していた `TypeError` を修正します。また、修正内容を検証する包括的なユニットテストが追加されています。

- `typeof body.databaseId !== \"string\"` の型チェックを追加し、文字列でない場合は 400 を返すよう変更。
- 新規テストファイル (`route.test.ts`) を追加し、401・400（型エラー）・400（空文字）・200（正常系）の各シナリオを網羅。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は局所的でリスクが低く、型チェックの追加とテストのみで本質的なロジックは変わっていない。

修正自体は正確で `typeof` チェックが正しい位置に挿入されている。ただし `request.json()` が `null` を返すケース（ボディが JSON の null）については型チェック前に `body` 自体がオブジェクトかを確認していないため、`body.databaseId` へのアクセスで `TypeError` が発生し 500 レスポンスになる可能性が残っている。

packages/web/src/app/api/databases/select/route.ts — `body` が null の場合の追加ガード検討が望ましい。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/databases/select/route.ts | databaseIdの型チェックを追加。bodyがnullの場合にTypeErrorが発生する可能性が残っている。 |
| packages/web/src/app/api/databases/select/route.test.ts | 新規テストファイル。主要シナリオのカバレッジは十分だが、bodyがnullのケースは未テスト。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web/src/app/api/databases/select/route.ts:31-33
`body` が JSON の `null` の場合（例: リクエストボディが文字列 `"null"` のとき）、`request.json()` は `null` を返します。その状態で `body.databaseId` にアクセスすると `TypeError: Cannot read properties of null` が発生し、外側の `catch` に捕捉されて 500 が返されます。今回追加した文字列チェックの前に、`body` がオブジェクトであることを確認することで 400 を返せます。

```suggestion
        const body = (await request.json()) as SelectBody;

        if (body === null || typeof body !== "object") {
            return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
        }

        if (typeof body.databaseId !== "string") {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix missing runtime type validation f..."](https://github.com/hiroki-org/paper-tools/commit/b77445151ea055ac458454f04cdfbc549cfe74c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606242)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->