### PR TITLE
🧹 Remove unnecessary S2AuthorPapersResponse import

### DIFF
--- a/packages/author-profiler/src/tests/coauthor-network.test.ts
+++ b/packages/author-profiler/src/tests/coauthor-network.test.ts
@@ -1,204 +1,232 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { aggregateCoauthorsFromPapers, buildCoauthorNetwork } from "../services/coauthor-network.js";
-import { getAuthorPapers, type S2Paper, type S2AuthorPapersResponse } from "@paper-tools/core";
+import { getAuthorPapers, type S2Paper } from "@paper-tools/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	aggregateCoauthorsFromPapers,
+	buildCoauthorNetwork,
+} from "../services/coauthor-network.js";
 
 vi.mock("@paper-tools/core", () => ({
-    getAuthorPapers: vi.fn(),
+	getAuthorPapers: vi.fn(),
 }));
 
 describe("aggregateCoauthorsFromPapers", () => {
-    it("aggregates coauthor counts and excludes self", () => {
-        const papers = [
-            {
-                paperId: "p1",
-                title: "A",
-                authors: [
-                    { authorId: "self", name: "Self" },
-                    { authorId: "a1", name: "Alice" },
-                    { authorId: "a2", name: "Bob" },
-                ],
-            },
-            {
-                paperId: "p2",
-                title: "B",
-                authors: [
-                    { authorId: "self", name: "Self" },
-                    { authorId: "a1", name: "Alice" },
-                ],
-            },
-        ];
+	it("aggregates coauthor counts and excludes self", () => {
+		const papers = [
+			{
+				paperId: "p1",
+				title: "A",
+				authors: [
+					{ authorId: "self", name: "Self" },
+					{ authorId: "a1", name: "Alice" },
+					{ authorId: "a2", name: "Bob" },
+				],
+			},
+			{
+				paperId: "p2",
+				title: "B",
+				authors: [
+					{ authorId: "self", name: "Self" },
+					{ authorId: "a1", name: "Alice" },
+				],
+			},
+		];
 
-        const result = aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[]);
-        expect(result).toEqual([
-            { authorId: "a1", name: "Alice", paperCount: 2 },
-            { authorId: "a2", name: "Bob", paperCount: 1 },
-        ]);
-    });
+		const result = aggregateCoauthorsFromPapers(
+			"self",
+			papers as Partial<S2Paper>[] as S2Paper[],
+		);
+		expect(result).toEqual([
+			{ authorId: "a1", name: "Alice", paperCount: 2 },
+			{ authorId: "a2", name: "Bob", paperCount: 1 },
+		]);
+	});
 
-    it("normalizes authorId correctly when aggregating", () => {
-        const papers = [
-            {
-                paperId: "p1",
-                title: "A",
-                authors: [
-                    { authorId: " self ", name: "Self" },
-                    { authorId: " a1 ", name: "Alice" },
-                    { authorId: "  a2", name: "Bob" },
-                ],
-            },
-            {
-                paperId: "p2",
-                title: "B",
-                authors: [
-                    { authorId: "self", name: "Self" },
-                    { authorId: "a1", name: "Alice" },
-                ],
-            },
-        ];
+	it("normalizes authorId correctly when aggregating", () => {
+		const papers = [
+			{
+				paperId: "p1",
+				title: "A",
+				authors: [
+					{ authorId: " self ", name: "Self" },
+					{ authorId: " a1 ", name: "Alice" },
+					{ authorId: "  a2", name: "Bob" },
+				],
+			},
+			{
+				paperId: "p2",
+				title: "B",
+				authors: [
+					{ authorId: "self", name: "Self" },
+					{ authorId: "a1", name: "Alice" },
+				],
+			},
+		];
 
-        const result = aggregateCoauthorsFromPapers(" self ", papers as Partial<S2Paper>[] as S2Paper[]);
-        expect(result).toEqual([
-            { authorId: "a1", name: "Alice", paperCount: 2 },
-            { authorId: "a2", name: "Bob", paperCount: 1 },
-        ]);
-    });
+		const result = aggregateCoauthorsFromPapers(
+			" self ",
+			papers as Partial<S2Paper>[] as S2Paper[],
+		);
+		expect(result).toEqual([
+			{ authorId: "a1", name: "Alice", paperCount: 2 },
+			{ authorId: "a2", name: "Bob", paperCount: 1 },
+		]);
+	});
 
-    it("handles empty papers array", () => {
-        const result = aggregateCoauthorsFromPapers("self", []);
-        expect(result).toEqual([]);
-    });
+	it("handles empty papers array", () => {
+		const result = aggregateCoauthorsFromPapers("self", []);
+		expect(result).toEqual([]);
+	});
 
-    it("handles papers with no authors", () => {
-        const papers = [
-            { paperId: "p1", title: "A" },
-            { paperId: "p2", title: "B", authors: [] },
-        ];
-        const result = aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[]);
-        expect(result).toEqual([]);
-    });
+	it("handles papers with no authors", () => {
+		const papers = [
+			{ paperId: "p1", title: "A" },
+			{ paperId: "p2", title: "B", authors: [] },
+		];
+		const result = aggregateCoauthorsFromPapers(
+			"self",
+			papers as Partial<S2Paper>[] as S2Paper[],
+		);
+		expect(result).toEqual([]);
+	});
 
