### PR TITLE
🧹 fix: add context block to build instructions in copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1009,16 +1009,11 @@ beforeEach(() => {
 const result = await limiter.schedule(async () => {...});
 ```
 
-**"ReferenceError: describe is not defined"**
-
-```bash
-# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
-```
-
 **"Cannot find module .js"**
 
 ```bash
 # Cause: TypeScript test file isn't transpiled
+# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
 # Or: Use tsx loader for Node.js files
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1009,11 +1009,16 @@ beforeEach(() => {
 const result = await limiter.schedule(async () => {...});
 ```
 
+**"ReferenceError: describe is not defined"**
+
+```bash
+# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
+```
+
 **"Cannot find module .js"**
 
 ```bash
 # Cause: TypeScript test file isn't transpiled
-# Fix: Ensure vitest.config.ts has globals: true, environment: "node"
 # Or: Use tsx loader for Node.js files
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1119,11 +1119,22 @@ OPENALEX_MAILTO=your-email@example.com
 
 **Building one package breaks others**
 
+```json
+  {
+    "error": "Property 'getPaper' does not exist on type 'typeof import(\"@paper-tools/core\")'"
+  }
+```
+
 ```bash
 # Cause: Interdependent packages
 # Fix: Build in correct order
 pnpm --filter @paper-tools/core build
+pnpm --filter @paper-tools/author-profiler build
+pnpm --filter @paper-tools/drilldown build
+pnpm --filter @paper-tools/scraper build
 pnpm --filter @paper-tools/recommender build
+pnpm --filter @paper-tools/visualizer build
+pnpm --filter @paper-tools/bibtex build
 pnpm --filter @paper-tools/web build
 
 # Or just:


### PR DESCRIPTION
🎯 **What:** Added the error context block and completed the build order in the "Build in correct order" instruction in `.github/copilot-instructions.md`.
💡 **Why:** To match the provided context, make it clear what error this fix resolves, and provide the complete actual package dependency order for building.
✅ **Verification:** Verified by checking the file contents with sed and running tests.
✨ **Result:** The documentation now accurately reflects the required error context and complete build order.

---
*PR created automatically by Jules for task [14393258341682683385](https://jules.google.com/task/14393258341682683385) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ビルド手順の説明を補完するドキュメントのみの変更です。
- `getPaper` の型エラー例をコンテキストとして追加
- モノレポ各パッケージの完全なビルド順序を追記
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

ブロッキングとなる問題は残っていません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/copilot-instructions.md | エラー例とパッケージのビルド順序を追加して、トラブルシューティング手順を明確化しています。 |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: preserve distinct test troubleshoo..."](https://github.com/hiroki-org/paper-tools/commit/74c505d6abdae0e1ffda7e6f04e1b44ed7b08535) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47325750)</sub>

<!-- /greptile_comment -->