### PR TITLE
🔒 Fix Information Exposure in Archive API

### DIFF
--- a/packages/web/src/app/api/archive/route.test.ts
+++ b/packages/web/src/app/api/archive/route.test.ts
@@ -1,15 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth", () => ({
-    getAccessToken: vi.fn(),
-    getSelectedDatabaseId: vi.fn(),
-    getUserInfo: vi.fn(),
-    getNotionClient: vi.fn(),
+	getAccessToken: vi.fn(),
+	getSelectedDatabaseId: vi.fn(),
+	getUserInfo: vi.fn(),
+	getNotionClient: vi.fn(),
 }));
 
 vi.mock("@/lib/notion-data-source", () => ({
-    resolveNotionDataSource: vi.fn(),
+	resolveNotionDataSource: vi.fn(),
 }));
 
 const auth = await import("@/lib/auth");
@@ -17,252 +17,267 @@ const notionDataSource = await import("@/lib/notion-data-source");
 const { GET, POST } = await import("./route");
 
 describe("/api/archive", () => {
-    let mockQuery: ReturnType<typeof vi.fn>;
-    let mockCreate: ReturnType<typeof vi.fn>;
+	let mockQuery: ReturnType<typeof vi.fn>;
+	let mockCreate: ReturnType<typeof vi.fn>;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
+	beforeEach(() => {
+		vi.clearAllMocks();
 
-        mockQuery = vi.fn().mockResolvedValue({ results: [] });
-        mockCreate = vi.fn().mockResolvedValue({});
+		mockQuery = vi.fn().mockResolvedValue({ results: [] });
+		mockCreate = vi.fn().mockResolvedValue({});
 
-        vi.mocked(auth.getAccessToken).mockReturnValue("fake-token");
-        vi.mocked(auth.getSelectedDatabaseId).mockReturnValue("fake-db-id");
-        vi.mocked(auth.getUserInfo).mockReturnValue({ workspaceName: "Fake Workspace" });
-        vi.mocked(auth.getNotionClient).mockReturnValue({
-            dataSources: { query: mockQuery },
-            pages: { create: mockCreate },
-        } as unknown as ReturnType<typeof auth.getNotionClient>);
+		vi.mocked(auth.getAccessToken).mockReturnValue("fake-token");
+		vi.mocked(auth.getSelectedDatabaseId).mockReturnValue("fake-db-id");
+		vi.mocked(auth.getUserInfo).mockReturnValue({
+			workspaceName: "Fake Workspace",
+		});
+		vi.mocked(auth.getNotionClient).mockReturnValue({
+			dataSources: { query: mockQuery },
+			pages: { create: mockCreate },
+		} as unknown as ReturnType<typeof auth.getNotionClient>);
 
-        vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValue({
-            object: "data_source",
-            id: "fake-ds-id",
-            title: [{ plain_text: "Fake Database" }],
-            properties: {
-                "Name": { type: "title", title: {} },
-                "DOI": { type: "rich_text", rich_text: {} },
-                "Semantic Scholar": { type: "rich_text", rich_text: {} },
-            },
-        });
-    });
+		vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValue({
+			object: "data_source",
+			id: "fake-ds-id",
+			title: [{ plain_text: "Fake Database" }],
+			properties: {
+				Name: { type: "title", title: {} },
+				DOI: { type: "rich_text", rich_text: {} },
+				"Semantic Scholar": { type: "rich_text", rich_text: {} },
+			},
+		});
+	});
 