-    it("handles authors with missing or empty authorId", () => {
-        const papers = [
-            {
-                paperId: "p1",
-                title: "A",
-                authors: [
-                    { authorId: "self", name: "Self" },
-                    { authorId: "", name: "No ID 1" },
-                    { name: "No ID 2" },
-                    { authorId: "  ", name: "No ID 3" },
-                ],
-            },
-        ];
-        const result = aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[]);
-        expect(result).toEqual([]);
-    });
+	it("handles authors with missing or empty authorId", () => {
+		const papers = [
+			{
+				paperId: "p1",
+				title: "A",
+				authors: [
+					{ authorId: "self", name: "Self" },
+					{ authorId: "", name: "No ID 1" },
+					{ name: "No ID 2" },
+					{ authorId: "  ", name: "No ID 3" },
+				],
+			},
+		];
+		const result = aggregateCoauthorsFromPapers(
+			"self",
+			papers as Partial<S2Paper>[] as S2Paper[],
+		);
+		expect(result).toEqual([]);
+	});
 
-    it("handles authors with missing or empty names, falling back to 'Unknown'", () => {
-        const papers = [
-            {
-                paperId: "p1",
-                title: "A",
-                authors: [
-                    { authorId: "self", name: "Self" },
-                    { authorId: "a1" },
-                    { authorId: "a2", name: "" },
-                    { authorId: "a3", name: "  " },
-                ],
-            },
-        ];
-        const result = aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[]);
-        expect(result).toEqual([
-            { authorId: "a1", name: "Unknown", paperCount: 1 },
-            { authorId: "a2", name: "Unknown", paperCount: 1 },
-            { authorId: "a3", name: "Unknown", paperCount: 1 },
-        ]);
-    });
+	it("handles authors with missing or empty names, falling back to 'Unknown'", () => {
+		const papers = [
+			{
+				paperId: "p1",
+				title: "A",
+				authors: [
+					{ authorId: "self", name: "Self" },
+					{ authorId: "a1" },
+					{ authorId: "a2", name: "" },
+					{ authorId: "a3", name: "  " },
+				],
+			},
+		];
+		const result = aggregateCoauthorsFromPapers(
+			"self",
+			papers as Partial<S2Paper>[] as S2Paper[],
+		);
+		expect(result).toEqual([
+			{ authorId: "a1", name: "Unknown", paperCount: 1 },
+			{ authorId: "a2", name: "Unknown", paperCount: 1 },
+			{ authorId: "a3", name: "Unknown", paperCount: 1 },
+		]);
+	});
 
-    it("ignores duplicate authors within the same paper", () => {
-        const papers = [
-            {
-                paperId: "p1",
-                title: "A",
-                authors: [
-                    { authorId: "self", name: "Self" },
-                    { authorId: "a1", name: "Alice" },
-                    { authorId: "a1", name: "Alice Duplicate" },
-                ],
-            },
-        ];
-        const result = aggregateCoauthorsFromPapers("self", papers as Partial<S2Paper>[] as S2Paper[]);
-        expect(result).toEqual([
-            { authorId: "a1", name: "Alice", paperCount: 1 },
-        ]);
-    });
+	it("ignores duplicate authors within the same paper", () => {
+		const papers = [
+			{
+				paperId: "p1",
+				title: "A",
+				authors: [
+					{ authorId: "self", name: "Self" },
+					{ authorId: "a1", name: "Alice" },
+					{ authorId: "a1", name: "Alice Duplicate" },
+				],
+			},
+		];
+		const result = aggregateCoauthorsFromPapers(
+			"self",
+			papers as Partial<S2Paper>[] as S2Paper[],
+		);
+		expect(result).toEqual([{ authorId: "a1", name: "Alice", paperCount: 1 }]);
+	});
 });
 
 describe("buildCoauthorNetwork", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-    });
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
 
