### PR TITLE
🧪 Add tests for useSaveToNotion hook

### DIFF
--- a/packages/web/src/hooks/useSaveToNotion.test.ts
+++ b/packages/web/src/hooks/useSaveToNotion.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useSaveToNotion } from "./useSaveToNotion";
+import type { S2Paper } from "@paper-tools/core";
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+describe("useSaveToNotion", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it("initializes with idle status", () => {
+		const { result } = renderHook(() => useSaveToNotion({}));
+		expect(result.current.status).toBe("idle");
+		expect(result.current.error).toBeNull();
+	});
+
+	it("does nothing if already saved", async () => {
+		const { result } = renderHook(() => useSaveToNotion({ saved: true }));
+		await act(async () => {
+			await result.current.save();
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result.current.status).toBe("idle");
+	});
+
+	it("saves paper directly if provided", async () => {
+		const mockPaper = { paperId: "123", title: "Test Paper" } as S2Paper;
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ success: true }),
+		});
+
+		const onSaved = vi.fn();
+		const { result } = renderHook(() => useSaveToNotion({ paper: mockPaper, onSaved }));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith("/api/archive", expect.objectContaining({
+			method: "POST",
+			body: JSON.stringify({ paper: mockPaper }),
+		}));
+
+		expect(result.current.status).toBe("done");
+		expect(onSaved).toHaveBeenCalled();
+	});
+
+	it("resolves paper first if only doi is provided", async () => {
+		const mockPaper = { paperId: "123", title: "Resolved Paper" } as S2Paper;
+
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ paper: mockPaper }),
+		});
+
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ success: true }),
+		});
+
+		const { result } = renderHook(() => useSaveToNotion({ doi: "10.1234/test" }));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/resolve", expect.objectContaining({
+			body: JSON.stringify({ doi: "10.1234/test" }),
+		}));
+		expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/archive", expect.objectContaining({
+			body: JSON.stringify({ paper: mockPaper }),
+		}));
+
+		expect(result.current.status).toBe("done");
+	});
+
+	it("handles resolve error", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			json: async () => ({ error: "Resolve failed" }),
+		});
+
+		const { result } = renderHook(() => useSaveToNotion({ doi: "10.1234/test" }));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toBe("Resolve failed");
+	});
+
+	it("handles archive error", async () => {
+		const mockPaper = { paperId: "123", title: "Test Paper" } as S2Paper;
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			json: async () => ({ error: "Archive failed" }),
+		});
+
+		const { result } = renderHook(() => useSaveToNotion({ paper: mockPaper }));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toBe("Archive failed");
+	});
+
+	it("throws error if no paper, doi, or title is provided", async () => {
+		const { result } = renderHook(() => useSaveToNotion({}));
+
+		await act(async () => {
+			await result.current.save();
+		});
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toBe("保存対象の DOI またはタイトルが見つかりません");
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added comprehensive test coverage for the `useSaveToNotion` React hook.
📊 **Coverage:** Covered initialization, early exit if already saved, direct saving with a provided paper, resolving via DOI prior to saving, handling resolution errors, handling archival errors, and handling missing input errors.
✨ **Result:** Improved test coverage and reliability for the saving functionality.

---
*PR created automatically by Jules for task [2267945843930902381](https://jules.google.com/task/2267945843930902381) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `useSaveToNotion` フックのテストを追加しています。

- 初期状態と保存済み時の早期終了を検証。
- 直接保存と DOI 解決後の保存を検証。
- 解決失敗、保存失敗、入力不足のエラー状態を検証。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

追加テストの型インポートが公開エントリポイントと合わない場合、型チェック付き CI が失敗します。

- 本番コードの実行パスは変更されていません。
- テストの期待値はフックの現在の保存フローと概ね一致しています。
- `@paper-tools/core` からの型インポートは公開エクスポートに依存しています。

packages/web/src/hooks/useSaveToNotion.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/hooks/useSaveToNotion.test.ts | `useSaveToNotion` の主要な保存パスとエラーパスを検証する新規テストです。型インポートの公開エクスポート形状だけ確認が必要です。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web/src/hooks/useSaveToNotion.test.ts:6
**公開エクスポートにない型参照**

`S2Paper` が `@paper-tools/core` のパッケージルートから再エクスポートされていない場合、この追加テストは型チェック時に `S2Paper` を解決できず CI が失敗します。公開エントリポイントで保証された型を使うか、ルートから再エクスポートしてから参照してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for useSaveToNotion hook"](https://github.com/hiroki-org/paper-tools/commit/4ba3ca5be48b953acfa1fc2ad553d489dc901e1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440335)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->