### PR TITLE
🧹 Remove 'as any' type assertion in notion-client.ts

### DIFF
--- a/packages/recommender/src/notion-client.ts
+++ b/packages/recommender/src/notion-client.ts
@@ -208,7 +208,8 @@ export async function createPaperPage(
     const doi = paper.externalIds?.DOI ?? "";
     const fieldsOfStudy = paper.fieldsOfStudy ?? [];
 
-    const notionProperties: Record<string, unknown> = {
+    type PageProperties = Parameters<InstanceType<typeof Client>["pages"]["create"]>[0]["properties"];
+    const notionProperties: PageProperties = {
         "タイトル": {
             title: [{ text: { content: paper.title || "(untitled)" } }],
         },
@@ -249,7 +250,7 @@ export async function createPaperPage(
 
     await client.pages.create({
         parent: { database_id: databaseId },
-        properties: notionProperties as any,
+        properties: notionProperties,
     });
 }
 


### PR DESCRIPTION
🎯 **What:** Removed 'as any' type assertion in notion-client.ts.
💡 **Why:** Using 'any' bypasses TypeScript's type checking. Extracting the proper type directly from the Notion SDK ensures type safety when sending properties.
✅ **Verification:** Ran `pnpm -r build` and `pnpm -r test` to confirm compilation and existing tests pass.
✨ **Result:** Improved maintainability and readability by utilizing strict typing for Notion properties.

---
*PR created automatically by Jules for task [4897848983406068001](https://jules.google.com/task/4897848983406068001) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion ページ作成時のプロパティ型を SDK の `pages.create` 引数から直接抽出し、`as any` 型アサーションを削除する変更です。
- `notionProperties` に Notion SDK が要求する厳密な型を付与
- 実行時のペイロードやページ作成処理は変更なし
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は安全にマージできると考えられます。

型アサーションを SDK 由来の型へ置き換えていますが、TypeScript の型はコンパイル時に消去されるため、Notion に送信されるプロパティや実行時の処理は変わりません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/recommender/src/notion-client.ts | Notion プロパティの型安全性を改善するコンパイル時のみの変更で、具体的な不具合は確認されませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove as any type assertion in n..."](https://github.com/hiroki-org/paper-tools/commit/63a0bf0cbb8171ea30f0d3583dcfff2c5af2b2aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325525)</sub>

**Context used:**

- Knowledge Base — [Recommender package](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/recommender.md)

<!-- /greptile_comment -->