### PR TITLE
🔒 Sanitize Notion OAuth callback error message

### DIFF
--- a/packages/web/src/app/api/auth/callback/notion/route.ts
+++ b/packages/web/src/app/api/auth/callback/notion/route.ts
@@ -60,7 +60,7 @@ export async function GET(request: NextRequest) {
         });
         return response;
     } catch (error) {
-        const message = error instanceof Error ? error.message : "OAuth callback failed";
-        return NextResponse.redirect(new URL(`/login?error=${encodeURIComponent(message)}`, request.url));
+        console.error("Notion OAuth callback error:", error);
+        return NextResponse.redirect(new URL("/login?error=oauth_callback_failed", request.url));
     }
 }


### PR DESCRIPTION
🎯 **What:** The Notion OAuth callback was directly reflecting the internal error message in the URL query parameter.
⚠️ **Risk:** By reflecting unescaped internal error objects, an attacker could potentially expose internal application state or mount Reflected Cross-Site Scripting (XSS) attacks through malicious input forcing specific errors.
🛡️ **Solution:** Replaced the reflected error message with a generic error code (`oauth_callback_failed`) and added internal logging for the original error.

---
*PR created automatically by Jules for task [12136993793543667893](https://jules.google.com/task/12136993793543667893) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Notion OAuthコールバックで捕捉した内部エラーメッセージをURLへ反映せず、固定エラーコードへ置き換える変更です。
- 元の例外はサーバー側でログへ記録されます。
- ブラウザーには`oauth_callback_failed`のみが返され、内部情報のURL露出を防ぎます。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして問題ないと考えられ、変更によって生じる具体的な不具合は確認できませんでした。

OAuthコールバックの成功処理は変更されず、失敗時に外部へ返す値だけが固定されており、ログイン画面もerrorクエリの具体的な内容へ依存していません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/callback/notion/route.ts | OAuth失敗時のリダイレクトを固定エラーコードへ変更しており、確認できた既存フローとの非互換や具体的な障害はありません。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): sanitize Notion OAuth callback..."](https://github.com/hiroki-org/paper-tools/commit/89f2577dd143dd6d5f7c4ee2eecd704c197fccc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582650)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->