### PR TITLE
🧪 Add tests for searchByVenue

### DIFF
--- a/packages/drilldown/tests/search.test.ts
+++ b/packages/drilldown/tests/search.test.ts
@@ -1,162 +1,210 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock global fetch
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // Import after mocking
-const { searchByKeyword, searchByVenue, enrichWithCrossref, enrichAllWithCrossref, searchCrossref } = await import("../src/search.js");
+const {
+	searchByKeyword,
+	searchByVenue,
+	enrichWithCrossref,
+	enrichAllWithCrossref,
+	searchCrossref,
+} = await import("../src/search.js");
 
 describe("search", () => {
-    beforeEach(() => {
-        mockFetch.mockReset();
-    });
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
 
-    it("searchByKeyword should return papers from DBLP", async () => {
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            json: async () => ({
-                result: {
-                    hits: {
-                        hit: [
-                            {
-                                info: {
-                                    title: "Deep Learning Survey",
-                                    authors: { author: [{ text: "Alice" }] },
-                                    doi: "10.1234/dl",
-                                    year: "2024",
-                                    venue: "NeurIPS",
-                                },
-                            },
-                        ],
-                    },
-                },
-            }),
-        });
+	it("searchByKeyword should return papers from DBLP", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				result: {
+					hits: {
+						hit: [
+							{
+								info: {
+									title: "Deep Learning Survey",
+									authors: { author: [{ text: "Alice" }] },
+									doi: "10.1234/dl",
+									year: "2024",
+									venue: "NeurIPS",
+								},
+							},
+						],
+					},
+				},
+			}),
+		});
 
-        const papers = await searchByKeyword("deep learning", 10);
-        expect(papers).toHaveLength(1);
-        expect(papers[0].title).toBe("Deep Learning Survey");
-        expect(papers[0].doi).toBe("10.1234/dl");
-    });
+		const papers = await searchByKeyword("deep learning", 10);
+		expect(papers).toHaveLength(1);
+		expect(papers[0].title).toBe("Deep Learning Survey");
+		expect(papers[0].doi).toBe("10.1234/dl");
+	});
 
-    it("searchByVenue should pass venue and year to DBLP", async () => {
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            json: async () => ({
-                result: { hits: { hit: [] } },
-            }),
-        });
+	it("searchByVenue should return empty array if no hits", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				result: { hits: { hit: [] } },
+			}),
+		});
 
-        await searchByVenue("ICSE", 2024, 50);
-        const calledUrl = mockFetch.mock.calls[0][0] as string;
-        expect(calledUrl).toContain("ICSE");
-        expect(calledUrl).toContain("2024");
-    });
+		const papers = await searchByVenue("ICSE", 2024, 50);
+		expect(papers).toHaveLength(0);
+	});
 
-    it("enrichWithCrossref should merge Crossref metadata", async () => {
-        // Mock Crossref API response
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            json: async () => ({
-                status: "ok",
-                message: {
-                    title: ["Enriched Title"],
-                    author: [{ given: "Bob", family: "Smith" }],
-                    DOI: "10.1234/test",
-                    abstract: "A great abstract",
-                    subject: ["Computer Science"],
-                    "is-referenced-by-count": 42,
-                    "references-count": 10,
-                },
-            }),
-        });
+	it("searchByVenue should return mapped papers when hits are present", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				result: {
+					hits: {
+						hit: [
+							{
+								info: {
+									title: "Venue Paper",
+									authors: { author: [{ text: "Bob" }] },
+									doi: "10.1234/venue",
+									year: "2024",
+									venue: "ICSE",
+								},
+							},
+						],
+					},
+				},
+			}),
+		});
 
-        const paper = {
-            title: "Original Title",
-            authors: [{ name: "Alice" }],
-            doi: "10.1234/test",
-        };
+		const papers = await searchByVenue("ICSE");
+		expect(papers).toHaveLength(1);
+		expect(papers[0].title).toBe("Venue Paper");
+		expect(papers[0].doi).toBe("10.1234/venue");
+	});
 
