### PR TITLE
🔒 Fix missing runtime validation for resolution parameters

### DIFF
--- a/packages/web/src/app/api/resolve/route.test.ts
+++ b/packages/web/src/app/api/resolve/route.test.ts
@@ -66,6 +66,16 @@ describe("/api/resolve POST", () => {
         expect(data.paper.paperId).toBe("abc123");
     });
 
+    it("不正な型は400", async () => {
+        const res = await POST(makeRequest([{ doi: "10" }]));
+        expect(res.status).toBe(400);
+    });
+
+    it("フィールドの不正な型は無視される", async () => {
+        const res = await POST(makeRequest({ doi: 123 }));
+        expect(res.status).toBe(400);
+    });
+
     it("入力不足は400", async () => {
         const res = await POST(makeRequest({}));
         const data = await res.json();

--- a/packages/web/src/app/api/resolve/route.ts
+++ b/packages/web/src/app/api/resolve/route.ts
@@ -13,10 +13,14 @@ function normalizeDoi(input: string) {
 
 export async function POST(request: NextRequest) {
     try {
-        const body = (await request.json()) as ResolveBody;
-        const doi = body.doi?.trim();
-        const title = body.title?.trim();
-        const s2Id = body.s2Id?.trim();
+        const rawBody = await request.json();
+        if (!rawBody || typeof rawBody !== 'object' || Array.isArray(rawBody)) {
+            return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+        }
+        const body = rawBody as Record<string, unknown>;
+        const doi = typeof body.doi === 'string' ? body.doi.trim() : undefined;
+        const title = typeof body.title === 'string' ? body.title.trim() : undefined;
+        const s2Id = typeof body.s2Id === 'string' ? body.s2Id.trim() : undefined;
 
         if (!doi && !title && !s2Id) {
             return NextResponse.json(


### PR DESCRIPTION
🎯 **What:**
Added runtime type validation to the `/api/resolve` POST route to ensure the parsed JSON body is a valid object and the `doi`, `title`, and `s2Id` fields are strings before processing them.

⚠️ **Risk:**
Without runtime validation, passing an array or an unexpected primitive type in the request body, or passing unexpected types (like objects) for the specific fields, could cause runtime errors (e.g., `TypeError` when calling `.trim()` on a non-string). This could lead to crashes (Denial of Service) or potential prototype pollution vulnerabilities depending on how the data is handled downstream.

🛡️ **Solution:**
Replaced the unsafe type casting (`as ResolveBody`) with a rigorous check ensuring `rawBody` is a non-null object and not an array. Added explicit `typeof ... === 'string'` checks before calling `.trim()` on the parameters, falling back to `undefined` for invalid types, gracefully returning a 400 Bad Request if no valid parameters are provided. Also added corresponding test cases to verify this behavior.

---
*PR created automatically by Jules for task [9396151140465442390](https://jules.google.com/task/9396151140465442390) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`/api/resolve` POST ルートに対してランタイムバリデーションを追加したPRです。`as ResolveBody` の unsafe キャストを廃止し、ボディが非null オブジェクトであること、各フィールドが文字列であることを明示的に検証するようになりました。

- **route.ts**: `!rawBody`・`typeof !== 'object'`・`Array.isArray` の3段階チェックでボディ形式を検証し、各フィールドは `typeof === 'string'` の場合のみ `.trim()` を呼び出して、それ以外は `undefined` にフォールバックします。
- **route.test.ts**: 配列ボディと数値フィールドの2テストケースを追加しており、新しいバリデーションパスをカバーしています。ただし `null` ボディのケースと、テスト名の表現に若干の改善余地があります。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

実装ロジックは正しく、既存の動作への影響もありません。テストの命名と null ボディのカバレッジに軽微な改善余地がある程度です。

バリデーションロジック自体は堅牢で、null/配列/非文字列フィールドのすべてを適切に処理しています。テスト名と null ボディのカバレッジに軽微な改善余地がありますが、コードの動作には影響しません。

route.test.ts のテスト名と null ボディカバレッジ。route.ts 自体は問題なし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/resolve/route.ts | ランタイムバリデーションを追加。rawBodyのnull/配列チェックと、各フィールドのtypeofチェックにより、非文字列入力でのクラッシュを防止。ロジックは正しく、既存動作への副作用もない。 |
| packages/web/src/app/api/resolve/route.test.ts | 配列ボディと数値フィールドの2ケースを追加。ただしテスト名「フィールドの不正な型は無視される」が400を返す副作用を隠しており、nullボディのカバレッジもない。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /api/resolve] --> B[request.json]
    B --> C{rawBodyが有効か}
    C -->|non-null/object/not array| E[Record に型変換]
    C -->|invalid| D[400 Invalid request body]
    E --> F[doi: string? trim else undefined]
    E --> G[title: string? trim else undefined]
    E --> H[s2Id: string? trim else undefined]
    F --> O{いずれかが存在?}
    G --> O
    H --> O
    O -->|なし| P[400 入力不足]
    O -->|doi| Q[getPaper DOI]
    O -->|title| R[searchPapers]
    O -->|s2Id| S[getPaper s2Id]
    Q --> T{paperが存在?}
    R --> T
    S --> T
    T -->|yes| U[200 paper]
    T -->|no| V[404 解決できず]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[POST /api/resolve] --> B[request.json]
    B --> C{rawBodyが有効か}
    C -->|non-null/object/not array| E[Record に型変換]
    C -->|invalid| D[400 Invalid request body]
    E --> F[doi: string? trim else undefined]
    E --> G[title: string? trim else undefined]
    E --> H[s2Id: string? trim else undefined]
    F --> O{いずれかが存在?}
    G --> O
    H --> O
    O -->|なし| P[400 入力不足]
    O -->|doi| Q[getPaper DOI]
    O -->|title| R[searchPapers]
    O -->|s2Id| S[getPaper s2Id]
    Q --> T{paperが存在?}
    R --> T
    S --> T
    T -->|yes| U[200 paper]
    T -->|no| V[404 解決できず]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web/src/app/api/resolve/route.test.ts:74-77
テスト名「フィールドの不正な型は無視される」は実際の動作を正確に表していません。`doi: 123` を渡すと型チェックで `doi` が `undefined` になり、有効なパラメーターが1つも残らないため 400 が返ります。「無視される」という表現は副作用（全フィールド欠落 → 400）を隠しており、将来のメンテナーが混乱する恐れがあります。

```suggestion
    it("フィールドが全て無効な型の場合は400", async () => {
        const res = await POST(makeRequest({ doi: 123 }));
        expect(res.status).toBe(400);
    });
```

### Issue 2 of 2
packages/web/src/app/api/resolve/route.test.ts:69-77
**`null` ボディのテストケースが不足**

JSON として `null` を送信した場合（`makeRequest(null)`）、`!rawBody` の条件が `true` になって 400 が返る想定ですが、このケースがテストで網羅されていません。`typeof null === 'object'` という JavaScript の挙動があるため、`!rawBody` チェックが特に重要であり、その動作を保証するテストがあると安心感が増します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): add runtime type validation fo..."](https://github.com/hiroki-org/paper-tools/commit/ff3899fa03660bc19d7f5267df074953d5e6d5bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606361)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->