-    describe("GET", () => {
-        it("returns 401 if access token is missing", async () => {
-            vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(401);
-            const data = await res.json();
-            expect(data.error).toBe("Not authenticated");
-        });
+	describe("GET", () => {
+		it("returns 401 if access token is missing", async () => {
+			vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(401);
+			const data = await res.json();
+			expect(data.error).toBe("Not authenticated");
+		});
 
-        it("returns 400 if database id is missing", async () => {
-            vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toBe("Database is not selected");
-        });
+		it("returns 400 if database id is missing", async () => {
+			vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(400);
+			const data = await res.json();
+			expect(data.error).toBe("Database is not selected");
+		});
 
-        it("returns empty records if no pages found", async () => {
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(200);
-            const data = await res.json();
-            expect(data.records).toHaveLength(0);
-            expect(data.total).toBe(0);
-            expect(data.database).toEqual({
-                databaseId: "fake-ds-id",
-                databaseName: "Fake Database",
-                workspaceName: "Fake Workspace",
-            });
-            expect(mockQuery).toHaveBeenCalledWith({ data_source_id: "fake-ds-id", page_size: 100 });
-        });
+		it("returns empty records if no pages found", async () => {
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data.records).toHaveLength(0);
+			expect(data.total).toBe(0);
+			expect(data.database).toEqual({
+				databaseId: "fake-ds-id",
+				databaseName: "Fake Database",
+				workspaceName: "Fake Workspace",
+			});
+			expect(mockQuery).toHaveBeenCalledWith({
+				data_source_id: "fake-ds-id",
+				page_size: 100,
+			});
+		});
 
-        it("maps page records correctly", async () => {
-            mockQuery.mockResolvedValueOnce({
-                results: [
-                    {
-                        object: "page",
-                        id: "page-1",
-                        properties: {
-                            "Name": { type: "title", title: [{ plain_text: "Test Paper" }] },
-                            "DOI": { type: "rich_text", rich_text: [{ plain_text: "10.1234/test" }] },
-                            "Semantic Scholar": { type: "rich_text", rich_text: [{ plain_text: "s2-123" }] },
-                        },
-                    },
-                    {
-                        object: "page",
-                        id: "page-2",
-                        properties: {
-                            "Name": { type: "title", title: [] }, // untitled
-                        },
-                    },
-                    {
-                        object: "not-a-page",
-                        id: "page-3",
-                    }
-                ],
-            });
+		it("maps page records correctly", async () => {
+			mockQuery.mockResolvedValueOnce({
+				results: [
+					{
+						object: "page",
+						id: "page-1",
+						properties: {
+							Name: { type: "title", title: [{ plain_text: "Test Paper" }] },
+							DOI: {
+								type: "rich_text",
+								rich_text: [{ plain_text: "10.1234/test" }],
+							},
+							"Semantic Scholar": {
+								type: "rich_text",
+								rich_text: [{ plain_text: "s2-123" }],
+							},
+						},
+					},
+					{
+						object: "page",
+						id: "page-2",
+						properties: {
+							Name: { type: "title", title: [] }, // untitled
+						},
+					},
+					{
+						object: "not-a-page",
+						id: "page-3",
+					},
+				],
+			});
 
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(200);
-            const data = await res.json();
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(200);
+			const data = await res.json();
 
-            expect(data.records).toHaveLength(2); // filters out not-a-page
-            expect(data.records[0]).toEqual({
-                pageId: "page-1",
-                title: "Test Paper",
-                doi: "10.1234/test",
-                semanticScholarId: "s2-123",
-            });
-            expect(data.records[1]).toEqual({
-                pageId: "page-2",
-                title: "(untitled)",
-            });
-            expect(data.total).toBe(2);
-        });
+			expect(data.records).toHaveLength(2); // filters out not-a-page
+			expect(data.records[0]).toEqual({
+				pageId: "page-1",
+				title: "Test Paper",
+				doi: "10.1234/test",
+				semanticScholarId: "s2-123",
+			});
+			expect(data.records[1]).toEqual({
+				pageId: "page-2",
+				title: "(untitled)",
+			});
+			expect(data.total).toBe(2);
+		});
 
-        it("returns 500 on error", async () => {
-            mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Notion API Error");
-        });
+		it("returns 500 on error", async () => {
+			mockQuery.mockRejectedValueOnce(new Error("Notion API Error"));
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Internal server error");
+		});
 
-        it("returns 500 on non-Error error", async () => {
-            mockQuery.mockRejectedValueOnce("Unknown Error String");
-            const req = new NextRequest("http://localhost/api/archive");
-            const res = await GET(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Unknown error");
-        });
-    });
+		it("returns 500 on non-Error error", async () => {
+			mockQuery.mockRejectedValueOnce("Unknown Error String");
+			const req = new NextRequest("http://localhost/api/archive");
+			const res = await GET(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Internal server error");
+		});
+	});
 
-    describe("POST", () => {
-        const mockPaper = {
-            paperId: "s2-456",
-            title: "New Test Paper",
-            externalIds: { DOI: "10.5678/new" },
-        };
+	describe("POST", () => {
+		const mockPaper = {
+			paperId: "s2-456",
+			title: "New Test Paper",
+			externalIds: { DOI: "10.5678/new" },
+		};
 
-        it("returns 401 if access token is missing", async () => {
-            vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(401);
-        });
+		it("returns 401 if access token is missing", async () => {
+			vi.mocked(auth.getAccessToken).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(401);
+		});
 
-        it("returns 400 if database id is missing", async () => {
-            vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(400);
-        });
+		it("returns 400 if database id is missing", async () => {
+			vi.mocked(auth.getSelectedDatabaseId).mockReturnValueOnce(null);
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(400);
+		});
 
-        it("returns 400 if paper is missing from body", async () => {
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({}),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toBe("paper is required");
-        });
+		it("returns 400 if paper is missing from body", async () => {
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(400);
+			const data = await res.json();
+			expect(data.error).toBe("paper is required");
+		});
 
-        it("creates a page in notion successfully", async () => {
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(200);
-            const data = await res.json();
-            expect(data.success).toBe(true);
+		it("creates a page in notion successfully", async () => {
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data.success).toBe(true);
 
-            expect(mockCreate).toHaveBeenCalledWith({
-                parent: { data_source_id: "fake-ds-id" },
-                properties: {
-                    "Name": { title: [{ text: { content: "New Test Paper" } }] },
-                    "DOI": { rich_text: [{ text: { content: "10.5678/new" } }] },
-                    "Semantic Scholar": { rich_text: [{ text: { content: "s2-456" } }] },
-                },
-            });
-        });
+			expect(mockCreate).toHaveBeenCalledWith({
+				parent: { data_source_id: "fake-ds-id" },
+				properties: {
+					Name: { title: [{ text: { content: "New Test Paper" } }] },
+					DOI: { rich_text: [{ text: { content: "10.5678/new" } }] },
+					"Semantic Scholar": { rich_text: [{ text: { content: "s2-456" } }] },
+				},
+			});
+		});
 
-        it("handles url type for DOI", async () => {
-             vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValueOnce({
-                object: "data_source",
-                id: "fake-ds-id",
-                properties: {
-                    "Name": { type: "title", title: {} },
-                    "DOI": { type: "url", url: "" },
-                },
-            });
+		it("handles url type for DOI", async () => {
+			vi.mocked(notionDataSource.resolveNotionDataSource).mockResolvedValueOnce(
+				{
+					object: "data_source",
+					id: "fake-ds-id",
+					properties: {
+						Name: { type: "title", title: {} },
+						DOI: { type: "url", url: "" },
+					},
+				},
+			);
 
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            await POST(req);
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			await POST(req);
 
-            expect(mockCreate).toHaveBeenCalledWith({
-                parent: { data_source_id: "fake-ds-id" },
-                properties: {
-                    "Name": { title: [{ text: { content: "New Test Paper" } }] },
-                    "DOI": { url: "https://doi.org/10.5678/new" },
-                },
-            });
-        });
+			expect(mockCreate).toHaveBeenCalledWith({
+				parent: { data_source_id: "fake-ds-id" },
+				properties: {
+					Name: { title: [{ text: { content: "New Test Paper" } }] },
+					DOI: { url: "https://doi.org/10.5678/new" },
+				},
+			});
+		});
 
-        it("handles missing title in paper gracefully", async () => {
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: { paperId: "123" } }),
-            });
-            await POST(req);
+		it("handles missing title in paper gracefully", async () => {
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: { paperId: "123" } }),
+			});
+			await POST(req);
 
