### PR TITLE
🧹 Fix unused import in `route.test.ts`

### DIFF
--- a/packages/web/src/app/api/authors/[authorId]/route.test.ts
+++ b/packages/web/src/app/api/authors/[authorId]/route.test.ts
@@ -1,64 +1,64 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthorProfile } from "@paper-tools/core";
 import { NextRequest } from "next/server";
-import { type AuthorProfile } from "@paper-tools/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@paper-tools/author-profiler", () => ({
-    buildAuthorProfile: vi.fn(),
+	buildAuthorProfile: vi.fn(),
 }));
 
 const profiler = await import("@paper-tools/author-profiler");
 const { GET } = await import("./route");
 
 describe("/api/authors/[authorId] GET", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    it("returns author profile", async () => {
-        vi.mocked(profiler.buildAuthorProfile).mockResolvedValueOnce({
-            id: "123",
-            name: "Alice",
-            affiliations: [{ name: "Example U" }],
-            hIndex: 10,
-            citationCount: 200,
-            paperCount: 30,
-            influentialCitationCount: 50,
-            topPapers: [],
-            coauthors: [],
-            topicTimeline: [],
-        } as Partial<AuthorProfile> as AuthorProfile);
+	it("returns author profile", async () => {
+		vi.mocked(profiler.buildAuthorProfile).mockResolvedValueOnce({
+			id: "123",
+			name: "Alice",
+			affiliations: [{ name: "Example U" }],
+			hIndex: 10,
+			citationCount: 200,
+			paperCount: 30,
+			influentialCitationCount: 50,
+			topPapers: [],
+			coauthors: [],
+			topicTimeline: [],
+		} as Partial<AuthorProfile> as AuthorProfile);
 
-        const req = new NextRequest("http://localhost/api/authors/123");
-        const res = await GET(req, { params: { authorId: "123" } });
-        const data = await res.json();
+		const req = new NextRequest("http://localhost/api/authors/123");
+		const res = await GET(req, { params: { authorId: "123" } });
+		const data = await res.json();
 
-        expect(res.status).toBe(200);
-        expect(data.id).toBe("123");
-    });
+		expect(res.status).toBe(200);
+		expect(data.id).toBe("123");
+	});
 
-    it("returns 400 when authorId is empty", async () => {
-        const req = new NextRequest("http://localhost/api/authors/");
-        const res = await GET(req, { params: { authorId: "" } });
-        expect(res.status).toBe(400);
-    });
+	it("returns 400 when authorId is empty", async () => {
+		const req = new NextRequest("http://localhost/api/authors/");
+		const res = await GET(req, { params: { authorId: "" } });
+		expect(res.status).toBe(400);
+	});
 
-    it("returns 404 only for Semantic Scholar 404 error format", async () => {
-        vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
-            new Error("Semantic Scholar API error: 404 Not Found - missing"),
-        );
+	it("returns 404 only for Semantic Scholar 404 error format", async () => {
+		vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
+			new Error("Semantic Scholar API error: 404 Not Found - missing"),
+		);
 
-        const req = new NextRequest("http://localhost/api/authors/unknown");
-        const res = await GET(req, { params: { authorId: "unknown" } });
-        expect(res.status).toBe(404);
-    });
+		const req = new NextRequest("http://localhost/api/authors/unknown");
+		const res = await GET(req, { params: { authorId: "unknown" } });
+		expect(res.status).toBe(404);
+	});
 
-    it("returns 502 when message incidentally includes 404", async () => {
-        vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
-            new Error("Topic score 0.404 failed validation"),
-        );
+	it("returns 502 when message incidentally includes 404", async () => {
+		vi.mocked(profiler.buildAuthorProfile).mockRejectedValueOnce(
+			new Error("Topic score 0.404 failed validation"),
+		);
 
-        const req = new NextRequest("http://localhost/api/authors/unknown");
-        const res = await GET(req, { params: { authorId: "unknown" } });
-        expect(res.status).toBe(502);
-    });
+		const req = new NextRequest("http://localhost/api/authors/unknown");
+		const res = await GET(req, { params: { authorId: "unknown" } });
+		expect(res.status).toBe(502);
+	});
 });


### PR DESCRIPTION
🎯 **What:** The code health issue concerning the `AuthorProfile` type import (unused import warning) was addressed by explicitly declaring it as an `import type` and sorting imports alphabetically in `packages/web/src/app/api/authors/[authorId]/route.test.ts`.

💡 **Why:** By converting the type import to `import type`, standard linters recognize the intended usage. Type imports ensure they are stripped completely during compilation, maintaining clean module boundaries and averting false positives around unused values, thus improving overall code maintainability and reducing cognitive overhead.

✅ **Verification:**
- Verified no lint errors remain using `pnpm dlx @biomejs/biome check`.
- Executed the full unit test suite via `pnpm test` in the `packages/web` package (107 tests across 19 files passed) to ensure existing functionality remains perfectly intact.

✨ **Result:** The import issue is fixed properly without modifying any functional logic. The file is also updated with consistent project-level auto-formatting.

---
*PR created automatically by Jules for task [11219858715869084467](https://jules.google.com/task/11219858715869084467) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは author API route のテストで型インポートと整形を整理しています。

- `AuthorProfile` を明示的な `import type` に変更。
- インポート順を整理。
- テスト本文のインデントをプロジェクト形式に整形。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/authors/[authorId]/route.test.ts | `AuthorProfile` の型専用インポート化とフォーマット整理のみで、テストの実行時ロジックは変わっていません。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Fix unused import in \`route.test.ts\`"](https://github.com/hiroki-org/paper-tools/commit/7f5c9d74fdc60e53b618d6db5159969116fccdac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440300)</sub>

<!-- /greptile_comment -->