### PR TITLE
🧹 Code Health: Remove 'as any' type assertion in Notion OAuth callback

### DIFF
--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -33,10 +33,10 @@ export async function GET(request: NextRequest) {
         });
 
         const owner = tokenResponse.owner;
-        const userName = owner.type === "user" ? (owner.user as any)?.name : undefined;
+        const userName = owner.type === "user" && "name" in owner.user ? (owner.user as { name?: string | null }).name ?? undefined : undefined;
 
         const response = NextResponse.redirect(new URL("/setup", request.url));
-        const refreshToken = (tokenResponse as any).refresh_token as string | undefined;
+        const refreshToken = (tokenResponse as { refresh_token?: string | null }).refresh_token ?? undefined;
         if (!refreshToken) {
             return NextResponse.redirect(new URL("/login?error=missing_refresh_token", request.url));
         }
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
             userInfo: {
                 name: userName,
                 workspaceName: tokenResponse.workspace_name ?? undefined,
-                workspaceIcon: tokenResponse.workspace_icon,
+                workspaceIcon: tokenResponse.workspace_icon ?? undefined,
             },
             request,
         });


### PR DESCRIPTION
🎯 **What:** Removed 'as any' assertions from Notion OAuth callback.\n💡 **Why:** Using 'any' bypasses TypeScript's type checking, making the code harder to maintain and prone to runtime errors. Safely accessing properties using type narrowing improves reliability.\n✅ **Verification:** Ran test suite to verify OAuth and callback behavior remains intact.\n✨ **Result:** Improved type safety and readability without altering existing functionality.

---
*PR created automatically by Jules for task [5866267111808101153](https://jules.google.com/task/5866267111808101153) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuth コールバックの型安全性を改善する変更です。
- OAuth レスポンスのユーザー名取得から `as any` を除去し、プロパティを型絞り込みして参照
- リフレッシュトークンを nullable なレスポンスとして明示的に正規化
- ワークスペースアイコンの `null` を `undefined` に正規化
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージして問題ないと判断します。

変更は OAuth レスポンスの型絞り込みと nullish 値の正規化に限定され、現行の SDK 契約および認証フローを破壊する具体的な不具合は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/callback/notion/route.ts | Notion OAuth レスポンスの nullable フィールドを安全に正規化し、既存の認証フローを維持しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor Notion OAuth callback to remove..."](https://github.com/hiroki-org/paper-tools/commit/bcb248378865c7cfb9aa056ae72ba5c65200d474) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325685)</sub>

<!-- /greptile_comment -->