### PR TITLE
🧹 Fix unused import in openalex-client test

### DIFF
--- a/packages/core/tests/openalex-client.test.ts
+++ b/packages/core/tests/openalex-client.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { getOpenAlexAuthor, resolveOpenAlexAuthorId } from "../src/openalex-client.js";
+import { resolveOpenAlexAuthorId } from "../src/openalex-client.js";
 
 describe("OpenAlex Client", () => {
     beforeEach(() => {


### PR DESCRIPTION
🎯 **What:** Removed unused `getOpenAlexAuthor` import from `packages/core/tests/openalex-client.test.ts`.
💡 **Why:** Removing unused imports reduces cognitive load and improves code readability.
✅ **Verification:** Verified by running `pnpm test` in the `packages/core` directory. All 54 tests passed.
✨ **Result:** Improved code health without affecting any functionality.

---
*PR created automatically by Jules for task [1698183445651872535](https://jules.google.com/task/1698183445651872535) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは OpenAlex クライアントのテストから未使用 import を削除します。

- `openalex-client.test.ts` の import から `getOpenAlexAuthor` を削除。
- 同テストで使われている `resolveOpenAlexAuthorId` の import は維持。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/tests/openalex-client.test.ts | `getOpenAlexAuthor` の未使用 import が削除され、テストが参照する import だけが残りました。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix unused import in openalex-client tes..."](https://github.com/hiroki-org/paper-tools/commit/d612c271e8226203765c19415ebc192872a39b89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440255)</sub>

**Context used:**

- Knowledge Base — [packages/core](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/core.md)

<!-- /greptile_comment -->