-    it("fetches papers and aggregates coauthors correctly", async () => {
-        const mockPapers = [
-            {
-                paperId: "p1",
-                title: "Paper 1",
-                authors: [
-                    { authorId: "target", name: "Target Author" },
-                    { authorId: "c1", name: "Coauthor One" },
-                ],
-            },
-            {
-                paperId: "p2",
-                title: "Paper 2",
-                authors: [
-                    { authorId: "target", name: "Target Author" },
-                    { authorId: "c1", name: "Coauthor One" },
-                    { authorId: "c2", name: "Coauthor Two" },
-                ],
-            },
-        ];
+	it("fetches papers and aggregates coauthors correctly", async () => {
+		const mockPapers = [
+			{
+				paperId: "p1",
+				title: "Paper 1",
+				authors: [
+					{ authorId: "target", name: "Target Author" },
+					{ authorId: "c1", name: "Coauthor One" },
+				],
+			},
+			{
+				paperId: "p2",
+				title: "Paper 2",
+				authors: [
+					{ authorId: "target", name: "Target Author" },
+					{ authorId: "c1", name: "Coauthor One" },
+					{ authorId: "c2", name: "Coauthor Two" },
+				],
+			},
+		];
 
-        vi.mocked(getAuthorPapers).mockResolvedValue({
-            data: mockPapers as Partial<S2Paper>[] as S2Paper[],
-            total: 2,
-            offset: 0,
-            next: 0,
-        });
+		vi.mocked(getAuthorPapers).mockResolvedValue({
+			data: mockPapers as Partial<S2Paper>[] as S2Paper[],
+			total: 2,
+			offset: 0,
+			next: 0,
+		});
 
-        const result = await buildCoauthorNetwork("target", { limit: 10, sort: "paperCount" });
+		const result = await buildCoauthorNetwork("target", {
+			limit: 10,
+			sort: "paperCount",
+		});
 
-        expect(getAuthorPapers).toHaveBeenCalledWith("target", { limit: 10, sort: "paperCount" });
-        expect(result).toEqual([
-            { authorId: "c1", name: "Coauthor One", paperCount: 2 },
-            { authorId: "c2", name: "Coauthor Two", paperCount: 1 },
-        ]);
-    });
+		expect(getAuthorPapers).toHaveBeenCalledWith("target", {
+			limit: 10,
+			sort: "paperCount",
+		});
+		expect(result).toEqual([
+			{ authorId: "c1", name: "Coauthor One", paperCount: 2 },
+			{ authorId: "c2", name: "Coauthor Two", paperCount: 1 },
+		]);
+	});
 
-    it("uses default options when none are provided", async () => {
-        vi.mocked(getAuthorPapers).mockResolvedValue({
-            data: [],
-            total: 0,
-            offset: 0,
-            next: 0,
-        });
+	it("uses default options when none are provided", async () => {
+		vi.mocked(getAuthorPapers).mockResolvedValue({
+			data: [],
+			total: 0,
+			offset: 0,
+			next: 0,
+		});
 
-        await buildCoauthorNetwork("target");
+		await buildCoauthorNetwork("target");
 
-        expect(getAuthorPapers).toHaveBeenCalledWith("target", { limit: 200, sort: undefined });
-    });
+		expect(getAuthorPapers).toHaveBeenCalledWith("target", {
+			limit: 200,
+			sort: undefined,
+		});
+	});
 
-    it("handles getAuthorPapers returning undefined data", async () => {
-        vi.mocked(getAuthorPapers).mockResolvedValue({
-            data: undefined,
-            total: 0,
-            offset: 0,
-            next: 0,
-        } as unknown as S2AuthorPapersResponse);
+	it("handles getAuthorPapers returning undefined data", async () => {
+		vi.mocked(getAuthorPapers).mockResolvedValue({
+			data: undefined,
+			total: 0,
+			offset: 0,
+			next: 0,
+		} as unknown as NonNullable<Awaited<ReturnType<typeof getAuthorPapers>>>);
 
-        const result = await buildCoauthorNetwork("target");
+		const result = await buildCoauthorNetwork("target");
 
-        expect(result).toEqual([]);
-    });
+		expect(result).toEqual([]);
+	});
 });


### PR DESCRIPTION
🎯 **What:** Removed unnecessary `S2AuthorPapersResponse` import and type cast. Replaced the type cast with `NonNullable<Awaited<ReturnType<typeof getAuthorPapers>>>` to stay in sync with the function being mocked.
💡 **Why:** It removes unused imports and reduces cognitive load while improving type safety.
✅ **Verification:** Verified tests pass with `pnpm test` and formatting via `biome check`.
✨ **Result:** Improved code health and maintainability.

---
*PR created automatically by Jules for task [15042940359087233668](https://jules.google.com/task/15042940359087233668) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは coauthor network のテスト内の型 import を整理します。主な変更は次のとおりです。

- `S2AuthorPapersResponse` の未使用 import を削除。
- モックレスポンスの型を `getAuthorPapers` の戻り値から導出。
- import 順と整形を更新。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/author-profiler/src/tests/coauthor-network.test.ts | テスト内の core 型 import を削除し、モックレスポンスのキャストを関数戻り値由来の型へ置き換えています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove unnecessary import in t..."](https://github.com/hiroki-org/paper-tools/commit/3e1edd20e06027d901fd2c81a68c901465f12bd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440689)</sub>

**Context used:**

- Knowledge Base — [Author Profiler](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/author-profiler.md)

<!-- /greptile_comment -->