### PR TITLE
🧪 Add tests for recommendFromSingle

### DIFF
--- a/packages/recommender/tests/recommend.test.ts
+++ b/packages/recommender/tests/recommend.test.ts
@@ -137,3 +137,65 @@ describe("recommendFromMultiple", () => {
         expect(core.getRecommendations).not.toHaveBeenCalled();
     });
 });
+describe("recommendFromSingle", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("正常に単一論文から推薦を取得できる", async () => {
+        const { recommendFromSingle } = await import("../src/recommend.js");
+
+        // Use the mocked core module
+        const core = await import("@paper-tools/core");
+
+        vi.mocked(core.getRecommendationsForPaper).mockResolvedValueOnce({
+            recommendedPapers: [{ paperId: "rec1", title: "R1" } as any],
+        });
+
+        const results = await recommendFromSingle("pos1");
+        expect(results).toHaveLength(1);
+        expect(results[0].paperId).toBe("rec1");
+        expect(core.getRecommendationsForPaper).toHaveBeenCalledWith("pos1", {
+            limit: 10,
+            from: "recent"
+        });
+    });
+
+    it("カスタムオプションが適用される", async () => {
+        const { recommendFromSingle } = await import("../src/recommend.js");
+        const core = await import("@paper-tools/core");
+
+        vi.mocked(core.getRecommendationsForPaper).mockResolvedValueOnce({
+            recommendedPapers: [],
+        });
+
+        await recommendFromSingle("pos1", { limit: 5, from: "all-cs" });
+        expect(core.getRecommendationsForPaper).toHaveBeenCalledWith("pos1", {
+            limit: 5,
+            from: "all-cs"
+        });
+    });
+
+    it("recommendedPapersが未定義の場合、空配列を返す", async () => {
+        const { recommendFromSingle } = await import("../src/recommend.js");
+        const core = await import("@paper-tools/core");
+
+        vi.mocked(core.getRecommendationsForPaper).mockResolvedValueOnce({} as any);
+
+        const results = await recommendFromSingle("pos1");
+        expect(results).toEqual([]);
+    });
+
+    it("resolveToS2Idを通じてIDが解決される", async () => {
+        const { recommendFromSingle } = await import("../src/recommend.js");
+        const core = await import("@paper-tools/core");
+
+        vi.mocked(core.getPaper).mockResolvedValueOnce({ paperId: "s2-doi", title: "t" } as any);
+        vi.mocked(core.getRecommendationsForPaper).mockResolvedValueOnce({
+            recommendedPapers: [],
+        });
+
+        await recommendFromSingle("DOI:10.1000/xyz");
+        expect(core.getRecommendationsForPaper).toHaveBeenCalledWith("s2-doi", expect.any(Object));
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added comprehensive tests for the `recommendFromSingle` function in `recommend.ts`.
📊 **Coverage:** Covered standard behavior with default options, custom `limit`/`from` options, handling of undefined `recommendedPapers`, and ID resolution via `resolveToS2Id`.
✨ **Result:** Increased test coverage and confidence in the recommender module's core behavior.

---
*PR created automatically by Jules for task [6306510621485993407](https://jules.google.com/task/6306510621485993407) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `recommendFromSingle` のテストを追加しています。主な変更は次のとおりです。

- デフォルトの推薦取得オプションの確認。
- カスタム `limit` と `from` の受け渡し確認。
- `recommendedPapers` がない場合の空配列確認。
- DOI入力からS2 IDへ解決される経路の確認。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/recommender/tests/recommend.test.ts | `recommendFromSingle` の主要な挙動を確認するテストが追加され、既存の実装とモック構成に沿っています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(recommender): add tests for recomme..."](https://github.com/hiroki-org/paper-tools/commit/1c7016cf700fce103f0e55579dc52f219bd4279d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440649)</sub>

**Context used:**

- Knowledge Base — [Recommender package](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/recommender.md)

<!-- /greptile_comment -->