### PR TITLE
🔒 Fix internal error exposure in token refresh

### DIFF
--- a/packages/web/src/app/api/auth/refresh/route.test.ts
+++ b/packages/web/src/app/api/auth/refresh/route.test.ts
@@ -1,138 +1,156 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { NextRequest } from "next/server";
-import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE, USER_INFO_COOKIE } from "@/lib/auth-cookies";
 
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Instead of mocking the whole auth module, we'll spy on the getters to simulate incoming cookies
 // and allow setAuthCookies to operate normally on the NextResponse object.
 import * as auth from "@/lib/auth";
+import {
+	ACCESS_TOKEN_COOKIE,
+	REFRESH_TOKEN_COOKIE,
+	USER_INFO_COOKIE,
+} from "@/lib/auth-cookies";
 
 const { POST } = await import("./route");
 
 describe("/api/auth/refresh POST", () => {
-    let mockFetch: any;
+	let mockFetch: any;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "test-client-id");
-        vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "test-client-secret");
-        vi.stubEnv("COOKIE_SECRET", "test-secret");
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "test-client-id");
+		vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "test-client-secret");
+		vi.stubEnv("COOKIE_SECRET", "test-secret");
 
-        mockFetch = vi.fn();
-        vi.stubGlobal("fetch", mockFetch);
+		mockFetch = vi.fn();
+		vi.stubGlobal("fetch", mockFetch);
 
-        vi.spyOn(auth, "getRefreshToken").mockReturnValue("old-refresh-token");
-        vi.spyOn(auth, "getUserInfo").mockReturnValue(null);
-    });
+		vi.spyOn(auth, "getRefreshToken").mockReturnValue("old-refresh-token");
+		vi.spyOn(auth, "getUserInfo").mockReturnValue(null);
+	});
 
-    afterEach(() => {
-        vi.unstubAllEnvs();
-        vi.unstubAllGlobals();
-        vi.restoreAllMocks();
-    });
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
 
-    it("should return 500 if OAuth config is missing", async () => {
-        vi.unstubAllEnvs();
-        vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "");
-        vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "");
+	it("should return 500 if OAuth config is missing", async () => {
+		vi.unstubAllEnvs();
+		vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "");
+		vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "");
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(500);
-        const data = await res.json();
-        expect(data.error).toBe("OAuth config is missing");
-    });
+		expect(res.status).toBe(500);
+		const data = await res.json();
+		expect(data.error).toBe("OAuth config is missing");
+	});
 
-    it("should return 401 if refresh token is not found in cookies", async () => {
-        vi.spyOn(auth, "getRefreshToken").mockReturnValue(null);
+	it("should return 401 if refresh token is not found in cookies", async () => {
+		vi.spyOn(auth, "getRefreshToken").mockReturnValue(null);
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(401);
-        const data = await res.json();
-        expect(data.error).toBe("refresh_token not found");
-    });
+		expect(res.status).toBe(401);
+		const data = await res.json();
+		expect(data.error).toBe("refresh_token not found");
+	});
 
-    it("should return 401 if Notion API request fails", async () => {
-        mockFetch.mockResolvedValue({
-            ok: false,
-            status: 400,
-            json: async () => ({ error: "invalid_grant" }),
-        });
+	it("should return 401 if Notion API request fails", async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 400,
+			json: async () => ({ error: "invalid_grant" }),
+		});
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(400);
-        const data = await res.json();
-        expect(data.error).toBe("invalid_grant");
-    });
+		expect(res.status).toBe(400);
+		const data = await res.json();
+		expect(data.error).toBe("invalid_grant");
+	});
 
-    it("should return 502 if Notion response is missing refresh_token", async () => {
-        mockFetch.mockResolvedValue({
-            ok: true,
-            status: 200,
-            json: async () => ({ access_token: "new-access-token" }), // Missing refresh_token
-        });
+	it("should return 502 if Notion response is missing refresh_token", async () => {
+		mockFetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ access_token: "new-access-token" }), // Missing refresh_token
+		});
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(502);
-        const data = await res.json();
-        expect(data.error).toBe("refresh_token missing in response");
-    });
+		expect(res.status).toBe(502);
+		const data = await res.json();
+		expect(data.error).toBe("refresh_token missing in response");
+	});
 
-    it("should return 200, call fetch correctly, and set cookies on success", async () => {
-        mockFetch.mockResolvedValue({
-            ok: true,
-            status: 200,
-            json: async () => ({
-                access_token: "new-access-token",
-                refresh_token: "new-refresh-token",
-                workspace_name: "Test Workspace",
-            }),
-        });
+	it("should return 200, call fetch correctly, and set cookies on success", async () => {
+		mockFetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				workspace_name: "Test Workspace",
+			}),
+		});
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(200);
-        const data = await res.json();
-        expect(data.success).toBe(true);
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.success).toBe(true);
 