-            expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
-                properties: expect.objectContaining({
-                    "Name": { title: [{ text: { content: "Untitled" } }] },
-                }),
-            }));
-        });
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					properties: expect.objectContaining({
+						Name: { title: [{ text: { content: "Untitled" } }] },
+					}),
+				}),
+			);
+		});
 
-        it("returns 500 on error", async () => {
-            mockCreate.mockRejectedValueOnce(new Error("Create Error"));
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Create Error");
-        });
+		it("returns 500 on error", async () => {
+			mockCreate.mockRejectedValueOnce(new Error("Create Error"));
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Internal server error");
+		});
 
-        it("returns 500 on non-Error error in POST", async () => {
-            mockCreate.mockRejectedValueOnce("Unknown Create Error");
-            const req = new NextRequest("http://localhost/api/archive", {
-                method: "POST",
-                body: JSON.stringify({ paper: mockPaper }),
-            });
-            const res = await POST(req);
-            expect(res.status).toBe(500);
-            const data = await res.json();
-            expect(data.error).toBe("Unknown error");
-        });
-    });
+		it("returns 500 on non-Error error in POST", async () => {
+			mockCreate.mockRejectedValueOnce("Unknown Create Error");
+			const req = new NextRequest("http://localhost/api/archive", {
+				method: "POST",
+				body: JSON.stringify({ paper: mockPaper }),
+			});
+			const res = await POST(req);
+			expect(res.status).toBe(500);
+			const data = await res.json();
+			expect(data.error).toBe("Internal server error");
+		});
+	});
 });

