### PR TITLE
🧪 Test fetchWithRetry delay logic on 429

### DIFF
--- a/packages/core/tests/rate-limiter.test.ts
+++ b/packages/core/tests/rate-limiter.test.ts
@@ -81,6 +81,38 @@ describe("fetchWithRetry", () => {
         expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
+
+    it("delays baseDelayMs * 2^attempt before retrying a 429 error", async () => {
+        vi.useFakeTimers();
+        const response429 = new Response("slow down", {
+            status: 429,
+            statusText: "Too Many Requests",
+        });
+        const responseOk = new Response("ok", {
+            status: 200,
+            statusText: "OK",
+        });
+        const fetchMock = vi.mocked(globalThis.fetch);
+        fetchMock
+            .mockResolvedValueOnce(response429)
+            .mockResolvedValueOnce(responseOk);
+
+        const promise = fetchWithRetry("https://example.com", {}, 2, 1000);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(998);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(2);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        const result = await promise;
+        expect(result).toBe(responseOk);
+        vi.useRealTimers();
+    });
+
     it("returns successful response immediately", async () => {
         const response = new Response("ok", {
             status: 200,


### PR DESCRIPTION
🎯 **What:** Added a missing test case for fetchWithRetry delay logic when handling 429 responses.
📊 **Coverage:** Covered the retry delay path for 429 responses with exponential backoff and fake timers.
✨ **Result:** Enhanced test suite reliability.

---
*PR created automatically by Jules for task [16957324553904651473](https://jules.google.com/task/16957324553904651473) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

429 応答後に指数バックオフの遅延を挟んで再試行することを、fake timers で検証するテストを追加しています。
- 1,000 ms より前には再試行されないことを確認
- 遅延経過後に2回目の fetch が実行され、成功レスポンスが返ることを確認
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

PR はマージ可能ですが、テスト失敗時にも fake timers を確実に復元する非ブロッキングな改善が望まれます。

追加された検証自体は 429 の遅延動作を適切に対象としていますが、途中で失敗すると末尾のタイマー復元処理が実行されず、後続のリトライテストがタイムアウトする可能性があります。

**Files Needing Attention:** packages/core/tests/rate-limiter.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/tests/rate-limiter.test.ts | 429 のバックオフ時間を検証するテストを追加しているが、テスト失敗時に fake timers が後続テストへ漏れる可能性がある。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/core/tests/rate-limiter.test.ts:86
**fake timer の復元漏れ**

途中のタイミング検証が失敗したり Promise が reject したりすると、末尾の `vi.useRealTimers()` が実行されません。その結果、fake timers が後続の 5xx リトライテストへ漏れ、リトライ用のタイマーが進まずタイムアウトするため、`afterEach` など失敗時にも実行される箇所で復元してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add delay test for 429 retry in fe..."](https://github.com/hiroki-org/paper-tools/commit/aa8921e2b4a4a1e20dcf02c8699636dce5552e3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582696)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [packages/core](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/core.md)

<!-- /greptile_comment -->