### PR TITLE
🧹 [code health] Remove 'as any' type assertion in Notion OAuth callback

### DIFF
--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -33,10 +33,10 @@ export async function GET(request: NextRequest) {
         });
 
         const owner = tokenResponse.owner;
-        const userName = owner.type === "user" ? (owner.user as any)?.name : undefined;
+        const userName = owner.type === "user" && "name" in owner.user ? (owner.user.name ?? undefined) : undefined;
 
         const response = NextResponse.redirect(new URL("/setup", request.url));
-        const refreshToken = (tokenResponse as any).refresh_token as string | undefined;
+        const refreshToken = ("refresh_token" in tokenResponse ? (tokenResponse as { refresh_token?: string }).refresh_token : undefined);
         if (!refreshToken) {
             return NextResponse.redirect(new URL("/login?error=missing_refresh_token", request.url));
         }


### PR DESCRIPTION
🎯 **What:** Replaced `as any` type assertions in `packages/web/src/app/api/auth/callback/notion/route.ts` with proper type narrowing using the `in` operator.
💡 **Why:** Using explicit types and type narrowing improves type safety, avoids circumventing the compiler, and increases maintainability.
✅ **Verification:** Verified via `tsc --noEmit` on the file and running tests across the workspace.
✨ **Result:** The code is safer, more readable, and correctly typed without relying on `any`.

---
*PR created automatically by Jules for task [15552474572516676931](https://jules.google.com/task/15552474572516676931) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuth コールバックの型安全性を改善する変更です。
- `owner.user.name` を `in` 演算子で絞り込むよう変更
- `refresh_token` の存在確認と明示的な型付けにより `as any` を除去
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージを妨げる具体的な問題は確認されず、安全にマージできると考えられます。

OAuth コールバックの制御フロー、更新トークン欠落時の処理、Cookie 設定の挙動を変えずに型の絞り込みを明示しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/callback/notion/route.ts | Notion OAuth レスポンスの既存処理を維持しながら、ユーザー名と更新トークンの取得から `as any` を除去しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: eliminate &#39;as any&#39; in Notion O..."](https://github.com/hiroki-org/paper-tools/commit/3aa21b16ac04535ad52db549b325e0bea7789897) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47326233)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->