--- a/packages/web/src/app/api/archive/route.ts
+++ b/packages/web/src/app/api/archive/route.ts
@@ -1,188 +1,226 @@
-import { NextRequest, NextResponse } from "next/server";
 import type { S2Paper } from "@paper-tools/core";
-import { getAccessToken, getNotionClient, getSelectedDatabaseId, getUserInfo } from "@/lib/auth";
-import { resolveNotionDataSource, type NotionDataSource } from "@/lib/notion-data-source";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	getAccessToken,
+	getNotionClient,
+	getSelectedDatabaseId,
+	getUserInfo,
+} from "@/lib/auth";
+import {
+	type NotionDataSource,
+	resolveNotionDataSource,
+} from "@/lib/notion-data-source";
 
 type NotionProperty = {
-    type?: string;
-    title?: Array<{ plain_text?: string }>;
-    rich_text?: Array<{ plain_text?: string }>;
-    url?: string | null;
-    multi_select?: Array<{ name?: string }>;
+	type?: string;
+	title?: Array<{ plain_text?: string }>;
+	rich_text?: Array<{ plain_text?: string }>;
+	url?: string | null;
+	multi_select?: Array<{ name?: string }>;
 };
 
 type ArchiveNotionDataSource = NotionDataSource<NotionProperty>;
 
 type NotionClient = ReturnType<typeof getNotionClient>;
-type NotionPageCreateProperties = Parameters<NotionClient["pages"]["create"]>[0]["properties"];
+type NotionPageCreateProperties = Parameters<
+	NotionClient["pages"]["create"]
+>[0]["properties"];
 
 function getPlainText(items: Array<{ plain_text?: string }> | undefined) {
-    return (items ?? []).map((item) => item.plain_text ?? "").join("").trim();
+	return (items ?? [])
+		.map((item) => item.plain_text ?? "")
+		.join("")
+		.trim();
 }
 
 function findTitleProperty(properties: Record<string, NotionProperty>) {
-    const entry = Object.entries(properties).find(([, prop]) => prop.type === "title");
-    return entry?.[0] ?? "Name";
+	const entry = Object.entries(properties).find(
+		([, prop]) => prop.type === "title",
+	);
+	return entry?.[0] ?? "Name";
 }
 
