### PR TITLE
🧹 Remove 'as any' type assertion in Notion callback

### DIFF
--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
         });
 
         const owner = tokenResponse.owner;
-        const userName = owner.type === "user" ? (owner.user as any)?.name : undefined;
+        const userName = owner.type === "user" && "name" in owner.user ? owner.user.name ?? undefined : undefined;
 
         const response = NextResponse.redirect(new URL("/setup", request.url));
         const refreshToken = (tokenResponse as any).refresh_token as string | undefined;


### PR DESCRIPTION
🎯 **What:** Removed `as any` type assertion when accessing `owner.user.name` in the Notion callback.
💡 **Why:** Using `any` defeats the purpose of TypeScript. By using `"name" in owner.user`, we properly narrow the type and improve maintainability without changing runtime behavior.
✅ **Verification:** Ran `pnpm vitest run src/app/api/auth` and `pnpm tsc --noEmit` to confirm the type fix does not break the code and test coverage passes.
✨ **Result:** Improved type safety and cleaner code.

---
*PR created automatically by Jules for task [13809444300682704745](https://jules.google.com/task/13809444300682704745) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuth コールバックで、ユーザー名取得時の `as any` をプロパティ存在チェックによる型の絞り込みへ置き換えています。
- `owner.type === "user"` の判定を維持しています。
- `name` が存在しない場合は、従来どおり `undefined` として扱います。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は既存の OAuth コールバック動作を維持しており、安全にマージできると判断します。

Notion の user owner では `user` オブジェクトが提供され、変更後も owner 種別と name の存在を確認してから同じ値を認証 Cookie 用情報へ渡すため、具体的な不具合は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/callback/notion/route.ts | Notion の owner ユーザー名取得から `any` を除去し、既存の動作を保ったまま型安全なプロパティ判定へ変更しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(auth): remove &#39;as any&#39; type ass..."](https://github.com/hiroki-org/paper-tools/commit/cf41426f3dbb55352a914cff1b56edcb603fde6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325502)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->