### PR TITLE
🧹 Remove leftover console.log in bibtex validation

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -217,10 +217,6 @@ program
             const errors = report.issues.filter((i) => i.level === "error");
             const warnings = report.issues.filter((i) => i.level === "warning");
 
-            console.log(`Entries: ${report.total}`);
-            console.log(`Errors: ${errors.length}`);
-            console.log(`Warnings: ${warnings.length}`);
-
             for (const issue of report.issues) {
                 const prefix = issue.level.toUpperCase();
                 const keyInfo = issue.key ? ` [${issue.key}]` : "";


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.log` statements for Entries, Errors, and Warnings counts in the `validate` command handler of `packages/bibtex/src/index.ts`.
💡 **Why:** To improve code hygiene and maintainability by removing unnecessary standard output logging. The subsequent detailed issue logging remains intact.
✅ **Verification:** Verified the removal using `sed` and confirmed that the bibtex package test suite and build completed successfully without regressions.
✨ **Result:** A cleaner and more concise validation output.

---
*PR created automatically by Jules for task [8426757448142606566](https://jules.google.com/task/8426757448142606566) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

validate コマンドの詳細な問題表示と終了コードを維持したまま、Entries・Errors・Warnings の集計ログを削除します。
- `packages/bibtex/src/index.ts` から3件の `console.log` を削除
- 検証エラーおよび警告の個別表示は変更なし
- エラー検出時の非ゼロ終了も変更なし
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると考えられます。

削除対象は未文書化かつリポジトリ内で依存されていない集計ログに限られ、個別の検証結果表示とエラー時の終了コードは維持されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/index.ts | validate コマンドから不要な集計出力のみを削除しており、具体的な不具合は確認されませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove leftover console.log in bibtex va..."](https://github.com/hiroki-org/paper-tools/commit/6c270c6729c33bf1b38bf09a6b78e3e8261092bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325111)</sub>

<!-- /greptile_comment -->