-        const enriched = await enrichWithCrossref(paper);
-        expect(enriched.title).toBe("Original Title"); // 元のタイトルを保持
-        expect(enriched.abstract).toBe("A great abstract");
-        expect(enriched.citationCount).toBe(42);
-    });
+	it("searchByVenue should pass venue and year to DBLP", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				result: { hits: { hit: [] } },
+			}),
+		});
 
-    it("enrichWithCrossref should return paper as-is if no DOI", async () => {
-        const paper = { title: "No DOI Paper", authors: [{ name: "Alice" }] };
-        const result = await enrichWithCrossref(paper);
-        expect(result).toEqual(paper);
-        expect(mockFetch).not.toHaveBeenCalled();
-    });
+		await searchByVenue("ICSE", 2024, 50);
+		const calledUrl = mockFetch.mock.calls[0][0] as string;
+		expect(calledUrl).toContain("ICSE");
+		expect(calledUrl).toContain("2024");
+	});
 
-    it("enrichAllWithCrossref should honor the requested concurrency", async () => {
-        let activeRequests = 0;
-        let peakConcurrency = 0;
+	it("enrichWithCrossref should merge Crossref metadata", async () => {
+		// Mock Crossref API response
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				status: "ok",
+				message: {
+					title: ["Enriched Title"],
+					author: [{ given: "Bob", family: "Smith" }],
+					DOI: "10.1234/test",
+					abstract: "A great abstract",
+					subject: ["Computer Science"],
+					"is-referenced-by-count": 42,
+					"references-count": 10,
+				},
+			}),
+		});
 
-        mockFetch.mockImplementation(async () => {
-            activeRequests += 1;
-            peakConcurrency = Math.max(peakConcurrency, activeRequests);
-            await new Promise((resolve) => setTimeout(resolve, 5));
-            activeRequests -= 1;
+		const paper = {
+			title: "Original Title",
+			authors: [{ name: "Alice" }],
+			doi: "10.1234/test",
+		};
 
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({
-                    status: "ok",
-                    message: {
-                        title: ["Enriched Title"],
-                        author: [{ given: "Bob", family: "Smith" }],
-                        DOI: "10.1234/test",
-                    },
-                }),
-            };
-        });
+		const enriched = await enrichWithCrossref(paper);
+		expect(enriched.title).toBe("Original Title"); // 元のタイトルを保持
+		expect(enriched.abstract).toBe("A great abstract");
+		expect(enriched.citationCount).toBe(42);
+	});
 
