### PR TITLE
🧹 Refactor: Remove unnecessary any in Notion auth callback

### DIFF
--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -1,66 +1,90 @@
 import { Client } from "@notionhq/client";
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import {
-    OAUTH_STATE_COOKIE,
-    buildNotionRedirectUri,
-    setAuthCookies,
+	buildNotionRedirectUri,
+	OAUTH_STATE_COOKIE,
+	setAuthCookies,
 } from "@/lib/auth";
 
+interface NotionTokenResponse {
+	access_token: string;
+	workspace_id: string;
+	workspace_name: string | null;
+	workspace_icon: string | null;
+	owner: {
+		type: string;
+		user?: {
+			name?: string;
+			avatar_url?: string;
+		};
+	};
+	refresh_token?: string;
+}
+
 export async function GET(request: NextRequest) {
-    const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
-    const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
-    if (!clientId || !clientSecret) {
-        return NextResponse.redirect(new URL("/login?error=missing_oauth_config", request.url));
-    }
+	const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
+	const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
+	if (!clientId || !clientSecret) {
+		return NextResponse.redirect(
+			new URL("/login?error=missing_oauth_config", request.url),
+		);
+	}
 
-    const url = new URL(request.url);
-    const code = url.searchParams.get("code");
-    const state = url.searchParams.get("state");
-    const stateInCookie = request.cookies.get(OAUTH_STATE_COOKIE)?.value;
+	const url = new URL(request.url);
+	const code = url.searchParams.get("code");
+	const state = url.searchParams.get("state");
+	const stateInCookie = request.cookies.get(OAUTH_STATE_COOKIE)?.value;
 
-    if (!code || !state || !stateInCookie || state !== stateInCookie) {
-        return NextResponse.redirect(new URL("/login?error=invalid_state", request.url));
-    }
+	if (!code || !state || !stateInCookie || state !== stateInCookie) {
+		return NextResponse.redirect(
+			new URL("/login?error=invalid_state", request.url),
+		);
+	}
 
-    try {
-        const notion = new Client();
-        const tokenResponse = await notion.oauth.token({
-            client_id: clientId,
-            client_secret: clientSecret,
-            grant_type: "authorization_code",
-            code,
-            redirect_uri: buildNotionRedirectUri(request),
-        });
+	try {
+		const notion = new Client();
+		const tokenResponse = (await notion.oauth.token({
+			client_id: clientId,
+			client_secret: clientSecret,
+			grant_type: "authorization_code",
+			code,
+			redirect_uri: buildNotionRedirectUri(request),
+		})) as unknown as NotionTokenResponse;
 
-        const owner = tokenResponse.owner;
-        const userName = owner.type === "user" ? (owner.user as any)?.name : undefined;
+		const owner = tokenResponse.owner;
+		const userName = owner.type === "user" ? owner.user?.name : undefined;
 
-        const response = NextResponse.redirect(new URL("/setup", request.url));
-        const refreshToken = (tokenResponse as any).refresh_token as string | undefined;
-        if (!refreshToken) {
-            return NextResponse.redirect(new URL("/login?error=missing_refresh_token", request.url));
-        }
+		const response = NextResponse.redirect(new URL("/setup", request.url));
+		const refreshToken = tokenResponse.refresh_token;
+		if (!refreshToken) {
+			return NextResponse.redirect(
+				new URL("/login?error=missing_refresh_token", request.url),
+			);
+		}
 
-        setAuthCookies(response, {
-            accessToken: tokenResponse.access_token,
-            refreshToken,
-            userInfo: {
-                name: userName,
-                workspaceName: tokenResponse.workspace_name ?? undefined,
-                workspaceIcon: tokenResponse.workspace_icon,
-            },
-            request,
-        });
-        response.cookies.set(OAUTH_STATE_COOKIE, "", {
-            path: "/",
-            maxAge: 0,
-            httpOnly: true,
-            secure: process.env.NODE_ENV === "production",
-            sameSite: "lax",
-        });
-        return response;
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "OAuth callback failed";
-        return NextResponse.redirect(new URL(`/login?error=${encodeURIComponent(message)}`, request.url));
-    }
+		setAuthCookies(response, {
+			accessToken: tokenResponse.access_token,
+			refreshToken,
+			userInfo: {
+				name: userName,
+				workspaceName: tokenResponse.workspace_name ?? undefined,
+				workspaceIcon: tokenResponse.workspace_icon,
+			},
+			request,
+		});
+		response.cookies.set(OAUTH_STATE_COOKIE, "", {
+			path: "/",
+			maxAge: 0,
+			httpOnly: true,
+			secure: process.env.NODE_ENV === "production",
+			sameSite: "lax",
+		});
+		return response;
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "OAuth callback failed";
+		return NextResponse.redirect(
+			new URL(`/login?error=${encodeURIComponent(message)}`, request.url),
+		);
+	}
 }