-        // Assert fetch was called correctly
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        const [url, options] = mockFetch.mock.calls[0];
-        expect(url).toBe("https://api.notion.com/v1/oauth/token");
-        expect(options.method).toBe("POST");
-        const basic = Buffer.from("test-client-id:test-client-secret").toString("base64");
-        expect(options.headers).toMatchObject({
-            "Content-Type": "application/json",
-            "Notion-Version": "2025-09-03",
-            "Authorization": `Basic ${basic}`
-        });
-        expect(JSON.parse(options.body)).toEqual({
-            grant_type: "refresh_token",
-            refresh_token: "old-refresh-token"
-        });
+		// Assert fetch was called correctly
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		const [url, options] = mockFetch.mock.calls[0];
+		expect(url).toBe("https://api.notion.com/v1/oauth/token");
+		expect(options.method).toBe("POST");
+		const basic = Buffer.from("test-client-id:test-client-secret").toString(
+			"base64",
+		);
+		expect(options.headers).toMatchObject({
+			"Content-Type": "application/json",
+			"Notion-Version": "2025-09-03",
+			Authorization: `Basic ${basic}`,
+		});
+		expect(JSON.parse(options.body)).toEqual({
+			grant_type: "refresh_token",
+			refresh_token: "old-refresh-token",
+		});
 
-        // Assert cookies were set properly
-        expect(res.cookies.get(ACCESS_TOKEN_COOKIE)).toBeDefined();
-        expect(res.cookies.get(REFRESH_TOKEN_COOKIE)).toBeDefined();
-        expect(res.cookies.get(USER_INFO_COOKIE)).toBeDefined();
-    });
+		// Assert cookies were set properly
+		expect(res.cookies.get(ACCESS_TOKEN_COOKIE)).toBeDefined();
+		expect(res.cookies.get(REFRESH_TOKEN_COOKIE)).toBeDefined();
+		expect(res.cookies.get(USER_INFO_COOKIE)).toBeDefined();
+	});
 
-    it("should return 401 if fetch throws an error", async () => {
-        mockFetch.mockRejectedValue(new Error("Network failure"));
+	it("should return 401 if fetch throws an error", async () => {
+		mockFetch.mockRejectedValue(new Error("Network failure"));
 
-        const req = new NextRequest("http://localhost/api/auth/refresh", { method: "POST" });
-        const res = await POST(req);
+		const req = new NextRequest("http://localhost/api/auth/refresh", {
+			method: "POST",
+		});
+		const res = await POST(req);
 
-        expect(res.status).toBe(401);
-        const data = await res.json();
-        expect(data.error).toBe("Network failure");
-    });
+		expect(res.status).toBe(401);
+		const data = await res.json();
+		expect(data.error).toBe("Token refresh failed");
+	});
 });

--- a/packages/web/src/app/api/auth/refresh/route.ts
+++ b/packages/web/src/app/api/auth/refresh/route.ts
@@ -1,65 +1,76 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getRefreshToken, getUserInfo, setAuthCookies } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
-    const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
-    const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
-    if (!clientId || !clientSecret) {
-        return NextResponse.json({ error: "OAuth config is missing" }, { status: 500 });
-    }
+	const clientId = process.env.NOTION_OAUTH_CLIENT_ID;
+	const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET;
+	if (!clientId || !clientSecret) {
+		return NextResponse.json(
+			{ error: "OAuth config is missing" },
+			{ status: 500 },
+		);
+	}
 
-    const refreshToken = getRefreshToken(request.cookies);
-    if (!refreshToken) {
-        return NextResponse.json({ error: "refresh_token not found" }, { status: 401 });
-    }
+	const refreshToken = getRefreshToken(request.cookies);
+	if (!refreshToken) {
+		return NextResponse.json(
+			{ error: "refresh_token not found" },
+			{ status: 401 },
+		);
+	}
 
