### PR TITLE
🧪 Add test for empty array input to enrichAllWithCrossref

### DIFF
--- a/packages/drilldown/tests/search.test.ts
+++ b/packages/drilldown/tests/search.test.ts
@@ -94,6 +94,12 @@ describe("search", () => {
         expect(mockFetch).not.toHaveBeenCalled();
     });
 
+
+    it("enrichAllWithCrossref should return empty array if input is empty", async () => {
+        const result = await enrichAllWithCrossref([]);
+        expect(result).toEqual([]);
+    });
+
     it("enrichAllWithCrossref should honor the requested concurrency", async () => {
         let activeRequests = 0;
         let peakConcurrency = 0;


### PR DESCRIPTION
🎯 **What:** Add a unit test to cover the early return block `if (papers.length === 0)` in `enrichAllWithCrossref`.

📊 **Coverage:** Tests that `enrichAllWithCrossref([])` successfully returns `[]`.

✨ **Result:** Improved test coverage for `search.ts`.

---
*PR created automatically by Jules for task [12054117637700198504](https://jules.google.com/task/12054117637700198504) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `enrichAllWithCrossref` の空配列入力をテストに追加します。

- `packages/drilldown/tests/search.test.ts` に空配列入力のケースを追加。
- `enrichAllWithCrossref([])` が `[]` を返すことを検証。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/search.test.ts | 空配列入力に対する `enrichAllWithCrossref` の期待動作を確認するテストが追加されました。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add test case for empty array input to e..."](https://github.com/hiroki-org/paper-tools/commit/d9a175d29f2a0d89f3797d4be46f29ebcf818ca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440496)</sub>

**Context used:**

- Knowledge Base — [Drilldown CLI (`packages/drilldown`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/drilldown.md)

<!-- /greptile_comment -->