### PR TITLE
🧪 Add tests for useSavedPapers hook

### DIFF
--- a/packages/web/src/app/search/hooks/useSavedPapers.test.ts
+++ b/packages/web/src/app/search/hooks/useSavedPapers.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { Paper } from "@paper-tools/core";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSavedPapers } from "./useSavedPapers";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("useSavedPapers", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it("should initialize empty and fetch archive correctly", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				records: [
+					{ doi: "10.123/456", title: "Test Paper" },
+					{ title: "No DOI Paper" },
+				],
+			}),
+		});
+
+		const { result } = renderHook(() => useSavedPapers());
+
+		expect(mockFetch).toHaveBeenCalledWith("/api/archive");
+
+		await waitFor(() => {
+			expect(result.current.isSaved({ doi: "10.123/456" } as Paper)).toBe(true);
+		});
+
+		expect(result.current.isSaved({ title: "Test Paper" } as Paper)).toBe(true);
+		expect(result.current.isSaved({ title: "No DOI Paper" } as Paper)).toBe(
+			true,
+		);
+		expect(
+			result.current.isSaved({ doi: "unknown", title: "unknown" } as Paper),
+		).toBe(false);
+	});
+
+	it("should handle empty or malformed fetch responses gracefully", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ records: null }),
+		});
+
+		const { result } = renderHook(() => useSavedPapers());
+
+		await waitFor(() => {
+			expect(mockFetch).toHaveBeenCalled();
+		});
+
+		expect(result.current.isSaved({ doi: "10.123/456" } as Paper)).toBe(false);
+	});
+
+	it("should mark paper as saved", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ records: [] }),
+		});
+
+		const { result } = renderHook(() => useSavedPapers());
+
+		await waitFor(() => {
+			expect(mockFetch).toHaveBeenCalled();
+		});
+
+		const paper = { doi: "10.999/111", title: "New Paper" } as Paper;
+
+		act(() => {
+			result.current.markSaved(paper);
+		});
+
+		expect(result.current.isSaved(paper)).toBe(true);
+
+		// Testing with only title
+		const paperOnlyTitle = { title: "Title Only" } as Paper;
+		act(() => {
+			result.current.markSaved(paperOnlyTitle);
+		});
+
+		expect(result.current.isSaved(paperOnlyTitle)).toBe(true);
+		expect(result.current.isSaved({ doi: "10.999/111" } as Paper)).toBe(true); // Should match by DOI
+	});
+
+	it("should handle failed fetch without throwing", async () => {
+		mockFetch.mockRejectedValueOnce(new Error("Network Error"));
+
+		const { result } = renderHook(() => useSavedPapers());
+
+		await waitFor(() => {
+			expect(mockFetch).toHaveBeenCalled();
+		});
+
+		// Should still work for marking new papers
+		const paper = { doi: "10.999/error", title: "Error Paper" } as Paper;
+		act(() => {
+			result.current.markSaved(paper);
+		});
+		expect(result.current.isSaved(paper)).toBe(true);
+	});
+});


### PR DESCRIPTION
🎯 **What:** 
Added comprehensive unit tests for the previously untested `useSavedPapers` custom hook in the `@paper-tools/web` package. This hook manages state for saved papers by fetching an initial list from `/api/archive` and providing methods to check if a paper is saved and mark new ones as saved.

📊 **Coverage:** 
The new test suite covers:
*   **Happy Path:** Initializes successfully and accurately synchronizes with the `fetchArchive` API call.
*   **Error Handling:** Gracefully handles malformed or empty payloads (e.g., `records: null`) and handles internal fetch exceptions safely without crashing the UI.
*   **State Manipulation:** Properly verifies behavior for the `markSaved` and `isSaved` functions using precise `@testing-library/react` `act` logic, accurately resolving both DOI and title cases.

✨ **Result:** 
The reliability of the `useSavedPapers` hook is significantly increased. We are now protected against regressions related to API parsing errors and asynchronous state synchronization. Coverage metrics for `useSavedPapers.ts` are heavily improved.

