### PR TITLE
🧪 Add tests for preCachePaper eviction and patching

### DIFF
--- a/packages/web/src/components/paper/usePaperDetail.test.ts
+++ b/packages/web/src/components/paper/usePaperDetail.test.ts
@@ -144,4 +144,36 @@ describe("preCachePaper", () => {
         expect(result.current.paper?.title).toBe("Updated Title");
         expect(result.current.paper?.year).toBe(2025);
     });
+
+    it("should evict oldest cache entry when exceeding MAX_CACHE_ENTRIES", async () => {
+        vi.resetModules();
+        const { preCachePaper, usePaperDetail } = await import("./usePaperDetail");
+
+        for (let i = 0; i < 101; i++) {
+            preCachePaper({ paperId: `evict-${i}`, title: `Paper ${i}` });
+        }
+
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100))));
+
+        // The first one should be evicted
+        const { result: evictedResult } = renderHook(() => usePaperDetail("evict-0"));
+        expect(evictedResult.current.paper).toBeNull();
+
+        // The last one should still be cached
+        const { result: cachedResult } = renderHook(() => usePaperDetail("evict-100"));
+        expect(cachedResult.current.paper).not.toBeNull();
+    });
+
+    it("should patch influentialCitationCount correctly", async () => {
+        vi.resetModules();
+        const { preCachePaper, usePaperDetail } = await import("./usePaperDetail");
+
+        preCachePaper({ paperId: "patch-1", title: "Test" });
+        preCachePaper({ paperId: "patch-1", influentialCitationCount: 42 });
+
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100))));
+
+        const { result } = renderHook(() => usePaperDetail("patch-1"));
+        expect(result.current.paper?.influentialCitationCount).toBe(42);
+    });
 });


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `MAX_CACHE_ENTRIES` eviction logic and `influentialCitationCount` patching in `usePaperDetail.ts`.
📊 **Coverage:** Covered lines 11-13 (cache eviction) and 63 (influentialCitationCount).
✨ **Result:** Reached 100% test coverage for `usePaperDetail.ts`.

---
*PR created automatically by Jules for task [9352878521949841903](https://jules.google.com/task/9352878521949841903) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

キャッシュの上限超過時の削除処理と、既存キャッシュへの `influentialCitationCount` のパッチ適用を検証するテストを追加しています。
- 101件目の追加時に最古のキャッシュ項目が削除され、最新項目が保持されることを確認
- 同一論文への追加プレビューで `influentialCitationCount` が更新されることを確認
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはテスト追加のみで、具体的な問題は確認されておらず、安全にマージできると考えます。

追加されたアサーションは、削除対象のキャッシュミス、保持対象のキャッシュヒット、およびパッチ後の値をそれぞれ区別して検証しており、本番コードの挙動は変更していません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/components/paper/usePaperDetail.test.ts | `preCachePaper` のFIFO削除境界と既存エントリへの引用数パッチを、分離されたモジュール状態で適切に検証しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add coverage for preCachePaper evi..."](https://github.com/hiroki-org/paper-tools/commit/bfe163bca7eac784b4c2132c629fbe86e5a3e7a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325272)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->