### PR TITLE
🧹 Remove leftover console.log in bibtex validation

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -209,7 +209,6 @@ program
 
             const entries = splitBibtexEntries(text);
             if (entries.length === 0) {
-                console.log("No BibTeX entries found.");
                 return;
             }
 


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.log` in the bibtex validation command when no entries are found.
💡 **Why:** Improves code hygiene by removing unnecessary logging that might interfere with CLI usage or output parsing.
✅ **Verification:** Verified by checking the updated source file and running the existing test suite.
✨ **Result:** Cleaner codebase without unnecessary console output.

---
*PR created automatically by Jules for task [6460042185036462790](https://jules.google.com/task/6460042185036462790) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

BibTeX 検証コマンドでエントリが見つからなかった場合の不要な標準出力を削除します。
- `splitBibtexEntries` が空配列を返した際、メッセージを出力せず既存の早期 return を実行
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は安全にマージできると判断します。

不要な標準出力の削除に限定され、エントリの解析、検証、エラー判定、終了ステータスを変更する新たな不具合は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/index.ts | エントリなしの場合の `console.log` のみを削除しており、検証処理や終了ステータスの既存動作は変更していません。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove leftover console.log in bibtex..."](https://github.com/hiroki-org/paper-tools/commit/423075c04bb8db98f9bb69cd74f87627a942462b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325027)</sub>

<!-- /greptile_comment -->