### PR DESCRIPTION
🎯 **What:** Removed the unnecessary use of `any` in `packages/web/src/app/api/auth/callback/notion/route.ts` by introducing the `NotionTokenResponse` interface.
💡 **Why:** Defining an explicit interface for the Notion token response improves type safety, eliminates the need for `as any` type assertions, and self-documents the API response shape.
✅ **Verification:** Verified changes by reading the code. Ran `pnpm dlx @biomejs/biome check --write` to ensure proper formatting and linting. Ran the full test suite (`pnpm test` in the workspace packages) to verify that no functionality was broken.
✨ **Result:** Improved maintainability and type safety in the Notion OAuth callback route without altering existing behavior.

---
*PR created automatically by Jules for task [647574041171209865](https://jules.google.com/task/647574041171209865) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuth コールバックルートから散在していた `as any` キャストを除去し、`NotionTokenResponse` インターフェースを導入することで API レスポンスの形状を明示化したリファクタリングです。インデントスタイルの統一（タブ化）も含まれています。

- **`any` の置き換え**: `(tokenResponse as any).refresh_token` と `(owner.user as any)?.name` を `NotionTokenResponse` インターフェースへのキャストに統合し、自己文書化と一元管理を実現。
- **残存リスク**: 置き換え後も `as unknown as NotionTokenResponse` という二重キャストを使用しており、実行時の型安全性は以前と同等。インターフェースの形状が実際の Notion API レスポンスと乖離しても TypeScript は検出できない。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

既存の動作に変更はなく、コードの意図がより明確になっている。マージして問題ない。

変更は純粋にリファクタリングであり、ロジックの変更はない。`as unknown as NotionTokenResponse` という二重キャストが残るため、将来 Notion SDK や API レスポンスの形状が変化した際に静的解析で検出できない点は惜しいが、動作自体は従来と同一。

特に注意が必要なファイルはないが、`NotionTokenResponse` インターフェースの形状が実際の Notion API 仕様と一致しているか、SDK のアップグレード時に確認する運用が望ましい。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/callback/notion/route.ts | NotionTokenResponse インターフェースを導入して any を排除。as unknown as NotionTokenResponse という二重キャストが残っており、実行時の型安全性は as any と同等だが、自己文書化の観点では改善。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Route as GET /api/auth/callback/notion
    participant NotionSDK as notion.oauth.token()
    participant AuthLib as setAuthCookies()

    Browser->>Route: "GET ?code=...&state=..."
    Route->>Route: state cookie 検証
    alt state 不一致または欠落
        Route-->>Browser: "redirect /login?error=invalid_state"
    end
    Route->>NotionSDK: "token({ code, redirect_uri, ... })"
    NotionSDK-->>Route: unknown → as unknown as NotionTokenResponse
    alt refresh_token が undefined
        Route-->>Browser: "redirect /login?error=missing_refresh_token"
    end
    Route->>AuthLib: setAuthCookies(accessToken, refreshToken, userInfo)
    Route->>Route: OAUTH_STATE_COOKIE をクリア
    Route-->>Browser: redirect /setup
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Route as GET /api/auth/callback/notion
    participant NotionSDK as notion.oauth.token()
    participant AuthLib as setAuthCookies()

    Browser->>Route: "GET ?code=...&state=..."
    Route->>Route: state cookie 検証
    alt state 不一致または欠落
        Route-->>Browser: "redirect /login?error=invalid_state"
    end
    Route->>NotionSDK: "token({ code, redirect_uri, ... })"
    NotionSDK-->>Route: unknown → as unknown as NotionTokenResponse
    alt refresh_token が undefined
        Route-->>Browser: "redirect /login?error=missing_refresh_token"
    end
    Route->>AuthLib: setAuthCookies(accessToken, refreshToken, userInfo)
    Route->>Route: OAUTH_STATE_COOKIE をクリア
    Route-->>Browser: redirect /setup
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web/src/app/api/auth/callback/notion/route.ts:46-52
**`as unknown as` は `as any` と同等のリスク**

`as unknown as NotionTokenResponse` という二重キャストは TypeScript の型検査を完全に回避するため、実行時の安全性は元の `as any` と変わりません。Notion SDK が将来 `refresh_token` を省略したり、`owner` の形状を変更した場合、コンパイルエラーなしに実行時エラーが発生します。インターフェースの自己文書化効果は得られますが、型安全性の向上という点では限定的です。`zod` などによるランタイムバリデーション、もしくは SDK の公開型（`OauthTokenResponse`）と交差型で補う方法がより堅牢です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Refactor: Remove unnecessary any in N..."](https://github.com/hiroki-org/paper-tools/commit/d3acdd3ae0a8e8a63b59a27a56e40db1b75aeb9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606593)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->