### PR TITLE
🧪 Add missing edge case test for buildTopicTimelineFromPapers

### DIFF
--- a/packages/author-profiler/src/tests/profile-builder.test.ts
+++ b/packages/author-profiler/src/tests/profile-builder.test.ts
@@ -83,4 +83,19 @@ describe("profile-builder helpers", () => {
         expect(timeline[1]?.year).toBe(2023);
         expect(timeline[1]?.topics[0]).toEqual({ name: "Systems", score: 1 });
     });
+
+    it("buildTopicTimelineFromPapers ignores papers with missing year or fieldsOfStudy", () => {
+        const timeline = buildTopicTimelineFromPapers([
+            { paperId: "p1", title: "A", year: undefined, fieldsOfStudy: ["ML"] },
+            { paperId: "p2", title: "B", year: 2022, fieldsOfStudy: null },
+            { paperId: "p3", title: "C", year: null, fieldsOfStudy: ["ML"] },
+            { paperId: "p4", title: "D", year: 2022, fieldsOfStudy: ["ML"] },
+            { paperId: "p5", title: "E", year: 2023 }
+        ] as any);
+
+        expect(timeline).toHaveLength(1);
+        expect(timeline[0]?.year).toBe(2022);
+        expect(timeline[0]?.topics).toHaveLength(1);
+        expect(timeline[0]?.topics[0]).toEqual({ name: "ML", score: 1 });
+    });
 });


### PR DESCRIPTION
🎯 **What:** Added edge case test for buildTopicTimelineFromPapers to handle missing year or fieldsOfStudy.
📊 **Coverage:** Covered missing/undefined/null years and fieldsOfStudy inputs.
✨ **Result:** Improved test reliability and ensured graceful handling of unexpected input formats.

---
*PR created automatically by Jules for task [8360832172364648380](https://jules.google.com/task/8360832172364648380) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、`buildTopicTimelineFromPapers` が年または研究分野を欠く論文を無視することを確認するエッジケーステストを追加します。
- `undefined` および `null` の年を検証
- `undefined` および `null` の `fieldsOfStudy` を検証
- 有効な論文だけが年別トピック分布に反映されることを確認
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

追加テストは既存実装の欠損値処理と一致しており、安全にマージできると判断します。

有効な2022年の論文だけが集計されるという期待値は、年が欠損している論文または `fieldsOfStudy` が配列でない論文を除外する実装と一致しており、ビルドや実行を壊す変更もありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/author-profiler/src/tests/profile-builder.test.ts | 欠損した年・研究分野を含む入力の回帰テストを追加しており、期待値は現在の実装挙動と整合しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add missing edge case test for buildT..."](https://github.com/hiroki-org/paper-tools/commit/796b6f40d7416ab925de215b50a806cd2396e158) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582828)</sub>

<!-- /greptile_comment -->