### PR TITLE
🧪 Add tests for CACHE_TTL_MS in tags suggest cache

### DIFF
--- a/packages/web/src/app/api/tags/suggest/cache.test.ts
+++ b/packages/web/src/app/api/tags/suggest/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { cache, CACHE_TTL_MS } from "./cache";
+import { cache, CACHE_TTL_MS, MAX_CACHE_SIZE, setCacheWithPruning } from "./cache";
 
 describe("cache", () => {
     beforeEach(() => {
@@ -15,5 +15,48 @@ describe("cache", () => {
         cache.set("key", { data: ["tag1", "tag2"], timestamp: Date.now() });
         const entry = cache.get("key");
         expect(entry?.data).toEqual(["tag1", "tag2"]);
+    });
+});
+
+describe("setCacheWithPruning", () => {
+    let mockCache: Map<string, any>;
+
+    beforeEach(() => {
+        mockCache = new Map();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("should prune entries older than CACHE_TTL_MS", () => {
+        vi.setSystemTime(1000);
+
+        mockCache.set("old", { data: ["old"], timestamp: 1000 });
+
+        vi.setSystemTime(1000 + CACHE_TTL_MS);
+
+        setCacheWithPruning("new", { data: ["new"], timestamp: Date.now() }, mockCache);
+
+        expect(mockCache.has("old")).toBe(false);
+        expect(mockCache.has("new")).toBe(true);
+    });
+
+    it("should respect MAX_CACHE_SIZE and evict oldest when full", () => {
+        vi.setSystemTime(1000);
+
+        for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+            mockCache.set(`key${i}`, { data: [`val${i}`], timestamp: 1000 + i });
+        }
+
+        expect(mockCache.size).toBe(MAX_CACHE_SIZE);
+
+        setCacheWithPruning("newKey", { data: ["newVal"], timestamp: Date.now() }, mockCache);
+
+        expect(mockCache.size).toBe(MAX_CACHE_SIZE);
+        expect(mockCache.has("key0")).toBe(false);
+        expect(mockCache.has("key1")).toBe(true);
+        expect(mockCache.has("newKey")).toBe(true);
     });
 });


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `setCacheWithPruning` function in `cache.ts`.
📊 **Coverage:** Covered both eviction logic for elements older than `CACHE_TTL_MS` and eviction logic when `MAX_CACHE_SIZE` is exceeded.
✨ **Result:** Improved test coverage and reliability for cache pruning behavior.

---
*PR created automatically by Jules for task [17892429119688232979](https://jules.google.com/task/17892429119688232979) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds tests for tag suggest cache pruning. The main changes are:

- TTL-based removal coverage for old cache entries.
- Maximum-size eviction coverage for the oldest cache entry.
- Direct test coverage for `setCacheWithPruning`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/tags/suggest/cache.test.ts | Adds focused tests for TTL pruning and max-size eviction in the tag suggest cache. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for cache TTL and prunin..."](https://github.com/hiroki-org/paper-tools/commit/832bc1312aa9278c17b15bfcda4dfefd7c9ed856) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440236)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->