### PR TITLE
🧹 Remove 'as any' type assertion in auth refresh route

### DIFF
--- a/packages/web/src/app/api/auth/refresh/route.ts
+++ b/packages/web/src/app/api/auth/refresh/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
                 { status: tokenRes.status || 401 },
             );
         }
-        const nextRefreshToken = (tokenResponse as any).refresh_token as string | undefined;
+        const nextRefreshToken = tokenResponse.refresh_token;
         if (!nextRefreshToken) {
             return NextResponse.json({ error: "refresh_token missing in response" }, { status: 502 });
         }


### PR DESCRIPTION
🎯 **What:** Removed unnecessary `as any` type assertion in `packages/web/src/app/api/auth/refresh/route.ts`.
💡 **Why:** Using `any` defeats the purpose of TypeScript. `tokenResponse` already includes `refresh_token?: string` in its defined type, so `tokenResponse.refresh_token` works safely.
✅ **Verification:** Verified via `pnpm run test` and `pnpm -r build` (which includes type checking).
✨ **Result:** Improved type safety and codebase maintainability.

---
*PR created automatically by Jules for task [12927204973852847175](https://jules.google.com/task/12927204973852847175) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`tokenResponse` の型に既に定義されている `refresh_token` を直接参照するよう変更し、不要な `any` 型アサーションを削除しています。
- 欠落時の 502 応答を含め、実行時の処理は変更されません。
- 型安全性を改善する限定的なリファクタリングです。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は安全にマージできると判断します。

`refresh_token` は `tokenResponse` のローカル型で optional string として宣言済みであり、直接参照しても型チェックと実行時の欠落チェックは従来どおり機能します。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/refresh/route.ts | ローカル型で宣言済みの `refresh_token` を直接参照する変更であり、既存の成功・欠落時の挙動を維持しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove unnecessary type assert..."](https://github.com/hiroki-org/paper-tools/commit/1ec429f4e7eb74c151da6925aee87034b27119cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325317)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->