### PR TITLE
🧪 Add test for enrichWithCrossref when Crossref metadata is missing

### DIFF
--- a/packages/drilldown/tests/search.test.ts
+++ b/packages/drilldown/tests/search.test.ts
@@ -87,6 +87,18 @@ describe("search", () => {
         expect(enriched.citationCount).toBe(42);
     });
 
+
+    it("enrichWithCrossref should return paper as-is if Crossref returns null", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+        });
+
+        const paper = { title: "No Crossref Paper", authors: [{ name: "Alice" }], doi: "10.1234/missing" };
+        const result = await enrichWithCrossref(paper);
+        expect(result).toEqual(paper);
+    });
+
     it("enrichWithCrossref should return paper as-is if no DOI", async () => {
         const paper = { title: "No DOI Paper", authors: [{ name: "Alice" }] };
         const result = await enrichWithCrossref(paper);


### PR DESCRIPTION
🎯 **What:** Adds a test case for `enrichWithCrossref` in `packages/drilldown/src/search.ts` to cover the scenario where `getWorkByDoi` returns `null` (e.g., when the Crossref API returns a 404 for a given DOI).
📊 **Coverage:** Now tests the early return path when a paper has a DOI, but the Crossref metadata is not found.
✨ **Result:** Improved test coverage and reliability by explicitly testing the error/missing data edge case.

---
*PR created automatically by Jules for task [9848763694021384178](https://jules.google.com/task/9848763694021384178) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds coverage for missing Crossref metadata in drilldown search.

- Adds a test for `enrichWithCrossref` when Crossref returns 404.
- Verifies a paper with a DOI is returned unchanged when metadata is missing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/search.test.ts | Adds a focused test for the Crossref missing-metadata path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add enrichWithCrossref test for 40..."](https://github.com/hiroki-org/paper-tools/commit/e8d02bc25f30757423eadd91f29cb0eaf98d7e15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440498)</sub>

**Context used:**

- Knowledge Base — [Drilldown CLI (`packages/drilldown`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/drilldown.md)

<!-- /greptile_comment -->