-    try {
-        const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
-        const tokenRes = await fetch("https://api.notion.com/v1/oauth/token", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Notion-Version": "2025-09-03",
-                Authorization: `Basic ${basic}`,
-            },
-            body: JSON.stringify({
-                grant_type: "refresh_token",
-                refresh_token: refreshToken,
-            }),
-        });
-        const tokenResponse = (await tokenRes.json()) as {
-            access_token?: string;
-            refresh_token?: string;
-            workspace_name?: string | null;
-            workspace_icon?: string | null;
-            error?: string;
-        };
-        if (!tokenRes.ok || !tokenResponse.access_token) {
-            return NextResponse.json(
-                { error: tokenResponse.error ?? "Refresh failed" },
-                { status: tokenRes.status || 401 },
-            );
-        }
-        const nextRefreshToken = tokenResponse.refresh_token;
-        if (!nextRefreshToken) {
-            return NextResponse.json({ error: "refresh_token missing in response" }, { status: 502 });
-        }
+	try {
+		const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+		const tokenRes = await fetch("https://api.notion.com/v1/oauth/token", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Notion-Version": "2025-09-03",
+				Authorization: `Basic ${basic}`,
+			},
+			body: JSON.stringify({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+			}),
+		});
+		const tokenResponse = (await tokenRes.json()) as {
+			access_token?: string;
+			refresh_token?: string;
+			workspace_name?: string | null;
+			workspace_icon?: string | null;
+			error?: string;
+		};
+		if (!tokenRes.ok || !tokenResponse.access_token) {
+			return NextResponse.json(
+				{ error: tokenResponse.error ?? "Refresh failed" },
+				{ status: tokenRes.status || 401 },
+			);
+		}
+		const nextRefreshToken = tokenResponse.refresh_token;
+		if (!nextRefreshToken) {
+			return NextResponse.json(
+				{ error: "refresh_token missing in response" },
+				{ status: 502 },
+			);
+		}
 
-        const userInfo = getUserInfo(request.cookies) ?? {
-            workspaceName: tokenResponse.workspace_name ?? undefined,
-            workspaceIcon: tokenResponse.workspace_icon,
-        };
+		const userInfo = getUserInfo(request.cookies) ?? {
+			workspaceName: tokenResponse.workspace_name ?? undefined,
+			workspaceIcon: tokenResponse.workspace_icon,
+		};
 
-        const response = NextResponse.json({ success: true });
-        setAuthCookies(response, {
-            accessToken: tokenResponse.access_token,
-            refreshToken: nextRefreshToken,
-            userInfo,
-            request,
-        });
-        return response;
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Refresh failed";
-        return NextResponse.json({ error: message }, { status: 401 });
-    }
+		const response = NextResponse.json({ success: true });
+		setAuthCookies(response, {
+			accessToken: tokenResponse.access_token,
+			refreshToken: nextRefreshToken,
+			userInfo,
+			request,
+		});
+		return response;
+	} catch {
+		return NextResponse.json(
+			{ error: "Token refresh failed" },
+			{ status: 401 },
+		);
+	}
 }


### PR DESCRIPTION
🎯 **What:** Returning a generic error message in token refresh route.
⚠️ **Risk:** Exposure of internal error messages could put the codebase or its users at risk.
🛡️ **Solution:** Returning a generic "Token refresh failed" error instead of dynamic `error.message`.
✅ **Verification:** Format, build, and tests verified successfully.

---
*PR created automatically by Jules for task [7244817061752611979](https://jules.google.com/task/7244817061752611979) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

トークン更新中の例外詳細をクライアントへ返さず、固定のエラーメッセージへ置き換える変更です。
- refresh API の catch 応答を `"Token refresh failed"` に固定
- fetch 失敗時のテスト期待値を新しい固定メッセージへ更新
- ファイル全体を既存フォーマットへ整形
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる不具合は見当たりませんが、内部情報をレスポンスから隠したまま例外をサーバー側へ記録する改善を推奨します。

固定メッセージと従来どおりの 401 応答は現在の利用契約を壊しませんが、例外原因を完全に破棄するため障害調査が困難になります。

**Files Needing Attention:** packages/web/src/app/api/auth/refresh/route.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/auth/refresh/route.ts | クライアントへの内部例外露出は解消される一方、例外を捕捉・記録しないためサーバー側の障害診断情報も失われます。 |
| packages/web/src/app/api/auth/refresh/route.test.ts | fetch 拒否時に固定エラーメッセージが返ることへ期待値を更新し、その他は整形のみです。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/web/src/app/api/auth/refresh/route.ts:70-75
**サーバー側の例外情報も消失**

固定レスポンスによってクライアントへの内部情報露出は防げますが、例外を捕捉も記録もしないため、通信・JSON 解析・Cookie 設定のどこで失敗したかサーバーログから診断できません。クライアントには汎用メッセージを返しつつ、例外の詳細はサーバー側に記録してください。

```suggestion
	} catch (error) {
		console.error("Token refresh failed", error);
		return NextResponse.json(
			{ error: "Token refresh failed" },
			{ status: 401 },
		);
	}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix internal error exposure in token ref..."](https://github.com/hiroki-org/paper-tools/commit/e15d2e4cd4f45243650cbcbd2e266df42dacba32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582963)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->