### PR TITLE
🧪 Add unit test for MAX_CACHE_SIZE eviction logic

### DIFF
--- a/packages/web/src/app/api/tags/suggest/cache.test.ts
+++ b/packages/web/src/app/api/tags/suggest/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { cache, CACHE_TTL_MS } from "./cache";
+import { cache, CACHE_TTL_MS, MAX_CACHE_SIZE, setCacheWithPruning } from "./cache";
 
 describe("cache", () => {
     beforeEach(() => {
@@ -15,5 +15,32 @@ describe("cache", () => {
         cache.set("key", { data: ["tag1", "tag2"], timestamp: Date.now() });
         const entry = cache.get("key");
         expect(entry?.data).toEqual(["tag1", "tag2"]);
+    });
+
+    it("should prune oldest entry when exceeding MAX_CACHE_SIZE", () => {
+        const testCache = new Map();
+
+        // Fill the cache up to its max size
+        for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+            setCacheWithPruning(`key${i}`, { data: [`tag${i}`], timestamp: Date.now() }, testCache);
+        }
+
+        // Verify it reached max size
+        expect(testCache.size).toBe(MAX_CACHE_SIZE);
+
+        // Advance time to ensure next insertion doesn't share timestamp
+        vi.advanceTimersByTime(10);
+
+        // Add one more to exceed the max size
+        setCacheWithPruning('overflow', { data: ['overflowTag'], timestamp: Date.now() }, testCache);
+
+        // Size should remain MAX_CACHE_SIZE
+        expect(testCache.size).toBe(MAX_CACHE_SIZE);
+
+        // The oldest entry (key0) should be removed
+        expect(testCache.has('key0')).toBe(false);
+
+        // The newest entry should be present
+        expect(testCache.has('overflow')).toBe(true);
     });
 });


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify the `MAX_CACHE_SIZE` pruning logic in the tag suggestion cache.
📊 **Coverage:** The new test covers the scenario where the cache reaches its maximum capacity, verifying that the oldest entry is successfully pruned to keep the cache size constrained to `MAX_CACHE_SIZE`.
✨ **Result:** Improved test coverage and reliability for cache management logic.

---
*PR created automatically by Jules for task [1899873044753503925](https://jules.google.com/task/1899873044753503925) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds coverage for tag suggestion cache pruning.

- Adds imports for `MAX_CACHE_SIZE` and `setCacheWithPruning`.
- Adds a test that fills a separate cache to the limit.
- Verifies the oldest key is removed when one more entry is inserted.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/tags/suggest/cache.test.ts | Adds a focused unit test for size-based pruning in the tag suggestion cache. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add unit test for MAX\_CACHE\_SIZE evictio..."](https://github.com/hiroki-org/paper-tools/commit/40ce1b9bdf40b59d0ac8b5b4270792ad655bd164) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440406)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->