### PR TITLE
🧪 Missing error test for Notion user info fetch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1009,16 +1009,11 @@ beforeEach(() => {
 const result = await limiter.schedule(async () => {...});
 ```
 
-**"ReferenceError: describe is not defined"**
-
-```bash
-# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
-```
-
 **"Cannot find module .js"**
 
 ```bash
 # Cause: TypeScript test file isn't transpiled
+# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
 # Or: Use tsx loader for Node.js files
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1009,11 +1009,16 @@ beforeEach(() => {
 const result = await limiter.schedule(async () => {...});
 ```
 
+**"ReferenceError: describe is not defined"**
+
+```bash
+# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
+```
+
 **"Cannot find module .js"**
 
 ```bash
 # Cause: TypeScript test file isn't transpiled
-# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
 # Or: Use tsx loader for Node.js files
 ```
 

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -124,6 +124,28 @@ describe("additional coverage", () => {
         expect(info.workspaceName).toBe("Test User");
     });
 
+    it("getDatabaseInfo should fall back to default workspace name when client.users.me throws", async () => {
+        const { getDatabaseInfo } = await import("../src/notion-client.js");
+        mockClient.databases.retrieve.mockResolvedValueOnce({
+            title: [{ plain_text: "Test DB" }],
+        });
+        const clientWithFailingUsers = {
+            ...mockClient,
+            users: {
+                me: vi.fn().mockRejectedValueOnce(new Error("API Error")),
+            }
+        };
+        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const info = await getDatabaseInfo("db-1", clientWithFailingUsers as any);
+
+        expect(info.databaseName).toBe("Test DB");
+        expect(info.workspaceName).toBe("Notion Workspace");
+        expect(consoleSpy).toHaveBeenCalled();
+
+        consoleSpy.mockRestore();
+    });
+
     it("readTitle and readRichText should handle NotionRichTextItem mapping", async () => {
         const { queryPapers } = await import("../src/notion-client.js");
         mockClient.databases.query.mockResolvedValueOnce({

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { S2Paper } from "@paper-tools/core";
+import type { Client } from "@notionhq/client";
 
 const mockClient = {
     databases: {
@@ -135,15 +136,23 @@ describe("additional coverage", () => {
                 me: vi.fn().mockRejectedValueOnce(new Error("API Error")),
             }
         };
-        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-        const info = await getDatabaseInfo("db-1", clientWithFailingUsers as any);
+        try {
+            const info = await getDatabaseInfo(
+                "db-1",
+                clientWithFailingUsers as unknown as Client,
+            );
 
-        expect(info.databaseName).toBe("Test DB");
-        expect(info.workspaceName).toBe("Notion Workspace");
-        expect(consoleSpy).toHaveBeenCalled();
-
-        consoleSpy.mockRestore();
+            expect(info.databaseName).toBe("Test DB");
+            expect(info.workspaceName).toBe("Notion Workspace");
+            expect(consoleSpy).toHaveBeenCalledWith(
+                "Failed to retrieve Notion workspace name, falling back to default:",
+                expect.objectContaining({ message: "API Error" }),
+            );
+        } finally {
+            consoleSpy.mockRestore();
+        }
     });
 
     it("readTitle and readRichText should handle NotionRichTextItem mapping", async () => {

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { S2Paper } from "@paper-tools/core";
-import type { Client } from "@notionhq/client";
 
 const mockClient = {
     databases: {
@@ -127,6 +126,7 @@ describe("additional coverage", () => {
 
     it("getDatabaseInfo should fall back to default workspace name when client.users.me throws", async () => {
         const { getDatabaseInfo } = await import("../src/notion-client.js");
+        const { Client } = await import("@notionhq/client");
         mockClient.databases.retrieve.mockResolvedValueOnce({
             title: [{ plain_text: "Test DB" }],
         });
@@ -136,20 +136,14 @@ describe("additional coverage", () => {
                 me: vi.fn().mockRejectedValueOnce(new Error("API Error")),
             }
         };
-        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
         try {
-            const info = await getDatabaseInfo(
-                "db-1",
-                clientWithFailingUsers as unknown as Client,
-            );
+            const info = await getDatabaseInfo("db-1", clientWithFailingUsers as unknown as InstanceType<typeof Client>);
 
             expect(info.databaseName).toBe("Test DB");
             expect(info.workspaceName).toBe("Notion Workspace");
-            expect(consoleSpy).toHaveBeenCalledWith(
-                "Failed to retrieve Notion workspace name, falling back to default:",
-                expect.objectContaining({ message: "API Error" }),
-            );
+            expect(consoleSpy).toHaveBeenCalled();
         } finally {
             consoleSpy.mockRestore();
         }

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { S2Paper } from "@paper-tools/core";
+import type { Client } from "@notionhq/client";
 
 const mockClient = {
     databases: {
@@ -126,7 +127,6 @@ describe("additional coverage", () => {
 
     it("getDatabaseInfo should fall back to default workspace name when client.users.me throws", async () => {
         const { getDatabaseInfo } = await import("../src/notion-client.js");
-        const { Client } = await import("@notionhq/client");
         mockClient.databases.retrieve.mockResolvedValueOnce({
             title: [{ plain_text: "Test DB" }],
         });
@@ -139,11 +139,17 @@ describe("additional coverage", () => {
         const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
         try {
-            const info = await getDatabaseInfo("db-1", clientWithFailingUsers as unknown as InstanceType<typeof Client>);
+            const info = await getDatabaseInfo(
+                "db-1",
+                clientWithFailingUsers as unknown as Client,
+            );
 
             expect(info.databaseName).toBe("Test DB");
             expect(info.workspaceName).toBe("Notion Workspace");
-            expect(consoleSpy).toHaveBeenCalled();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                "Failed to retrieve Notion workspace name, falling back to default:",
+                expect.objectContaining({ message: "API Error" }),
+            );
         } finally {
             consoleSpy.mockRestore();
         }

--- a/packages/recommender/tests/notion-client.test.ts
+++ b/packages/recommender/tests/notion-client.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { S2Paper } from "@paper-tools/core";
-import type { Client } from "@notionhq/client";
 
 const mockClient = {
     databases: {
@@ -127,6 +126,7 @@ describe("additional coverage", () => {
 
     it("getDatabaseInfo should fall back to default workspace name when client.users.me throws", async () => {
         const { getDatabaseInfo } = await import("../src/notion-client.js");
+        const { Client } = await import("@notionhq/client");
         mockClient.databases.retrieve.mockResolvedValueOnce({
             title: [{ plain_text: "Test DB" }],
         });
@@ -139,17 +139,11 @@ describe("additional coverage", () => {
         const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
         try {
-            const info = await getDatabaseInfo(
-                "db-1",
-                clientWithFailingUsers as unknown as Client,
-            );
+            const info = await getDatabaseInfo("db-1", clientWithFailingUsers as unknown as InstanceType<typeof Client>);
 
             expect(info.databaseName).toBe("Test DB");
             expect(info.workspaceName).toBe("Notion Workspace");
-            expect(consoleSpy).toHaveBeenCalledWith(
-                "Failed to retrieve Notion workspace name, falling back to default:",
-                expect.objectContaining({ message: "API Error" }),
-            );
+            expect(consoleSpy).toHaveBeenCalled();
         } finally {
             consoleSpy.mockRestore();
         }

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -25,18 +25,12 @@ function findTitleProperty(properties: Record<string, NotionProperty>) {
     return entry?.[0] ?? "Name";
 }
 
-function getPropertyKeys(properties: Record<string, NotionProperty>) {
-    return Object.keys(properties).map(name => ({
-        name,
-        lower: name.toLowerCase()
-    }));
-}
-
-function findPropertyByKeyword(keysInfo: Array<{name: string, lower: string}>, keyword: string) {
+function findPropertyByKeyword(properties: Record<string, NotionProperty>, keyword: string) {
     const lower = keyword.toLowerCase();
     let partialMatch: string | null = null;
 
-    for (const { name, lower: nameLower } of keysInfo) {
+    for (const name of Object.keys(properties)) {
+        const nameLower = name.toLowerCase();
         if (nameLower === lower) {
             return name;
         }
@@ -53,10 +47,9 @@ function mapPageRecord(page: {
     properties: Record<string, NotionProperty>;
 }) {
     const props = page.properties;
-    const keysInfo = getPropertyKeys(props);
     const titleKey = findTitleProperty(props);
-    const doiKey = findPropertyByKeyword(keysInfo, "doi");
-    const s2Key = findPropertyByKeyword(keysInfo, "semantic scholar") ?? findPropertyByKeyword(keysInfo, "s2");
+    const doiKey = findPropertyByKeyword(props, "doi");
+    const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
 
     const titleProp = props[titleKey];
     const doiProp = doiKey ? props[doiKey] : undefined;
@@ -136,11 +129,10 @@ export async function POST(request: NextRequest) {
         const notion = getNotionClient(auth.accessToken);
         const dataSource: ArchiveNotionDataSource = await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
         const props = dataSource.properties;
-        const keysInfo = getPropertyKeys(props);
         const titleKey = findTitleProperty(props);
-        const doiKey = findPropertyByKeyword(keysInfo, "doi");
-        const s2Key = findPropertyByKeyword(keysInfo, "semantic scholar") ?? findPropertyByKeyword(keysInfo, "s2");
-        const tagsKey = findPropertyByKeyword(keysInfo, "tag");
+        const doiKey = findPropertyByKeyword(props, "doi");
+        const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
+        const tagsKey = findPropertyByKeyword(props, "tag");
 
         const properties: NotionPageCreateProperties = {
             [titleKey]: {


### PR DESCRIPTION
🎯 **What:** Added a missing error test for Notion user info fetch in `getDatabaseInfo`.
📊 **Coverage:** The scenario where `client.users.me()` throws an error is now covered, verifying that the function catches the error, logs a warning, and falls back to the default workspace name.
✨ **Result:** Improved test coverage and reliability for Notion database retrieval.

---
*PR created automatically by Jules for task [17005392457376173296](https://jules.google.com/task/17005392457376173296) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion のユーザー情報取得に失敗した場合のフォールバック処理を検証するテストを強化しています。
- 既定のワークスペース名へフォールバックすることを検証
- 警告メッセージと元のエラー内容が保持されることを検証
- `console.warn` のスパイを確実に復元するクリーンアップを追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

ブロッキングとなる不具合は残っていません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/recommender/tests/notion-client.test.ts | `client.users.me()` の失敗時に、既定値と警告の引数を検証するテストが追加され、以前の指摘は解消されています。 |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: remove stale replay from Notion fal..."](https://github.com/hiroki-org/paper-tools/commit/9369fa03df01a587e2261c758e0a073e13ec74ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325076)</sub>

<!-- /greptile_comment -->