### PR TITLE
🧪 test(drilldown): add test for extractKeywords sorting and topN

### DIFF
--- a/packages/drilldown/tests/drilldown.test.ts
+++ b/packages/drilldown/tests/drilldown.test.ts
@@ -9,7 +9,7 @@ const { extractKeywords, drilldown } = await import("../src/drilldown.js");
 
 describe("extractKeywords", () => {
     it("should extract keywords from paper titles", () => {
-        const papers = [
+        const papers: any[] = [
             { title: "Machine Learning for Software Engineering", authors: [] },
             { title: "Deep Learning Applications in Software Testing", authors: [] },
             { title: "Machine Learning Techniques for Bug Detection", authors: [] },
@@ -25,7 +25,7 @@ describe("extractKeywords", () => {
     });
 
     it("should give higher weight to paper keywords", () => {
-        const papers = [
+        const papers: any[] = [
             {
                 title: "A Paper About Cats",
                 authors: [],
@@ -46,7 +46,7 @@ describe("extractKeywords", () => {
     });
 
     it("should filter out stopwords", () => {
-        const papers = [
+        const papers: any[] = [
             { title: "The Impact of Using Machine Learning in the Field", authors: [] },
         ];
 
@@ -62,7 +62,7 @@ describe("extractKeywords", () => {
     });
 
     it("should extract keywords from abstract field content", () => {
-        const papers = [
+        const papers: any[] = [
             {
                 title: "A Study",
                 authors: [],
@@ -78,13 +78,25 @@ describe("extractKeywords", () => {
     });
 
     it("should return empty array for titles/abstracts with stopwords and symbols only", () => {
-        const papers = [
+        const papers: any[] = [
             { title: "The and of a in", authors: [], abstract: "!@#$%^&*() is to for be" },
             { title: "a to at on it", authors: [], abstract: "!!! ??? ###" },
         ];
 
         const keywords = extractKeywords(papers, 10);
         expect(keywords).toEqual([]);
+    });
+
+    it("should sort keywords by frequency in descending order and respect topN", () => {
+        const papers: any[] = [
+            { title: "Apple Banana Apple", authors: [] },
+            { title: "Apple Banana Cherry", authors: [] },
+            { title: "Cherry Cherry Cherry Cherry", authors: [] },
+        ];
+        // Frequencies after tokenization: cherry: 5, apple: 3, banana: 2
+        const keywords = extractKeywords(papers, 2);
+        expect(keywords).toEqual(["cherry", "apple"]);
+        expect(keywords).not.toContain("banana");
     });
 });
 


### PR DESCRIPTION
🎯 **What:** Added a test for the `extractKeywords` function in `drilldown.ts` to ensure it correctly sorts extracted keywords by frequency and limits them by the `topN` parameter. Also added explicit `any[]` typings to mock `papers` arrays to fix potential TypeScript compilation errors.
📊 **Coverage:** The new test covers sorting behaviour by frequency of text and correctly applying the `topN` cutoff to the array of strings returned.
✨ **Result:** Test coverage and reliability of the codebase is improved.

---
*PR created automatically by Jules for task [1547522635850596903](https://jules.google.com/task/1547522635850596903) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `extractKeywords` のテストを追加しています。主な変更は次のとおりです。

- 頻度順ソートと `topN` の切り詰めを検証するテストを追加。
- 既存の `papers` モック配列に `any[]` 型注釈を追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/drilldown.test.ts | `extractKeywords` の頻度順ソートと `topN` 制限を確認するテストが追加され、既存のモック配列に `any[]` 注釈が付与されました。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(drilldown): add test for extractKey..."](https://github.com/hiroki-org/paper-tools/commit/b46f5a51bd6b12d981935f0af8f79c2178183c90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440586)</sub>

**Context used:**

- Knowledge Base — [Drilldown CLI (`packages/drilldown`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/drilldown.md)

<!-- /greptile_comment -->