### PR TITLE
🧹 Refactor Notion auth callback to remove 'any' type assertions

### DIFF
--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -33,10 +33,10 @@ export async function GET(request: NextRequest) {
         });
 
         const owner = tokenResponse.owner;
-        const userName = owner.type === "user" ? (owner.user as any)?.name : undefined;
+        const userName = owner.type === "user" && owner.user && typeof owner.user === 'object' && 'name' in owner.user ? (owner.user.name as string | undefined) ?? undefined : undefined;
 
         const response = NextResponse.redirect(new URL("/setup", request.url));
-        const refreshToken = (tokenResponse as any).refresh_token as string | undefined;
+        const refreshToken = 'refresh_token' in tokenResponse ? (tokenResponse.refresh_token as string) : undefined;
         if (!refreshToken) {
             return NextResponse.redirect(new URL("/login?error=missing_refresh_token", request.url));
         }


### PR DESCRIPTION
🎯 **What:** Removed `as any` type assertions from the Notion OAuth callback route.
💡 **Why:** Using `any` defeats TypeScript's type safety. Safely narrowing the type with truthiness, object check, and `in` operator avoids crashes and properly narrows types.
✅ **Verification:** Verified by ensuring the Next.js build passes without type errors and the test suite passes.
✨ **Result:** Improved maintainability, readability, and type safety of the Notion OAuth callback logic.

---
*PR created automatically by Jules for task [16417852756660120566](https://jules.google.com/task/16417852756660120566) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuth コールバックの型安全性を改善するリファクタリングです。
- `owner.user.name` をオブジェクトおよびプロパティの存在確認後に取得するよう変更
- `refresh_token` をプロパティの存在確認後に取得するよう変更
- OAuth の分岐、Cookie 設定、エラー処理の動作は維持
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージして問題ないと判断します。

Notion OAuth 応答からのユーザー名とリフレッシュトークンの取得方法だけが型安全な絞り込みへ変更され、既存の欠損値チェック、Cookie 設定、リダイレクト動作は維持されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/callback/notion/route.ts | `any` の型アサーションを安全なプロパティ絞り込みに置き換えており、既存の OAuth コールバック動作を損なう問題は確認されませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor Notion auth callback to safely ..."](https://github.com/hiroki-org/paper-tools/commit/5d2a9877e0d1d9ce02c7c2c3f02e162cdd418fa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47326458)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->