### PR TITLE
🧪 Add tests for /api/search route

### DIFF
--- a/packages/web/src/app/api/search/route.test.ts
+++ b/packages/web/src/app/api/search/route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@paper-tools/drilldown", () => ({
+    searchByKeyword: vi.fn(),
+}));
+
+const { searchByKeyword } = await import("@paper-tools/drilldown");
+const { GET } = await import("./route");
+
+function makeRequest(url: string) {
+    return new NextRequest(url);
+}
+
+describe("/api/search GET", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("qパラメータのみ指定でsearchByKeywordがデフォルトmaxResults(30)で呼ばれる", async () => {
+        const mockPapers = [{ paperId: "paper1", title: "Paper 1" }];
+        vi.mocked(searchByKeyword).mockResolvedValueOnce(mockPapers as any);
+
+        const res = await GET(makeRequest("http://localhost/api/search?q=test"));
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(searchByKeyword).toHaveBeenCalledWith("test", 30);
+        expect(data.papers).toEqual(mockPapers);
+        expect(data.total).toBe(1);
+    });
+
+    it("maxResultsを指定した場合、正しく渡される", async () => {
+        const mockPapers = [{ paperId: "paper2", title: "Paper 2" }];
+        vi.mocked(searchByKeyword).mockResolvedValueOnce(mockPapers as any);
+
+        const res = await GET(makeRequest("http://localhost/api/search?q=test2&maxResults=50"));
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(searchByKeyword).toHaveBeenCalledWith("test2", 50);
+        expect(data.papers).toEqual(mockPapers);
+    });
+
+    it("maxResultsが100を超える場合は100に制限される", async () => {
+        vi.mocked(searchByKeyword).mockResolvedValueOnce([]);
+
+        const res = await GET(makeRequest("http://localhost/api/search?q=test&maxResults=150"));
+
+        expect(res.status).toBe(200);
+        expect(searchByKeyword).toHaveBeenCalledWith("test", 100);
+    });
+
+    it("maxResultsが1未満の場合は1に制限される", async () => {
+        vi.mocked(searchByKeyword).mockResolvedValueOnce([]);
+
+        const res = await GET(makeRequest("http://localhost/api/search?q=test&maxResults=-5"));
+
+        expect(res.status).toBe(200);
+        expect(searchByKeyword).toHaveBeenCalledWith("test", 1);
+    });
+
+    it("maxResultsが不正な文字列の場合は30になる", async () => {
+        vi.mocked(searchByKeyword).mockResolvedValueOnce([]);
+
+        const res = await GET(makeRequest("http://localhost/api/search?q=test&maxResults=abc"));
+
+        expect(res.status).toBe(200);
+        expect(searchByKeyword).toHaveBeenCalledWith("test", 30);
+    });
+
+    it("qパラメータが未指定の場合は400エラー", async () => {
+        const res = await GET(makeRequest("http://localhost/api/search"));
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toBe("q parameter is required");
+    });
+
+    it("searchByKeywordでErrorが発生した場合は502エラー", async () => {
+        vi.mocked(searchByKeyword).mockRejectedValueOnce(new Error("Backend timeout"));
+
+        const res = await GET(makeRequest("http://localhost/api/search?q=test"));
+        const data = await res.json();
+
+        expect(res.status).toBe(502);
+        expect(data.error).toBe("Search backend failed: Backend timeout");
+    });
+
+    it("searchByKeywordでError以外が発生した場合は502エラー(Unknown error)", async () => {
+        vi.mocked(searchByKeyword).mockRejectedValueOnce("String error");
+
+        const res = await GET(makeRequest("http://localhost/api/search?q=test"));
+        const data = await res.json();
+
+        expect(res.status).toBe(502);
+        expect(data.error).toBe("Search backend failed: Unknown error");
+    });
+});

--- a/packages/web/src/app/api/search/route.test.ts
+++ b/packages/web/src/app/api/search/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@paper-tools/drilldown", () => ({
@@ -6,7 +6,7 @@ vi.mock("@paper-tools/drilldown", () => ({
 }));
 
 const { searchByKeyword } = await import("@paper-tools/drilldown");
-const { GET } = await import("./route");
+const { GET } = await import("./route.js");
 
 function makeRequest(url: string) {
     return new NextRequest(url);
@@ -18,8 +18,10 @@ describe("/api/search GET", () => {
     });
 
     it("qパラメータのみ指定でsearchByKeywordがデフォルトmaxResults(30)で呼ばれる", async () => {
-        const mockPapers = [{ paperId: "paper1", title: "Paper 1" }];
-        vi.mocked(searchByKeyword).mockResolvedValueOnce(mockPapers as any);
+        const mockPapers: Awaited<ReturnType<typeof searchByKeyword>> = [
+            { title: "Paper 1", authors: [] },
+        ];
+        vi.mocked(searchByKeyword).mockResolvedValueOnce(mockPapers);
 
         const res = await GET(makeRequest("http://localhost/api/search?q=test"));
         const data = await res.json();
@@ -31,8 +33,10 @@ describe("/api/search GET", () => {
     });
 
     it("maxResultsを指定した場合、正しく渡される", async () => {
-        const mockPapers = [{ paperId: "paper2", title: "Paper 2" }];
-        vi.mocked(searchByKeyword).mockResolvedValueOnce(mockPapers as any);
+        const mockPapers: Awaited<ReturnType<typeof searchByKeyword>> = [
+            { title: "Paper 2", authors: [] },
+        ];
+        vi.mocked(searchByKeyword).mockResolvedValueOnce(mockPapers);
 
         const res = await GET(makeRequest("http://localhost/api/search?q=test2&maxResults=50"));
         const data = await res.json();


### PR DESCRIPTION
🎯 **What:** The /api/search GET endpoint was missing tests. This PR adds unit tests covering query parsing, error handling, and backend interactions.
📊 **Coverage:** Covered happy paths (valid `q` and `maxResults`), edge cases (bounds checking on `maxResults`, missing `q`), and error conditions (backend errors and unknown exceptions).
✨ **Result:** 100% test coverage for `packages/web/src/app/api/search/route.ts`.

---
*PR created automatically by Jules for task [17071583619169858139](https://jules.google.com/task/17071583619169858139) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`/api/search` の GET エンドポイントに対する単体テストを追加しています。
- `q` と `maxResults` の解析および上限・下限処理を検証
- 検索成功時のレスポンスとバックエンド呼び出しを検証
- 必須パラメータ不足とバックエンド例外時のエラー処理を検証
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると考えられます。

ブロッキングとなる不具合は残っていません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/search/route.test.ts | `/api/search` の正常系、入力境界値、必須パラメータ不足、バックエンド障害を網羅するテストを追加しています。 |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(web): align search route tests with..."](https://github.com/hiroki-org/paper-tools/commit/467a70737cbdfa4aeabfe58c511214ab089622ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47324997)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->