-function findPropertyByKeyword(properties: Record<string, NotionProperty>, keyword: string) {
-    const lower = keyword.toLowerCase();
-    let partialMatch: string | null = null;
+function findPropertyByKeyword(
+	properties: Record<string, NotionProperty>,
+	keyword: string,
+) {
+	const lower = keyword.toLowerCase();
+	let partialMatch: string | null = null;
 
-    for (const name of Object.keys(properties)) {
-        const nameLower = name.toLowerCase();
-        if (nameLower === lower) {
-            return name;
-        }
-        if (!partialMatch && nameLower.includes(lower)) {
-            partialMatch = name;
-        }
-    }
+	for (const name of Object.keys(properties)) {
+		const nameLower = name.toLowerCase();
+		if (nameLower === lower) {
+			return name;
+		}
+		if (!partialMatch && nameLower.includes(lower)) {
+			partialMatch = name;
+		}
+	}
 
-    return partialMatch;
+	return partialMatch;
 }
 
 function mapPageRecord(page: {
-    id: string;
-    properties: Record<string, NotionProperty>;
+	id: string;
+	properties: Record<string, NotionProperty>;
 }) {
-    const props = page.properties;
-    const titleKey = findTitleProperty(props);
-    const doiKey = findPropertyByKeyword(props, "doi");
-    const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
+	const props = page.properties;
+	const titleKey = findTitleProperty(props);
+	const doiKey = findPropertyByKeyword(props, "doi");
+	const s2Key =
+		findPropertyByKeyword(props, "semantic scholar") ??
+		findPropertyByKeyword(props, "s2");
 
-    const titleProp = props[titleKey];
-    const doiProp = doiKey ? props[doiKey] : undefined;
-    const s2Prop = s2Key ? props[s2Key] : undefined;
+	const titleProp = props[titleKey];
+	const doiProp = doiKey ? props[doiKey] : undefined;
+	const s2Prop = s2Key ? props[s2Key] : undefined;
 
-    return {
-        pageId: page.id,
-        title: getPlainText(titleProp?.title) || "(untitled)",
-        doi: getPlainText(doiProp?.rich_text) || doiProp?.url || undefined,
-        semanticScholarId: getPlainText(s2Prop?.rich_text) || undefined,
-    };
+	return {
+		pageId: page.id,
+		title: getPlainText(titleProp?.title) || "(untitled)",
+		doi: getPlainText(doiProp?.rich_text) || doiProp?.url || undefined,
+		semanticScholarId: getPlainText(s2Prop?.rich_text) || undefined,
+	};
 }
 
 function parseAuth(request: NextRequest) {
-    const accessToken = getAccessToken(request.cookies);
-    const dataSourceId = getSelectedDatabaseId(request.cookies);
-    if (!accessToken) {
-        return { ok: false as const, status: 401, error: "Not authenticated" };
-    }
-    if (!dataSourceId) {
-        return { ok: false as const, status: 400, error: "Database is not selected" };
-    }
-    return { ok: true as const, accessToken, dataSourceId };
+	const accessToken = getAccessToken(request.cookies);
+	const dataSourceId = getSelectedDatabaseId(request.cookies);
+	if (!accessToken) {
+		return { ok: false as const, status: 401, error: "Not authenticated" };
+	}
+	if (!dataSourceId) {
+		return {
+			ok: false as const,
+			status: 400,
+			error: "Database is not selected",
+		};
+	}
+	return { ok: true as const, accessToken, dataSourceId };
 }
 
 export async function GET(request: NextRequest) {
-    const auth = parseAuth(request);
-    if (!auth.ok) {
-        return NextResponse.json({ error: auth.error }, { status: auth.status });
-    }
+	const auth = parseAuth(request);
+	if (!auth.ok) {
+		return NextResponse.json({ error: auth.error }, { status: auth.status });
+	}
 
-    try {
-        const notion = getNotionClient(auth.accessToken);
-        const dataSource: ArchiveNotionDataSource = await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
-        const recordsRes = await notion.dataSources.query({
-            data_source_id: dataSource.id,
-            page_size: 100,
-        });
+	try {
+		const notion = getNotionClient(auth.accessToken);
+		const dataSource: ArchiveNotionDataSource =
+			await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
+		const recordsRes = await notion.dataSources.query({
+			data_source_id: dataSource.id,
+			page_size: 100,
+		});
 
-        const records = recordsRes.results
-            .filter((r) => r.object === "page")
-            .map((page) => mapPageRecord(page as { id: string; properties: Record<string, NotionProperty> }));
+		const records = recordsRes.results
+			.filter((r) => r.object === "page")
+			.map((page) =>
+				mapPageRecord(
+					page as { id: string; properties: Record<string, NotionProperty> },
+				),
+			);
 
-        const userInfo = getUserInfo(request.cookies);
-        const databaseTitle = dataSource.title ?? [];
-        const databaseName = getPlainText(databaseTitle) || "(untitled database)";
+		const userInfo = getUserInfo(request.cookies);
+		const databaseTitle = dataSource.title ?? [];
+		const databaseName = getPlainText(databaseTitle) || "(untitled database)";
 
-        return NextResponse.json({
-            records,
-            total: records.length,
-            database: {
-                databaseId: dataSource.id,
-                databaseName,
-                workspaceName: userInfo?.workspaceName ?? "Notion Workspace",
-            },
-        });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		return NextResponse.json({
+			records,
+			total: records.length,
+			database: {
+				databaseId: dataSource.id,
+				databaseName,
+				workspaceName: userInfo?.workspaceName ?? "Notion Workspace",
+			},
+		});
+	} catch (error) {
+		console.error("Archive API Error:", error);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500 },
+		);
+	}
 }
 
 export async function POST(request: NextRequest) {
-    const auth = parseAuth(request);
-    if (!auth.ok) {
-        return NextResponse.json({ error: auth.error }, { status: auth.status });
-    }
+	const auth = parseAuth(request);
+	if (!auth.ok) {
+		return NextResponse.json({ error: auth.error }, { status: auth.status });
+	}
 
-    try {
-        const body = (await request.json()) as { paper: S2Paper; tags?: string[] };
-        const { paper } = body;
+	try {
+		const body = (await request.json()) as { paper: S2Paper; tags?: string[] };
+		const { paper } = body;
 
-        if (!paper) {
-            return NextResponse.json({ error: "paper is required" }, { status: 400 });
-        }
+		if (!paper) {
+			return NextResponse.json({ error: "paper is required" }, { status: 400 });
+		}
 
-        const notion = getNotionClient(auth.accessToken);
-        const dataSource: ArchiveNotionDataSource = await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
-        const props = dataSource.properties;
-        const titleKey = findTitleProperty(props);
-        const doiKey = findPropertyByKeyword(props, "doi");
-        const s2Key = findPropertyByKeyword(props, "semantic scholar") ?? findPropertyByKeyword(props, "s2");
-        const tagsKey = findPropertyByKeyword(props, "tag");
+		const notion = getNotionClient(auth.accessToken);
+		const dataSource: ArchiveNotionDataSource =
+			await resolveNotionDataSource<NotionProperty>(notion, auth.dataSourceId);
+		const props = dataSource.properties;
+		const titleKey = findTitleProperty(props);
+		const doiKey = findPropertyByKeyword(props, "doi");
+		const s2Key =
+			findPropertyByKeyword(props, "semantic scholar") ??
+			findPropertyByKeyword(props, "s2");
+		const tagsKey = findPropertyByKeyword(props, "tag");
 
-        const properties: NotionPageCreateProperties = {
-            [titleKey]: {
-                title: [{ text: { content: paper.title ?? "Untitled" } }],
-            },
-        };
+		const properties: NotionPageCreateProperties = {
+			[titleKey]: {
+				title: [{ text: { content: paper.title ?? "Untitled" } }],
+			},
+		};
 
-        const doi = paper.externalIds?.DOI?.trim();
-        if (doiKey && doi) {
-            const doiType = props[doiKey]?.type;
-            if (doiType === "url") {
-                properties[doiKey] = { url: `https://doi.org/${doi}` };
-            } else {
-                properties[doiKey] = { rich_text: [{ text: { content: doi } }] };
-            }
-        }
+		const doi = paper.externalIds?.DOI?.trim();
+		if (doiKey && doi) {
+			const doiType = props[doiKey]?.type;
+			if (doiType === "url") {
+				properties[doiKey] = { url: `https://doi.org/${doi}` };
+			} else {
+				properties[doiKey] = { rich_text: [{ text: { content: doi } }] };
+			}
+		}
 
-        if (s2Key && paper.paperId) {
-            properties[s2Key] = {
-                rich_text: [{ text: { content: paper.paperId } }],
-            };
-        }
+		if (s2Key && paper.paperId) {
+			properties[s2Key] = {
+				rich_text: [{ text: { content: paper.paperId } }],
+			};
+		}
 
-        if (tagsKey && Array.isArray(body.tags) && body.tags.length > 0) {
-            const tagsType = props[tagsKey]?.type;
-            if (tagsType === "multi_select") {
-                const tagMap = new Map<string, string>();
-                for (const rawTag of body.tags) {
-                    const normalized = rawTag.trim();
-                    if (!normalized) continue;
-                    const dedupeKey = normalized.toLowerCase();
-                    if (!tagMap.has(dedupeKey)) {
-                        tagMap.set(dedupeKey, normalized);
-                    }
-                }
-                const tags = Array.from(tagMap.values()).map((name) => ({ name }));
-                if (tags.length > 0) {
-                    properties[tagsKey] = { multi_select: tags };
-                }
-            }
-        }
+		if (tagsKey && Array.isArray(body.tags) && body.tags.length > 0) {
+			const tagsType = props[tagsKey]?.type;
+			if (tagsType === "multi_select") {
+				const tagMap = new Map<string, string>();
+				for (const rawTag of body.tags) {
+					const normalized = rawTag.trim();
+					if (!normalized) continue;
+					const dedupeKey = normalized.toLowerCase();
+					if (!tagMap.has(dedupeKey)) {
+						tagMap.set(dedupeKey, normalized);
+					}
+				}
+				const tags = Array.from(tagMap.values()).map((name) => ({ name }));
+				if (tags.length > 0) {
+					properties[tagsKey] = { multi_select: tags };
+				}
+			}
+		}
 
-        await notion.pages.create({
-            parent: { data_source_id: dataSource.id },
-            properties,
-        });
+		await notion.pages.create({
+			parent: { data_source_id: dataSource.id },
+			properties,
+		});
 
-        return NextResponse.json({ success: true });
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		console.error("Archive API Error:", error);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500 },
+		);
+	}
 }


