### PR TITLE
🧪 Add tests for searchConferencePapers in dblp-integration

### DIFF
--- a/packages/scraper/tests/dblp-integration.test.ts
+++ b/packages/scraper/tests/dblp-integration.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the imported module BEFORE importing the file under test
+vi.mock("@paper-tools/core", () => ({
+	searchVenuePublications: vi.fn(),
+}));
+
+const { searchConferencePapers } = await import("../src/dblp-integration.js");
+const { searchVenuePublications } = await import("@paper-tools/core");
+
+describe("searchConferencePapers", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should call searchVenuePublications with correct arguments and return its result", async () => {
+		const mockPapers = [{ title: "Test Paper", authors: [] }];
+		vi.mocked(searchVenuePublications).mockResolvedValueOnce(
+			mockPapers as unknown as ReturnType<typeof searchVenuePublications>,
+		);
+
+		const result = await searchConferencePapers("ICSE", 2026, 50);
+
+		expect(searchVenuePublications).toHaveBeenCalledWith("ICSE", 2026, 50);
+		expect(searchVenuePublications).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(mockPapers);
+	});
+
+	it("should use default maxResults of 100 if not provided", async () => {
+		vi.mocked(searchVenuePublications).mockResolvedValueOnce([]);
+
+		await searchConferencePapers("ICSE", 2026);
+
+		expect(searchVenuePublications).toHaveBeenCalledWith("ICSE", 2026, 100);
+	});
+
+	it("should handle undefined year", async () => {
+		vi.mocked(searchVenuePublications).mockResolvedValueOnce([]);
+
+		await searchConferencePapers("ICSE");
+
+		expect(searchVenuePublications).toHaveBeenCalledWith(
+			"ICSE",
+			undefined,
+			100,
+		);
+	});
+});


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the untested public API `searchConferencePapers` in `packages/scraper/src/dblp-integration.ts`.

📊 **Coverage:** 
- Tested that the function correctly calls `searchVenuePublications` with the provided arguments (`venueName`, `year`, `maxResults`).
- Tested the default fallback value for `maxResults` (100).
- Tested the case where `year` is undefined.

✨ **Result:** 
The previously untested function is now fully covered, ensuring any future refactoring of `searchVenuePublications` or its integration will be verified. All tests pass successfully, and no regressions were introduced.

---
*PR created automatically by Jules for task [717692996946069226](https://jules.google.com/task/717692996946069226) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`searchConferencePapers` が引数とデフォルト値を `searchVenuePublications` に正しく転送することを検証する単体テストを追加しています。
- 明示した `venueName`、`year`、`maxResults` と戻り値を検証
- `maxResults` の既定値 100 を検証
- `year` が未指定の場合の転送内容を検証
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる問題はありませんが、モック値の二重キャストは削除して型検査を維持することを推奨します。

追加テストは実行時には意図どおり引数転送を検証しますが、`ReturnType` への強制キャストによって将来の戻り値型変更や不正なモック形状を検出できません。

**Files Needing Attention:** packages/scraper/tests/dblp-integration.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/scraper/tests/dblp-integration.test.ts | 公開ラッパーの主要な転送ケースを網羅していますが、最初のモック値に誤った二重型キャストがあり、テストデータの型安全性を失っています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/scraper/tests/dblp-integration.test.ts:19
**モック値の型検査を維持する**

`ReturnType<typeof searchVenuePublications>` は `Promise<Paper[]>` ですが、`mockResolvedValueOnce` が受け取るのは解決値の `Paper[]` です。この二重キャストは不正なモックデータも許容し、戻り値契約の変更をテスト時に検出できなくするため、配列を直接渡してください。

```suggestion
			mockPapers,
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for searchConferencePape..."](https://github.com/hiroki-org/paper-tools/commit/6a84fb7d2daeb345924ee4f3dc0347ec2b110b32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582522)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Scraper package](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/scraper.md)

<!-- /greptile_comment -->