### PR TITLE
🧹 docs: add ECONNREFUSED and Hydration mismatch to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1141,7 +1141,13 @@ node --version  # >= 20.0.0 required
 
 ### Web UI Debugging
 
-**"Pages are not being found" in Next.js dev mode**
+**"Pages are not being found" or ECONNREFUSED in Next.js dev mode**
+
+```json
+{
+  "error": "ECONNREFUSED"
+}
+```
 
 ```bash
 # Fix: Ensure server is running
@@ -1151,6 +1157,13 @@ pnpm --filter @paper-tools/web dev
 pnpm --filter @paper-tools/web clean
 rm -rf packages/web/.next
 pnpm --filter @paper-tools/web dev
+```
+
+**Hydration mismatch**
+
+```typescript
+// Issue: Server-rendered HTML doesn't match client HTML
+// Fix: Use next/dynamic with ssr: false for browser-only components
 ```
 
 **API routes returning 500 with vague errors**


### PR DESCRIPTION
🎯 **What:** Updated `.github/copilot-instructions.md` to include debugging tips for `ECONNREFUSED` errors and `Hydration mismatch` in Next.js development mode.
💡 **Why:** To improve debugging instructions for common Next.js issues.
✅ **Verification:** Verified formatting with markdown tools and ran test suite.
✨ **Result:** Better documentation for Copilot.

---
*PR created automatically by Jules for task [11461482869463661446](https://jules.google.com/task/11461482869463661446) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Copilot 向けの Next.js デバッグガイドを拡充しています。
- ECONNREFUSED の例と開発サーバー再起動手順を追加
- Hydration mismatch に対する `next/dynamic` の利用案内を追加
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる問題はありませんが、誤った対処を誘導しないよう二つのデバッグ手順を具体化することを推奨します。

ECONNREFUSED の接続先を区別せず、hydration mismatch の原因を限定しないまま SSR 無効化を案内しているため、Copilot が不要または無効な修正を提案する可能性があります。

**Files Needing Attention:** .github/copilot-instructions.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/copilot-instructions.md | デバッグ項目は追加されていますが、ECONNREFUSED の原因を狭く扱い、hydration mismatch に対して SSR 無効化を一般解として案内しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/copilot-instructions.md:1144
**ECONNREFUSED の原因を限定している**

ECONNREFUSED は API や外部サービスへの接続でも発生しますが、この見出しではページ未検出と同じ問題として扱い、Web 開発サーバーの再起動だけを案内しています。拒否されたホストとポートの確認手順も示さないと、利用者が正常な Web サーバーの再起動やキャッシュ削除を繰り返し、停止している依存サービスを特定できません。

### Issue 2 of 2
.github/copilot-instructions.md:1164
**SSR 無効化を一般解にしている**

Hydration mismatch は時刻、乱数、ロケール、不正な HTML 構造などでも発生しますが、ここでは原因を限定せず `ssr: false` を修正として案内しています。ブラウザー API に依存するコンポーネント向けの手段だと明記しないと、本来の不整合を隠し、SSR、初期 HTML、SEO、初期表示性能を不要に失います。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add ECONNREFUSED and Hydration mis..."](https://github.com/hiroki-org/paper-tools/commit/9b0e891f5dc64e10d34423c184753bd8d4dadf92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325392)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->