### PR DESCRIPTION
🎯 **What:** Fixed an information exposure vulnerability in the Archive API (GET and POST routes) where internal error messages were being leaked to the client.

⚠️ **Risk:** Potential leakage of sensitive internal server paths, dependency errors, or infrastructure details that an attacker could use for reconnaissance.

🛡️ **Solution:** Updated the error handling to log the actual error to the server console while returning a generic 'Internal server error' to the client.

✅ **Verification:** Verified by running vitest in packages/web.

---
*PR created automatically by Jules for task [3289657584469436362](https://jules.google.com/task/3289657584469436362) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Archive API の GET・POST が、内部例外をサーバー側へ記録しつつ、クライアントには固定の一般的なエラーメッセージを返すよう変更されています。
- Notion API やリクエスト処理の例外内容が 500 レスポンスから漏えいしないように変更
- Error オブジェクト以外が throw された場合も同じ安全なレスポンスへ統一
- GET・POST 双方のエラー応答テストを新しい契約に更新
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この PR は意図した情報漏えい対策を GET・POST の両経路へ一貫して適用しており、安全にマージできると考えます。

例外の詳細はサーバー側に保持され、認証や正常系の処理を変えずにクライアント向け 500 応答だけが固定文言へ置き換えられており、対応するテストも更新されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/archive/route.ts | GET・POST の例外処理を安全な固定レスポンスへ変更し、元の例外はサーバーログへ残しています。 |
| packages/web/src/app/api/archive/route.test.ts | Error および非 Error の例外について、内部情報を含まない固定の 500 応答を検証するよう更新されています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix Information Exposure in Archive A..."](https://github.com/hiroki-org/paper-tools/commit/74edd3697409f8a0172dd9f3c8f51253e26aa914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582858)</sub>

**Context used:**

- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->