### PR TITLE
🧹 Remove unused import in cache.test.ts

### DIFF
--- a/packages/web/src/app/api/tags/suggest/cache.test.ts
+++ b/packages/web/src/app/api/tags/suggest/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { cache, CACHE_TTL_MS } from "./cache";
+import { cache } from "./cache";
 
 describe("cache", () => {
     beforeEach(() => {


### PR DESCRIPTION
🎯 **What:** Removed unused `CACHE_TTL_MS` import from `cache.test.ts`.
💡 **Why:** Reduces cognitive load and fixes a code health issue.
✅ **Verification:** Ran test suite to ensure no functionality is broken.
✨ **Result:** Cleaner code and resolved unused import.

---
*PR created automatically by Jules for task [8015741586467749116](https://jules.google.com/task/8015741586467749116) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはタグ候補APIのキャッシュテストから未使用 import を削除します。

- `cache.test.ts` の `CACHE_TTL_MS` import を削除。
- 既存の `cache` import とテスト本体はそのまま。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/tags/suggest/cache.test.ts | `CACHE_TTL_MS` の未使用 import だけを削除しており、テスト内に残存参照はありません。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove unused import in cache.test.ts"](https://github.com/hiroki-org/paper-tools/commit/e26360602f730a908ac5efafafc66ba609491716) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440291)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->