### PR TITLE
🧪 test: add unit tests for setCacheWithPruning

### DIFF
--- a/packages/web/src/app/api/tags/suggest/cache.test.ts
+++ b/packages/web/src/app/api/tags/suggest/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { cache, CACHE_TTL_MS } from "./cache";
+import { cache, CACHE_TTL_MS, MAX_CACHE_SIZE, setCacheWithPruning } from "./cache";
 
 describe("cache", () => {
     beforeEach(() => {
@@ -15,5 +15,55 @@ describe("cache", () => {
         cache.set("key", { data: ["tag1", "tag2"], timestamp: Date.now() });
         const entry = cache.get("key");
         expect(entry?.data).toEqual(["tag1", "tag2"]);
+    });
+});
+
+describe("setCacheWithPruning", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("should prune stale entries when adding a new one", () => {
+        const testCache = new Map();
+        testCache.set("staleKey", { data: "staleData", timestamp: Date.now() - CACHE_TTL_MS - 1000 });
+        testCache.set("freshKey", { data: "freshData", timestamp: Date.now() });
+
+        setCacheWithPruning("newKey", { data: "newData", timestamp: Date.now() }, testCache);
+
+        expect(testCache.has("staleKey")).toBe(false);
+        expect(testCache.has("freshKey")).toBe(true);
+        expect(testCache.has("newKey")).toBe(true);
+    });
+
+    it("should remove oldest entry if max cache size is reached", () => {
+        const testCache = new Map();
+
+        for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+            testCache.set(`key${i}`, { data: `data${i}`, timestamp: Date.now() });
+        }
+
+        setCacheWithPruning("newKey", { data: "newData", timestamp: Date.now() }, testCache);
+
+        expect(testCache.has("key0")).toBe(false);
+        expect(testCache.has("newKey")).toBe(true);
+        expect(testCache.size).toBe(MAX_CACHE_SIZE);
+    });
+
+    it("should not remove if key already exists and max cache is reached", () => {
+        const testCache = new Map();
+
+        for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+            testCache.set(`key${i}`, { data: `data${i}`, timestamp: Date.now() });
+        }
+
+        setCacheWithPruning("key0", { data: "updatedData", timestamp: Date.now() }, testCache);
+
+        expect(testCache.has("key0")).toBe(true);
+        expect(testCache.get("key0")?.data).toBe("updatedData");
+        expect(testCache.size).toBe(MAX_CACHE_SIZE);
     });
 });


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `setCacheWithPruning` function in `cache.ts` to improve test coverage and reliability.
📊 **Coverage:** Covered stale entry pruning, max cache size pruning, and the edge case where updating an existing key shouldn't trigger max-size pruning.
✨ **Result:** Improved test coverage and confidence in the cache pruning logic.

---
*PR created automatically by Jules for task [9077831554815738025](https://jules.google.com/task/9077831554815738025) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds unit coverage for the tag suggestion cache pruning helper.

- Adds tests for removing stale cache entries.
- Adds tests for evicting the oldest entry at the cache size limit.
- Adds a test that updating an existing key does not trigger size-based eviction.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/tags/suggest/cache.test.ts | Adds focused Vitest coverage for `setCacheWithPruning`; no concrete issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add unit tests for setCacheWithPru..."](https://github.com/hiroki-org/paper-tools/commit/442f47a3b60f83f5853a9596d2671c44b51c46d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440482)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->