### PR TITLE
🧪 Improve extractKeywords test coverage

### DIFF
--- a/packages/drilldown/tests/drilldown.test.ts
+++ b/packages/drilldown/tests/drilldown.test.ts
@@ -56,6 +56,30 @@ describe("extractKeywords", () => {
         expect(keywords).not.toContain("in");
     });
 
+    it("should truncate the returned keywords to the topN value specified", () => {
+        const papers = [
+            {
+                title: "One Two Three Four Five Six",
+                authors: [],
+                keywords: ["Seven Eight Nine Ten"],
+            }
+        ];
+        // topN = 3
+        const keywords = extractKeywords(papers, 3);
+        expect(keywords.length).toBe(3);
+    });
+
+    it("should handle default parameter topN=10 properly", () => {
+        const papers = [
+            {
+                title: "WordOne WordTwo WordThree WordFour WordFive WordSix WordSeven WordEight WordNine WordTen WordEleven WordTwelve",
+                authors: []
+            }
+        ];
+        const keywords = extractKeywords(papers);
+        expect(keywords.length).toBe(10);
+    });
+
     it("should return empty array for empty input", () => {
         const keywords = extractKeywords([], 10);
         expect(keywords).toEqual([]);
@@ -85,6 +109,26 @@ describe("extractKeywords", () => {
 
         const keywords = extractKeywords(papers, 10);
         expect(keywords).toEqual([]);
+    });
+
+
+    it("should extract keywords from keywords array and prioritize frequency", () => {
+        const papers = [
+            {
+                title: "One",
+                authors: [],
+                keywords: ["first-keyword second-keyword"],
+            },
+            {
+                title: "Two",
+                authors: [],
+                keywords: ["first-keyword"],
+            },
+        ];
+
+        const keywords = extractKeywords(papers, 10);
+        expect(keywords[0]).toBe("first-keyword");
+        expect(keywords[1]).toBe("second-keyword");
     });
 });
 


### PR DESCRIPTION
🎯 **What:** Missing tests were added for the `extractKeywords` function inside the `drilldown` package.
📊 **Coverage:** Added test coverage for default parameters (topN=10), explicit topN limitation functionality, and correct prioritization behavior based on keyword token frequency weighting.
✨ **Result:** Enhanced the reliability and coverage of the core drilldown algorithms. Tests verified successfully against pure algorithmic implementations.

---
*PR created automatically by Jules for task [18376632112139947369](https://jules.google.com/task/18376632112139947369) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

extractKeywords の境界動作とキーワード順位に関するテストを追加しています。
- 明示した topN による件数制限を検証
- デフォルトの topN=10 を検証
- keywords 配列内の出現頻度による順位を検証
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる問題はありませんが、追加された順位テストは意図するキーワード重み付けの回帰を検出できません。

実装コードは変更されておらず、追加テストの入力設計に限定された非ブロッキングのカバレッジ不足です。

**Files Needing Attention:** packages/drilldown/tests/drilldown.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/drilldown/tests/drilldown.test.ts | topN の明示値・デフォルト値とキーワード頻度のテストが追加されたが、頻度テストはフィールド間の重み付けを区別できない。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/drilldown/tests/drilldown.test.ts:118-128
**重み付けを区別できないテスト**

有効な比較トークンがすべて `keywords` 由来で、`first-keyword` と `second-keyword` の出現回数だけが異なります。そのため、`keywords` の加算重みを 2 から 1 に変更しても順位とテスト結果は変わらず、タイトル・要約より優先する重み付けの回帰を検出できません。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(drilldown): Add tests for extractKe..."](https://github.com/hiroki-org/paper-tools/commit/007a7be26c7d137960220d5d5dc724a75b993593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325378)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->