---
*PR created automatically by Jules for task [3611352620395507779](https://jules.google.com/task/3611352620395507779) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`useSavedPapers` カスタムフックに対する初回のユニットテスト群を追加するPRです。4つのテストケース（正常系・不正レスポンス・`markSaved`・fetch失敗）でフックの主要な挙動をカバーしています。

- **`act()` の非 await（2箇所）**: `markSaved` を呼ぶ `act()` が await されておらず、React 18 環境では状態更新がコミットされる前にアサーションが実行される恐れがある。
- **`waitFor` の対象が fetch 開始の確認のみ**: 非同期チェーン完了を保証しないため、`waitFor` 内で実際の状態変化をアサートする形が堅牢。
- **`res.ok === false` ケースの未テスト**: フック実装にある早期リターン分岐が保護されていない。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

テスト自体は今の JSDOM 環境でおそらく通過しますが、`act()` の非 await パターンが複数箇所あり、ライブラリや React のバージョンアップ時に flaky になるリスクを抱えたままマージされます。

`act()` を await しないパターンが「should mark paper as saved」と「should handle failed fetch without throwing」の2テストに存在します。React 18 のバージョンアップ後に状態更新のコミット前にアサーションが走る可能性があり、信頼性の低いテストスイートになる恐れがあります。

`packages/web/src/app/search/hooks/useSavedPapers.test.ts` — `act()` の await 漏れを中心に確認が必要です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/search/hooks/useSavedPapers.test.ts | useSavedPapers の新規テストファイル。4ケースをカバーするが `act()` を await していないためフレークなテストになる可能性がある。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Test (vitest/RTL)
    participant Hook as useSavedPapers
    participant Fetch as global.fetch (mocked)

    Test->>Hook: renderHook()
    Hook->>Fetch: fetch("/api/archive")
    Fetch-->>Hook: resolved / rejected

    alt 正常系
        Hook->>Hook: setSavedKeys(new Set([doi, title]))
    else records: null
        Hook->>Hook: setSavedKeys(new Set())
    else fetch throws
        Hook->>Hook: catch console.warn
    end

    Test->>Hook: waitFor(...)
    Test->>Hook: "act(() => markSaved(paper))"
    Note over Test: await なし → 状態更新未確定のまま assert 可能性
    Hook->>Hook: setSavedKeys(prev + new keys)
    Test->>Hook: isSaved(paper) → expect true
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Test (vitest/RTL)
    participant Hook as useSavedPapers
    participant Fetch as global.fetch (mocked)

    Test->>Hook: renderHook()
    Hook->>Fetch: fetch("/api/archive")
    Fetch-->>Hook: resolved / rejected

    alt 正常系
        Hook->>Hook: setSavedKeys(new Set([doi, title]))
    else records: null
        Hook->>Hook: setSavedKeys(new Set())
    else fetch throws
        Hook->>Hook: catch console.warn
    end

    Test->>Hook: waitFor(...)
    Test->>Hook: "act(() => markSaved(paper))"
    Note over Test: await なし → 状態更新未確定のまま assert 可能性
    Hook->>Hook: setSavedKeys(prev + new keys)
    Test->>Hook: isSaved(paper) → expect true
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:75-85
`act()` が await されていません。React 18 では `act()` は async であり、await しないと `setSavedKeys` による状態更新がコミットされる前にアサーションが実行される可能性があります。同じ問題が 101 行目にも存在します。

```suggestion
		await act(async () => {
			result.current.markSaved(paper);
		});

		expect(result.current.isSaved(paper)).toBe(true);

		// Testing with only title
		const paperOnlyTitle = { title: "Title Only" } as Paper;
		await act(async () => {
			result.current.markSaved(paperOnlyTitle);
		});
```

### Issue 2 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:102-105
fetch 失敗テストでも `act()` が await されていません。`markSaved` が `setSavedKeys` を呼び出した後の状態が確定する前に `isSaved` を評価してしまう恐れがあります。

```suggestion
		await act(async () => {
			result.current.markSaved(paper);
		});
		expect(result.current.isSaved(paper)).toBe(true);
```

### Issue 3 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:54-58
`mockFetch` が呼ばれたかどうかは fetch が開始された直後に true になるため、`waitFor` がほぼ即座に解決します。`res.json()` → `setSavedKeys()` の非同期チェーンが完了している保証がなく、`waitFor` 内で実際の状態変化をアサートする形が堅牢です。

```suggestion
		await waitFor(() => {
			expect(mockFetch).toHaveBeenCalledWith("/api/archive");
			expect(result.current.isSaved({ doi: "10.123/456" } as Paper)).toBe(false);
		});
```

### Issue 4 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:1-10
**`res.ok === false` ケースのテストが欠落**

フック実装 (`useSavedPapers.ts` 39行目) では `if (!res.ok || cancelled) return;` で早期リターンしますが、このケースを検証するテストがありません。将来エラーハンドリングが変更された際にリグレッションを見落とすリスクがあります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for useSavedPapers hook"](https://github.com/hiroki-org/paper-tools/commit/eae0bc6ebe659811e1c8874c527004b46333db83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43608036)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->