### PR TITLE
🧪 Add explicit test for sealCookieValue format and output

### DIFF
--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -30,6 +30,16 @@ describe("auth", () => {
             expect(unsealed).toEqual(data);
         });
 
+        it("should correctly seal data into payload.signature format", () => {
+            const data = { test: true };
+            const sealed = sealCookieValue(data);
+
+            // Expected output with the stubbed secret "super-secret-key-12345"
+            // Payload: {"test":true} base64url encoded -> eyJ0ZXN0Ijp0cnVlfQ
+            // Signature: HMAC-SHA256 of payload with secret base64url encoded -> xDZiIw7yT8p-9ZGtL-c3wCPQS724YbX4WlmKUlqn13k
+            expect(sealed).toBe("eyJ0ZXN0Ijp0cnVlfQ.xDZiIw7yT8p-9ZGtL-c3wCPQS724YbX4WlmKUlqn13k");
+        });
+
         it("should return null for invalid signature", () => {
             const data = { test: true };
             const sealed = sealCookieValue(data);


### PR DESCRIPTION
🎯 **What:** Add an explicit test for `sealCookieValue` in `auth.ts` to ensure the exact payload and signature format are verified.

📊 **Coverage:** Tests the happy path of `sealCookieValue` to confirm that the output matches the expected deterministic base64url encoded payload and HMAC-SHA256 signature format.

✨ **Result:** Test coverage is improved for the `auth` module by specifically asserting the behavior of the `sealCookieValue` function in isolation from its unsealing counterpart.

---
*PR created automatically by Jules for task [12687955290045193952](https://jules.google.com/task/12687955290045193952) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a focused test for sealed auth cookie output.

- Adds a deterministic `sealCookieValue` happy-path assertion.
- Checks the exact base64url payload and HMAC signature format.
- Keeps the change limited to `packages/web/src/lib/auth.test.ts`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/lib/auth.test.ts | Adds a deterministic assertion for `sealCookieValue` output using the stubbed cookie secret. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for sealCookieValue output f..."](https://github.com/hiroki-org/paper-tools/commit/530484eec535796d43f248a478bb1eb68455af78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440194)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->