### PR TITLE
🧪 Add test for useSavedPapers

### DIFF
--- a/packages/web/src/app/search/hooks/useSavedPapers.test.ts
+++ b/packages/web/src/app/search/hooks/useSavedPapers.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useSavedPapers } from "./useSavedPapers";
+import type { Paper } from "@paper-tools/core";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("useSavedPapers", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should initialize with empty saved papers and fetch archive", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ records: [] }),
+    } as any);
+
+    let resultContainer;
+    await act(async () => {
+      resultContainer = renderHook(() => useSavedPapers());
+      await Promise.resolve();
+    });
+
+    const { result } = resultContainer!;
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/archive");
+    const paper: Paper = { id: "1", title: "Test Paper", doi: "10.1234/test", authors: [], abstract: "", year: 2024, url: "" };
+    expect(result.current.isSaved(paper)).toBe(false);
+  });
+
+  it("should initialize saved papers from fetch", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        records: [
+          { doi: "10.1234/saved1", title: "Saved Paper 1" },
+          { title: "Saved Paper 2" }
+        ],
+      }),
+    } as any);
+
+    let resultContainer;
+    await act(async () => {
+      resultContainer = renderHook(() => useSavedPapers());
+      await Promise.resolve();
+    });
+
+    const { result } = resultContainer!;
+
+    const paper1: Paper = { id: "1", title: "Saved Paper 1", doi: "10.1234/saved1", authors: [], abstract: "", year: 2024, url: "" };
+    const paper2: Paper = { id: "2", title: "Saved Paper 2", doi: "", authors: [], abstract: "", year: 2024, url: "" };
+    const paper3: Paper = { id: "3", title: "Not Saved", doi: "10.1234/notsaved", authors: [], abstract: "", year: 2024, url: "" };
+
+    expect(result.current.isSaved(paper1)).toBe(true);
+    expect(result.current.isSaved(paper2)).toBe(true);
+    expect(result.current.isSaved(paper3)).toBe(false);
+  });
+
+  it("should allow marking a paper as saved", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ records: [] }),
+    } as any);
+
+    let resultContainer;
+    await act(async () => {
+      resultContainer = renderHook(() => useSavedPapers());
+      await Promise.resolve();
+    });
+
+    const { result } = resultContainer!;
+
+    const paper: Paper = { id: "1", title: "New Paper", doi: "10.1234/new", authors: [], abstract: "", year: 2024, url: "" };
+
+    expect(result.current.isSaved(paper)).toBe(false);
+
+    act(() => {
+      result.current.markSaved(paper);
+    });
+
+    expect(result.current.isSaved(paper)).toBe(true);
+  });
+
+  it("should handle fetch error gracefully", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network Error"));
+
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+
+    let resultContainer;
+    await act(async () => {
+      resultContainer = renderHook(() => useSavedPapers());
+      await Promise.resolve();
+    });
+
+    const { result } = resultContainer!;
+
+    expect(consoleSpy).toHaveBeenCalledWith("Failed to fetch archive:", expect.any(Error));
+
+    const paper: Paper = { id: "1", title: "Test", doi: "10.1234/test", authors: [], abstract: "", year: 2024, url: "" };
+    expect(result.current.isSaved(paper)).toBe(false);
+
+    consoleSpy.mockRestore();
+    process.env.NODE_ENV = originalEnv;
+  });
+});


### PR DESCRIPTION
🎯 **What:**
Added comprehensive unit tests for the `useSavedPapers` React hook.

📊 **Coverage:**
The tests cover the following scenarios:
- Initializing with empty saved papers.
- Fetching and initializing saved papers from the `/api/archive` endpoint on mount.
- Successfully marking a new paper as saved.
- Gracefully handling fetch errors (network failures) without crashing the app, while suppressing the intentional `console.warn` during the test run.

✨ **Result:**
Improved test coverage for search-related hooks and ensured the hook reliably manages the saved state of papers.

---
*PR created automatically by Jules for task [29035004540458946](https://jules.google.com/task/29035004540458946) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds unit coverage for the `useSavedPapers` hook. The main changes are:

- A new jsdom Vitest test file for the search hook.
- Mocked `/api/archive` responses for empty and populated archives.
- Coverage for marking papers as saved.
- Coverage for fetch failure handling.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The new test file needs fixes before merging.

- `Paper` fixtures include a field that the imported type does not define.
- The archive-loading assertions can run before the hook effect finishes.
- Global fetch, console, and environment changes can leak into later tests.

packages/web/src/app/search/hooks/useSavedPapers.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/search/hooks/useSavedPapers.test.ts | Adds useful hook tests, but the new file has a type mismatch, insufficient async waiting, and global cleanup leaks. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:36
**Paper Type Rejects Id**

`paper` is explicitly typed as `Paper`, but the imported `Paper` interface does not define an `id` field. When this test file is included in TypeScript checking, the object literal fails excess-property checking before the tests can run.

```suggestion
    const paper: Paper = { title: "Test Paper", doi: "10.1234/test", authors: [], abstract: "", year: 2024, url: "" };
```

### Issue 2 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:52-55
**Archive Effect Is Not Settled**

`useSavedPapers` awaits both `fetch` and `res.json()` before updating saved keys, but this test only waits for one resolved promise after mounting. The assertions that follow can read the initial empty set instead of the fetched archive state, making the saved-paper test fail or pass without actually verifying the effect.

### Issue 3 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:10
**Fetch Mock Leaks Globally**

`global.fetch` is replaced when the test module loads, and the `afterEach` only clears calls rather than restoring the original global. In a shared Vitest worker, later tests that expect the real fetch implementation can still receive this `vi.fn()` stub and fail for the wrong reason.

### Issue 4 of 4
packages/web/src/app/search/hooks/useSavedPapers.test.ts:113-114
**Environment Cleanup Can Be Skipped**

`console.warn` and `NODE_ENV` are restored only after the assertions complete. If the warning expectation fails, the spy remains installed and `NODE_ENV` stays set to `development`, which can change warning behavior for later tests in the same worker.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for useSavedPapers"](https://github.com/hiroki-org/paper-tools/commit/3b60fa2a106da76924c44034f3976c957fa1aab5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440303)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->