### PR TITLE
🔒 Fix unvalidated input vulnerability in drilldown CLI

### DIFF
--- a/packages/drilldown/src/cli.ts
+++ b/packages/drilldown/src/cli.ts
@@ -19,6 +19,23 @@ const packageJson = JSON.parse(
 );
 const version = packageJson.version;
 
+
+/**
+ * 入力文字列を検証・サニタイズする
+ * @param input 検証する文字列
+ * @returns サニタイズされた文字列
+ */
+function sanitizeInput(input: string): string {
+    const trimmed = input.trim().replace(/[\x00-\x1F\x7F]/g, '');
+    if (!trimmed) {
+        throw new Error("入力が空、または無効な文字のみで構成されています");
+    }
+    if (trimmed.length > 500) {
+        throw new Error("入力が長すぎます（最大500文字）");
+    }
+    return trimmed;
+}
+
 /**
  * データを JSON フォーマットで出力する
  * 出力先ファイルが指定されている場合はファイルに書き込み、そうでない場合は stdout に出力する
@@ -63,7 +80,8 @@ program
     .action((keyword: string, options: { limit?: string; enrich?: boolean; output?: string }) => {
         runAction(async () => {
             const limit = parsePositiveInt(options.limit || "30", "--limit");
-            let papers = await searchByKeyword(keyword, limit);
+            const sanitizedKeyword = sanitizeInput(keyword);
+            let papers = await searchByKeyword(sanitizedKeyword, limit);
             if (options.enrich) {
                 papers = await enrichAllWithCrossref(papers);
             }
@@ -83,7 +101,8 @@ program
         runAction(async () => {
             const limit = parsePositiveInt(options.limit || "100", "--limit");
             const year = options.year ? parsePositiveInt(options.year, "--year") : undefined;
-            let papers = await searchByVenue(venue, year, limit);
+            const sanitizedVenue = sanitizeInput(venue);
+            let papers = await searchByVenue(sanitizedVenue, year, limit);
             if (options.enrich) {
                 papers = await enrichAllWithCrossref(papers);
             }
@@ -100,7 +119,8 @@ program
     .action((query: string, options: { limit?: string; output?: string }) => {
         runAction(async () => {
             const limit = parsePositiveInt(options.limit || "20", "--limit");
-            const papers = await searchCrossref(query, limit);
+            const sanitizedQuery = sanitizeInput(query);
+            const papers = await searchCrossref(sanitizedQuery, limit);
             await outputJson(papers, options.output);
         });
     });
@@ -127,7 +147,8 @@ program
             const maxPerLevel = parsePositiveInt(options.maxPerLevel || "10", "--max-per-level");
             const enrich = options.enrich ?? false;
 
-            const seedPapers = await searchByKeyword(keyword, seedLimit);
+            const sanitizedKeyword = sanitizeInput(keyword);
+            const seedPapers = await searchByKeyword(sanitizedKeyword, seedLimit);
             if (seedPapers.length === 0) {
                 console.error("シード検索結果が 0 件です");
                 process.exit(1);
@@ -150,14 +171,15 @@ program
             const limit = parsePositiveInt(options.limit || "20", "--limit");
             const topN = parsePositiveInt(options.top || "10", "--top");
 
-            const papers = await searchByKeyword(keyword, limit);
+            const sanitizedKeyword = sanitizeInput(keyword);
+            const papers = await searchByKeyword(sanitizedKeyword, limit);
             if (papers.length === 0) {
                 console.error("検索結果が 0 件です");
                 process.exit(1);
             }
 
             const keywords = extractKeywords(papers, topN);
-            await outputJson({ query: keyword, papersAnalyzed: papers.length, keywords }, options.output);
+            await outputJson({ query: sanitizedKeyword, papersAnalyzed: papers.length, keywords }, options.output);
         });
     });
 


### PR DESCRIPTION
🎯 **What:** The `query` argument from the CLI was passed directly to `searchCrossref` (and other search functions) without sanitization in `packages/drilldown/src/cli.ts`.

⚠️ **Risk:** The lack of validation could allow unvalidated inputs to be passed through the CLI to downstream APIs, potentially causing unexpected behavior, application crashes, or allowing abuse like extremely long payloads if used in a web or CI context. 

🛡️ **Solution:** Added a robust `sanitizeInput` function that trims whitespace, removes ASCII control characters, checks for empty strings, and enforces a sensible maximum length limit (500 characters). This function is now proactively applied to inputs for the `crossref`, `search`, `venue`, `drilldown`, and `keywords` commands.

---
*PR created automatically by Jules for task [6809369159016125097](https://jules.google.com/task/6809369159016125097) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds input validation to the drilldown CLI search commands.

- Added a shared `sanitizeInput` helper.
- Trimmed input, removed ASCII control characters, rejected empty input, and capped length at 500 characters.
- Applied the helper to `search`, `venue`, `crossref`, `drilldown`, and `keywords` command arguments.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The changed CLI parsing path can alter valid search terms and should be adjusted before merging.

- Internal tab or newline separators are deleted instead of preserved as word boundaries.
- The fixed 500-character cap can block long searches that the underlying clients would still send.
- The change is contained to the drilldown CLI file.

packages/drilldown/src/cli.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/src/cli.ts | Adds CLI input sanitization across drilldown search commands, with risks around separator removal and a fixed query-length cap. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/drilldown/src/cli.ts:29
**Word Separators Are Removed**

When a scripted or quoted CLI call passes a tab or newline as the separator in a search term, this replacement deletes the separator and joins the adjacent words. `neural\tnetworks` becomes `neuralnetworks`, so DBLP or Crossref receives a different query and can return incorrect results.

```suggestion
    const trimmed = input.trim().replace(/[\t\n\r\f\v]+/g, ' ').replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
```

### Issue 2 of 2
packages/drilldown/src/cli.ts:33-35
**CLI Rejects Long Queries**

The new 500-character limit applies before `searchByKeyword` and `searchCrossref`, while the downstream search clients do not enforce the same cap. A valid long Crossref or DBLP query with many title, author, or keyword terms now exits locally instead of reaching the API, so existing CLI searches can stop working.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sanitize query input in drilldown C..."](https://github.com/hiroki-org/paper-tools/commit/359a5a9c9e669ae7e9b7d62364c78bf2b07d434f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45441338)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Drilldown CLI (`packages/drilldown`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/drilldown.md)
- Knowledge Base — [packages/core](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/core.md)

<!-- /greptile_comment -->