### PR TITLE
🧹 [code health] Remove leftover console.log in bibtex validation

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -209,7 +209,6 @@ program
 
             const entries = splitBibtexEntries(text);
             if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
                 return;
             }
 


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.log` statement when no entries are found in `packages/bibtex/src/index.ts`.
💡 **Why:** To improve code health and remove unnecessary output.
✅ **Verification:** Verified by ensuring the code continues to parse entries properly and all tests pass.
✨ **Result:** A cleaner codebase.

---
*PR created automatically by Jules for task [3644403957001641103](https://jules.google.com/task/3644403957001641103) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`packages/bibtex/src/index.ts` の BibTeX 検証処理から、エントリが見つからなかった場合の不要な `console.log` 出力を削除しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は安全にマージできると判断します。

ブロッキングとなる不具合は残っていません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/index.ts | 空の解析結果に対する早期リターンは維持したまま、標準出力へのメッセージだけを削除しています。 |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/remove-bi..."](https://github.com/hiroki-org/paper-tools/commit/e7fa0acd51bc7bfd86dd8b9c902244a5417b3c15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325005)</sub>

<!-- /greptile_comment -->