### PR TITLE
🧹 Fix unnecessary use of 'any' in notion client

### DIFF
--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -47,6 +47,7 @@ function createNotionClient(): Client {
 
 type NotionDatabase = {
     properties: Record<string, { type: string }>;
+    title?: unknown;
 };
 
 export interface DatabaseValidationResult {
@@ -122,13 +123,13 @@ export async function getDatabaseInfo(
     databaseId: string,
     client: Client = createNotionClient(),
 ): Promise<NotionDatabaseInfo> {
-    const database = await client.databases.retrieve({ database_id: databaseId }) as any;
-    const databaseName = extractPlainText(database?.title) || "(untitled database)";
+    const database = await client.databases.retrieve({ database_id: databaseId }) as unknown as NotionDatabase;
+    const databaseName = extractPlainText(database.title) || "(untitled database)";
 
     let workspaceName = "Notion Workspace";
     try {
         const me = await client.users.me({});
-        workspaceName = (me as any)?.name?.trim() || workspaceName;
+        workspaceName = (me as unknown as { name?: string })?.name?.trim() || workspaceName;
     } catch (e) {
         console.warn("Failed to retrieve Notion workspace name, falling back to default:", e);
     }


### PR DESCRIPTION
🎯 **What:** Removed two instances of `as any` casts in `packages/recommender/src/notion-client.ts`.
💡 **Why:** Using `any` undermines TypeScript's type safety. Replacing it with proper types improves code quality, predictability, and maintainability.
✅ **Verification:** Verified that tests in `packages/recommender` pass, ran typechecking successfully via workspace build (`pnpm build`), and manually inspected the modified types in the codebase. Code Review passed with #Correct# rating.
✨ **Result:** The code health issue concerning the unnecessary use of `any` has been resolved safely without breaking runtime behavior.

---
*PR created automatically by Jules for task [16846092144689320163](https://jules.google.com/task/16846092144689320163) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`packages/recommender/src/notion-client.ts` 内の `as any` キャストを 2 箇所 `as unknown as T` に置き換え、型安全性を向上させた PR です。ロジック変更はなく、型レベルのみの修正です。

- `getDatabaseInfo` で `client.databases.retrieve()` の戻り値キャストを `as any` から `as unknown as NotionDatabase` に変更し、`NotionDatabase` 型に `title?: unknown` フィールドを追加。
- `client.users.me()` の戻り値キャストを `as any` から `as unknown as { name?: string }` に変更し、アクセスするプロパティを型で明示。
- 同ファイルの `NotionPage.properties: Record<string, any>`（144行目）および `notionProperties as any`（254行目）は今回の変更対象外として残存している。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

型キャストのみの変更であり、ランタイム動作は変わらない。マージしても安全。

変更はすべて型レベルに閉じており、ロジックの変更はない。`as any` から `as unknown as T` への置き換えは適切で、`extractPlainText` が `unknown` を受け付けるため `title?: unknown` の追加も機能上の問題はない。同ファイルに残存する `any` 箇所が未対応だが、スタイル上の指摘に留まる。

packages/recommender/src/notion-client.ts — 残存する `any` 箇所（144行目・254行目）を追跡する価値がある。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/recommender/src/notion-client.ts | `as any` を 2 箇所 `as unknown as T` に置き換え、`NotionDatabase` 型に `title?: unknown` フィールドを追加。ロジック変更はなし。ただし同ファイルに残存する `any` 箇所が 2 つある。 |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant getDatabaseInfo
    participant NotionSDK
    participant extractPlainText

    Caller->>getDatabaseInfo: getDatabaseInfo(databaseId, client)
    getDatabaseInfo->>NotionSDK: client.databases.retrieve
    NotionSDK-->>getDatabaseInfo: DatabaseObjectResponse cast to NotionDatabase
    getDatabaseInfo->>extractPlainText: extractPlainText(database.title)
    Note over extractPlainText: title unknown to Array.isArray check
    extractPlainText-->>getDatabaseInfo: databaseName string
    getDatabaseInfo->>NotionSDK: client.users.me
    NotionSDK-->>getDatabaseInfo: UserObjectResponse cast to name string
    getDatabaseInfo-->>Caller: NotionDatabaseInfo
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant getDatabaseInfo
    participant NotionSDK
    participant extractPlainText

    Caller->>getDatabaseInfo: getDatabaseInfo(databaseId, client)
    getDatabaseInfo->>NotionSDK: client.databases.retrieve
    NotionSDK-->>getDatabaseInfo: DatabaseObjectResponse cast to NotionDatabase
    getDatabaseInfo->>extractPlainText: extractPlainText(database.title)
    Note over extractPlainText: title unknown to Array.isArray check
    extractPlainText-->>getDatabaseInfo: databaseName string
    getDatabaseInfo->>NotionSDK: client.users.me
    NotionSDK-->>getDatabaseInfo: UserObjectResponse cast to name string
    getDatabaseInfo-->>Caller: NotionDatabaseInfo
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/recommender/src/notion-client.ts`, line 144-147 ([link](https://github.com/hiroki-org/paper-tools/blob/51ad34faf160d73fd43d925144268730f6e90a4f/packages/recommender/src/notion-client.ts#L144-L147)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **同ファイルに残存する `any` が未対応**

   このPRは `as any` を 2 箇所修正していますが、同じファイルに `any` がまだ残っています。`NotionPage.properties` の型（144〜147行目）は `Record<string, any>` のままであり、254行目の `notionProperties as any` も残存しています。

   `NotionPage.properties` については `Record<string, unknown>` にして各アクセス箇所で型を絞るか、`@notionhq/client` が公開している `PageObjectResponse` 型を直接使う方向が一貫性の観点で望ましいです。PR タイトルが「unnecessary use of 'any' の修正」であるため、これらも対象にするか、別 PR として追跡することを検討してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/recommender/src/notion-client.ts
   Line: 144-147

   Comment:
   **同ファイルに残存する `any` が未対応**

   このPRは `as any` を 2 箇所修正していますが、同じファイルに `any` がまだ残っています。`NotionPage.properties` の型（144〜147行目）は `Record<string, any>` のままであり、254行目の `notionProperties as any` も残存しています。

   `NotionPage.properties` については `Record<string, unknown>` にして各アクセス箇所で型を絞るか、`@notionhq/client` が公開している `PageObjectResponse` 型を直接使う方向が一貫性の観点で望ましいです。PR タイトルが「unnecessary use of 'any' の修正」であるため、これらも対象にするか、別 PR として追跡することを検討してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/recommender/src/notion-client.ts:144-147
**同ファイルに残存する `any` が未対応**

このPRは `as any` を 2 箇所修正していますが、同じファイルに `any` がまだ残っています。`NotionPage.properties` の型（144〜147行目）は `Record<string, any>` のままであり、254行目の `notionProperties as any` も残存しています。

`NotionPage.properties` については `Record<string, unknown>` にして各アクセス箇所で型を絞るか、`@notionhq/client` が公開している `PageObjectResponse` 型を直接使う方向が一貫性の観点で望ましいです。PR タイトルが「unnecessary use of 'any' の修正」であるため、これらも対象にするか、別 PR として追跡することを検討してください。

### Issue 2 of 2
packages/recommender/src/notion-client.ts:50
**`title?: unknown` は過度に緩い型**

`NotionDatabase.title` を `unknown` にするとコンパイルは通りますが、`extractPlainText` の引数型がすでに `unknown` を受け付けているため問題は表面化しません。Notion SDK の `DatabaseObjectResponse` では `title` は `Array<RichTextItemResponse>` として定義されているため、型情報をより正確にするなら `Array<{ plain_text?: string }>` 程度を指定できます。現状でも実行時の動作は正しいですが、型の精度という観点で改善の余地があります。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Fix unnecessary use of &#39;any&#39; in notio..."](https://github.com/hiroki-org/paper-tools/commit/51ad34faf160d73fd43d925144268730f6e90a4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606338)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->