### PR TITLE
🧹 Remove leftover console.log in bibtex validation

### DIFF
--- a/packages/bibtex/src/index.ts
+++ b/packages/bibtex/src/index.ts
@@ -217,9 +217,6 @@ program
             const errors = report.issues.filter((i) => i.level === "error");
             const warnings = report.issues.filter((i) => i.level === "warning");
 
-            console.log(`Entries: ${report.total}`);
-            console.log(`Errors: ${errors.length}`);
-            console.log(`Warnings: ${warnings.length}`);
 
             for (const issue of report.issues) {
                 const prefix = issue.level.toUpperCase();


### PR DESCRIPTION
🎯 **What:** Removed leftover console.log statements from `packages/bibtex/src/index.ts`. 
💡 **Why:** These were debugging logs that were inadvertently left behind, cluttering CLI output. Removing them improves code hygiene. 
✅ **Verification:** Verified by running tests in the bibtex package and ensuring the workspace still compiles successfully. 
✨ **Result:** A cleaner output for the bibtex validation command.

---
*PR created automatically by Jules for task [16417852756660120948](https://jules.google.com/task/16417852756660120948) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

BibTeX の `validate` コマンドから、エントリ数・エラー数・警告数を表示するデバッグ用の `console.log` 3行を削除しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

個別の警告・エラー出力、エラー時の非ゼロ終了コード、空入力時の案内は維持されており、削除対象の集計行に依存するリポジトリ内の呼び出し元や文書化された出力契約もありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/src/index.ts | 検証結果の個別表示と終了コードを維持したまま、不要な集計ログのみを削除しており、問題は見つかりませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove leftover console.log in bi..."](https://github.com/hiroki-org/paper-tools/commit/c68938dace745762ff321a4351050a213ba8dace) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325243)</sub>

<!-- /greptile_comment -->