-        const papers = [
-            { title: "Paper 1", authors: [{ name: "Alice" }], doi: "10.1234/test-1" },
-            { title: "Paper 2", authors: [{ name: "Alice" }], doi: "10.1234/test-2" },
-            { title: "Paper 3", authors: [{ name: "Alice" }], doi: "10.1234/test-3" },
-        ];
+	it("enrichWithCrossref should return paper as-is if no DOI", async () => {
+		const paper = { title: "No DOI Paper", authors: [{ name: "Alice" }] };
+		const result = await enrichWithCrossref(paper);
+		expect(result).toEqual(paper);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
 
-        const enriched = await enrichAllWithCrossref(papers, 2);
+	it("enrichAllWithCrossref should honor the requested concurrency", async () => {
+		let activeRequests = 0;
+		let peakConcurrency = 0;
 
-        expect(enriched).toHaveLength(3);
-        expect(peakConcurrency).toBeLessThanOrEqual(2);
-        expect(mockFetch).toHaveBeenCalledTimes(3);
-    });
+		mockFetch.mockImplementation(async () => {
+			activeRequests += 1;
+			peakConcurrency = Math.max(peakConcurrency, activeRequests);
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			activeRequests -= 1;
 
-    it("searchCrossref should call Crossref API and return papers", async () => {
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            status: 200,
-            json: async () => ({
-                message: {
-                    items: [
-                        {
-                            title: ["Machine Learning Basics"],
-                            author: [{ given: "John", family: "Doe" }],
-                            DOI: "10.5678/ml",
-                            "container-title": ["Journal of ML"],
-                        },
-                    ],
-                },
-            }),
-        });
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({
+					status: "ok",
+					message: {
+						title: ["Enriched Title"],
+						author: [{ given: "Bob", family: "Smith" }],
+						DOI: "10.1234/test",
+					},
+				}),
+			};
+		});
 
-        const papers = await searchCrossref("machine learning", 15);
-        expect(papers).toHaveLength(1);
-        expect(papers[0].title).toBe("Machine Learning Basics");
-        expect(papers[0].doi).toBe("10.5678/ml");
-        expect(papers[0].venue).toBe("Journal of ML");
+		const papers = [
+			{ title: "Paper 1", authors: [{ name: "Alice" }], doi: "10.1234/test-1" },
+			{ title: "Paper 2", authors: [{ name: "Alice" }], doi: "10.1234/test-2" },
+			{ title: "Paper 3", authors: [{ name: "Alice" }], doi: "10.1234/test-3" },
+		];
 
-        const calledUrl = mockFetch.mock.calls[0][0] as string;
-        expect(calledUrl).toContain("query=machine+learning");
-        expect(calledUrl).toContain("rows=15");
-    });
+		const enriched = await enrichAllWithCrossref(papers, 2);
+
+		expect(enriched).toHaveLength(3);
+		expect(peakConcurrency).toBeLessThanOrEqual(2);
+		expect(mockFetch).toHaveBeenCalledTimes(3);
+	});
+
+	it("searchCrossref should call Crossref API and return papers", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				message: {
+					items: [
+						{
+							title: ["Machine Learning Basics"],
+							author: [{ given: "John", family: "Doe" }],
+							DOI: "10.5678/ml",
+							"container-title": ["Journal of ML"],
+						},
+					],
+				},
+			}),
+		});
+
+		const papers = await searchCrossref("machine learning", 15);
+		expect(papers).toHaveLength(1);
+		expect(papers[0].title).toBe("Machine Learning Basics");
+		expect(papers[0].doi).toBe("10.5678/ml");
+		expect(papers[0].venue).toBe("Journal of ML");
+
+		const calledUrl = mockFetch.mock.calls[0][0] as string;
+		expect(calledUrl).toContain("query=machine+learning");
+		expect(calledUrl).toContain("rows=15");
+	});
 });


### PR DESCRIPTION
🎯 **What:** The `searchByVenue` function lacked tests for its mapping behavior and handling of empty API results.
📊 **Coverage:** The test suite now includes scenarios for `searchByVenue` receiving no hits (returning an empty array) and successfully receiving and mapping a hit into a Paper object.
✨ **Result:** Test coverage for the search APIs in `@paper-tools/drilldown` is improved, making refactoring safer.

---
*PR created automatically by Jules for task [16276690529729611993](https://jules.google.com/task/16276690529729611993) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds tests around `searchByVenue` in the drilldown package. The main changes are:

- Adds an empty DBLP hit case for `searchByVenue`.
- Adds a mapped-hit case for `searchByVenue`.
- Reformats the search test imports and dynamic import destructuring.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small cleanup to the new mapping test.

- The changed code is limited to tests.
- The import formatting keeps the mock setup order intact.
- The new mapped-hit test can miss broken `Paper` fields, but it does not change runtime behavior.

packages/drilldown/tests/search.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/search.test.ts | Adds `searchByVenue` empty-result and mapped-result tests; the mapped-result case only checks part of the returned `Paper` shape. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/drilldown/tests/search.test.ts:88-89
**Mapped Paper Fields Stay Untested**

When `searchByVenue` receives a DBLP hit, this test only checks `title` and `doi`. A regression that stops normalizing `authors`, leaves `year` as a string, or drops `venue` would still pass here even though callers receive an incomplete `Paper`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for searchByVenue behavi..."](https://github.com/hiroki-org/paper-tools/commit/7ea0c89d3f86684e07ffbe7003c50942c7c0ee2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440339)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Drilldown CLI (`packages/drilldown`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/drilldown.md)

<!-- /greptile_comment -->