### PR TITLE
🔒 Fix exposure of internal errors in Archive API

### DIFF
--- a/packages/web/src/app/api/archive/route.test.ts
+++ b/packages/web/src/app/api/archive/route.test.ts
@@ -131,7 +131,7 @@ describe("/api/archive", () => {
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Notion API Error");
+            expect(data.error).toBe("Internal Server Error");
         });
 
         it("returns 500 on non-Error error", async () => {
@@ -140,7 +140,7 @@ describe("/api/archive", () => {
             const res = await GET(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Unknown error");
+            expect(data.error).toBe("Internal Server Error");
         });
     });
 
@@ -250,7 +250,7 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Create Error");
+            expect(data.error).toBe("Internal Server Error");
         });
 
         it("returns 500 on non-Error error in POST", async () => {
@@ -262,7 +262,7 @@ describe("/api/archive", () => {
             const res = await POST(req);
             expect(res.status).toBe(500);
             const data = await res.json();
-            expect(data.error).toBe("Unknown error");
+            expect(data.error).toBe("Internal Server Error");
         });
     });
 });

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -107,8 +107,8 @@ export async function GET(request: NextRequest) {
             },
         });
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
+        console.error("[Archive API]", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
     }
 }
 
@@ -182,7 +182,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json({ success: true });
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
+        console.error("[Archive API]", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
     }
 }


### PR DESCRIPTION
🎯 **What:** Modified the Archive API (GET and POST routes) to log internal errors to the console instead of returning the raw error message to the client in a 500 response.
⚠️ **Risk:** Leaking raw error messages in HTTP responses could expose internal system details, stack traces, or sensitive configuration, which could be leveraged by an attacker to craft further exploits.
🛡️ **Solution:** The catch blocks now return a generic "Internal Server Error" string to the client while preserving the actual error object in `console.error` logs for internal debugging. Tests were also updated to expect this generic error string.

---
*PR created automatically by Jules for task [121259911535362029](https://jules.google.com/task/121259911535362029) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Archive API の GET・POST において、内部例外の内容をクライアントへ返さず、サーバーログへ記録して固定の 500 エラーを返す変更です。
- GET と POST の catch ブロックで内部エラーの直接返却を廃止
- クライアント向けエラーを `Internal Server Error` に統一
- エラー応答のテスト期待値を新しい契約に更新
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR はマージして問題ないと考えられ、具体的かつ対応可能な不具合は確認されませんでした。

Archive API のエラー応答は意図どおり固定化され、現在の呼び出し元は例外固有のメッセージに依存しておらず、GET・POST の関連テストも新しい応答契約を検証しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/archive/route.ts | GET・POST の内部例外をサーバー側で記録し、クライアントには固定の 500 エラーを返すよう変更されており、具体的な不具合は確認されなかった。 |
| packages/web/src/app/api/archive/route.test.ts | Error と非 Error の両方について、GET・POST が固定エラーメッセージを返す新しい契約へ期待値を更新している。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hide internal errors in archive api"](https://github.com/hiroki-org/paper-tools/commit/bd50c138b8c31964d1bebc0320edc29c19966550) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582844)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->