### PR TITLE
🧹 Refactor DOT graph formatting to support custom attributes styling

### DIFF
--- a/packages/visualizer/src/format.ts
+++ b/packages/visualizer/src/format.ts
@@ -3,31 +3,45 @@ import type { CitationGraph } from "./graph.js";
 export const SUPPORTED_FORMATS = ["json", "dot", "mermaid"] as const;
 export type Format = (typeof SUPPORTED_FORMATS)[number];
 
+export interface DotStyling {
+	graph?: Record<string, string>;
+	node?: Record<string, string>;
+	edge?: Record<string, string>;
+}
+
 /**
  * グラフを指定されたフォーマットに変換・出力する
  * @param graph - 変換対象の引用グラフ
  * @param format - 出力フォーマット
  * @param pretty - JSON 出力時に整形するかどうか (デフォルト: true)
+ * @param dotStyling - DOT 出力時のスタイリング設定
  * @returns フォーマット済みのグラフ文字列
  */
-export function formatGraph(graph: CitationGraph, format: Format, pretty = true): string {
-    switch (format) {
-        case "json":
-            return toJson(graph, pretty);
-        case "dot":
-            return toDot(graph);
-        case "mermaid":
-            return toMermaid(graph);
-        default:
-            throw new Error(`Unknown format: ${format}. Supported formats are: ${SUPPORTED_FORMATS.join(", ")}`);
-    }
+export function formatGraph(
+	graph: CitationGraph,
+	format: Format,
+	pretty = true,
+	dotStyling?: DotStyling,
+): string {
+	switch (format) {
+		case "json":
+			return toJson(graph, pretty);
+		case "dot":
+			return toDot(graph, dotStyling);
+		case "mermaid":
+			return toMermaid(graph);
+		default:
+			throw new Error(
+				`Unknown format: ${format}. Supported formats are: ${SUPPORTED_FORMATS.join(", ")}`,
+			);
+	}
 }
 
 /**
  * グラフを JSON 文字列として出力する。
  */
 function toJson(graph: CitationGraph, pretty = true): string {
-    return JSON.stringify(graph, null, pretty ? 2 : undefined);
+	return JSON.stringify(graph, null, pretty ? 2 : undefined);
 }
 
 /**
@@ -37,7 +51,7 @@ function toJson(graph: CitationGraph, pretty = true): string {
  * @returns DOT 形式用にエスケープされたテキスト
  */
 function escapeLabel(text: string): string {
-    return text.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+	return text.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 /**
@@ -47,40 +61,62 @@ function escapeLabel(text: string): string {
  * @returns グラフノード ID として使用可能な文字列
  */
 function doiToId(doi: string): string {
-    return doi.replace(/[^a-zA-Z0-9]/g, "_");
+	return doi.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+function formatAttrs(attrs: Record<string, string>): string {
+	return Object.entries(attrs)
+		.map(([k, v]) => `${k}="${escapeLabel(v)}"`)
+		.join(", ");
 }
 
 /**
  * グラフを DOT (Graphviz) 形式で出力する。
  * DOI由来のノード ID は Graphviz パーサーの互換性のため、引用符で囲んで出力する
  */
-function toDot(graph: CitationGraph): string {
-    const lines: string[] = [];
-    lines.push("digraph citations {");
-    lines.push("    rankdir=LR;");
-    lines.push("    node [shape=box, style=rounded];");
-    lines.push("");
+function toDot(graph: CitationGraph, styling?: DotStyling): string {
+	const lines: string[] = [];
+	lines.push("digraph citations {");
+	if (styling?.graph) {
+		lines.push(`    graph [${formatAttrs(styling.graph)}];`);
+	} else {
+		lines.push('    rankdir="LR";');
+	}
 
-    for (const node of graph.nodes) {
-        const id = doiToId(node.doi);
-        const label = node.title ? escapeLabel(node.title) : escapeLabel(node.doi);
-        lines.push(`    "${id}" [label="${label}"];`);
-    }
+	if (styling?.node) {
+		lines.push(`    node [${formatAttrs(styling.node)}];`);
+	} else {
+		lines.push('    node [shape="box", style="rounded"];');
+	}
 
-    lines.push("");
+	const edgeAttrs = styling?.edge ? ` [${formatAttrs(styling.edge)}]` : "";
+	if (edgeAttrs) {
+		lines.push(`    edge${edgeAttrs};`);
+	}
+	lines.push("");
 
-    for (const edge of graph.edges) {
-        const srcId = doiToId(edge.source);
-        const tgtId = doiToId(edge.target);
-        if (edge.creationDate) {
-            lines.push(`    "${srcId}" -> "${tgtId}" [label="${escapeLabel(edge.creationDate)}"];`);
-        } else {
-            lines.push(`    "${srcId}" -> "${tgtId}";`);
-        }
-    }
+	for (const node of graph.nodes) {
+		const id = doiToId(node.doi);
+		const label = node.title ? escapeLabel(node.title) : escapeLabel(node.doi);
+		lines.push(`    "${id}" [label="${label}"];`);
+	}
 
-    lines.push("}");
-    return lines.join("\n");
+	lines.push("");
+
+	for (const edge of graph.edges) {
+		const srcId = doiToId(edge.source);
+		const tgtId = doiToId(edge.target);
+		if (edge.creationDate) {
+			lines.push(
+				`    "${srcId}" -> "${tgtId}" [label="${escapeLabel(edge.creationDate)}"];`,
+			);
+		} else {
+			lines.push(`    "${srcId}" -> "${tgtId}";`);
+		}
+	}
+
+	lines.push("}");
+	return lines.join("\n");
 }
 
 /**
@@ -91,38 +127,42 @@ function toDot(graph: CitationGraph): string {
  * @returns Mermaid 形式用にエスケープされたテキスト
  */
 function escapeMermaid(text: string): string {
-    return text
-        .replace(/"/g, "&#34;")
-        .replace(/\(/g, "&#40;")
-        .replace(/\)/g, "&#41;")
-        .replace(/\[/g, "&#91;")
-        .replace(/\]/g, "&#93;")
-        .replace(/\{/g, "&#123;")
-        .replace(/\}/g, "&#125;");
+	return text
+		.replace(/"/g, "&#34;")
+		.replace(/\(/g, "&#40;")
+		.replace(/\)/g, "&#41;")
+		.replace(/\[/g, "&#91;")
+		.replace(/\]/g, "&#93;")
+		.replace(/\{/g, "&#123;")
+		.replace(/\}/g, "&#125;");
 }
 
 /**
  * グラフを Mermaid 形式で出力する。
  */
 function toMermaid(graph: CitationGraph): string {
-    const lines: string[] = [];
-    lines.push("graph LR");
+	const lines: string[] = [];
+	lines.push("graph LR");
 
-    for (const node of graph.nodes) {
-        const id = doiToId(node.doi);
-        const label = node.title ? escapeMermaid(node.title) : escapeMermaid(node.doi);
-        lines.push(`    ${id}["${label}"]`);
-    }
+	for (const node of graph.nodes) {
+		const id = doiToId(node.doi);
+		const label = node.title
+			? escapeMermaid(node.title)
+			: escapeMermaid(node.doi);
+		lines.push(`    ${id}["${label}"]`);
+	}
 
-    for (const edge of graph.edges) {
-        const srcId = doiToId(edge.source);
-        const tgtId = doiToId(edge.target);
-        if (edge.creationDate) {
-            lines.push(`    ${srcId} -->|"${escapeMermaid(edge.creationDate)}"| ${tgtId}`);
-        } else {
-            lines.push(`    ${srcId} --> ${tgtId}`);
-        }
-    }
+	for (const edge of graph.edges) {
+		const srcId = doiToId(edge.source);
+		const tgtId = doiToId(edge.target);
+		if (edge.creationDate) {
+			lines.push(
+				`    ${srcId} -->|"${escapeMermaid(edge.creationDate)}"| ${tgtId}`,
+			);
+		} else {
+			lines.push(`    ${srcId} --> ${tgtId}`);
+		}
+	}
 
-    return lines.join("\n");
+	return lines.join("\n");
 }

--- a/packages/visualizer/tests/format.test.ts
+++ b/packages/visualizer/tests/format.test.ts
@@ -1,112 +1,123 @@
-import { describe, it, expect } from "vitest";
-import type { CitationGraph } from "../src/graph.js";
+import { describe, expect, it } from "vitest";
 import type { Format } from "../src/format.js";
 import { formatGraph, SUPPORTED_FORMATS } from "../src/format.js";
+import type { CitationGraph } from "../src/graph.js";
 
 const sampleGraph: CitationGraph = {
-    nodes: [
-        { doi: "10.1234/a", title: "Paper A" },
-        { doi: "10.5678/b", title: "Paper B" },
-        { doi: "10.9999/c" },
-    ],
-    edges: [
-        { source: "10.1234/a", target: "10.5678/b", creationDate: "2024-01-01" },
-        { source: "10.5678/b", target: "10.9999/c" },
-    ],
+	nodes: [
+		{ doi: "10.1234/a", title: "Paper A" },
+		{ doi: "10.5678/b", title: "Paper B" },
+		{ doi: "10.9999/c" },
+	],
+	edges: [
+		{ source: "10.1234/a", target: "10.5678/b", creationDate: "2024-01-01" },
+		{ source: "10.5678/b", target: "10.9999/c" },
+	],
 };
 
 describe("formatGraph with json format", () => {
-    it("should output valid JSON with all nodes and edges", () => {
-        const json = formatGraph(sampleGraph, "json");
-        const parsed = JSON.parse(json) as CitationGraph;
-        expect(parsed.nodes).toHaveLength(3);
-        expect(parsed.edges).toHaveLength(2);
-        expect(parsed.nodes[0].doi).toBe("10.1234/a");
-    });
+	it("should output valid JSON with all nodes and edges", () => {
+		const json = formatGraph(sampleGraph, "json");
+		const parsed = JSON.parse(json) as CitationGraph;
+		expect(parsed.nodes).toHaveLength(3);
+		expect(parsed.edges).toHaveLength(2);
+		expect(parsed.nodes[0].doi).toBe("10.1234/a");
+	});
 
-    it("should output compact JSON when pretty=false", () => {
-        const compact = formatGraph(sampleGraph, "json", false);
-        expect(compact).not.toContain("\n");
-    });
+	it("should output compact JSON when pretty=false", () => {
+		const compact = formatGraph(sampleGraph, "json", false);
+		expect(compact).not.toContain("\n");
+	});
 
-    it("should output pretty JSON by default", () => {
-        const pretty = formatGraph(sampleGraph, "json");
-        expect(pretty).toContain("\n");
-    });
+	it("should output pretty JSON by default", () => {
+		const pretty = formatGraph(sampleGraph, "json");
+		expect(pretty).toContain("\n");
+	});
 });
 
 describe("formatGraph with dot format", () => {
-    it("should produce a valid DOT digraph", () => {
-        const dot = formatGraph(sampleGraph, "dot");
-        expect(dot).toContain("digraph citations {");
-        expect(dot).toContain("rankdir=LR;");
-        expect(dot).toContain("}");
-    });
+	it("should support custom styling", () => {
+		const customStyling = {
+			graph: { rankdir: "TB", bgcolor: "white" },
+			node: { shape: "circle", color: "blue" },
+			edge: { color: "red", style: "dashed" },
+		};
+		const dot = formatGraph(sampleGraph, "dot", true, customStyling);
+		expect(dot).toContain('graph [rankdir="TB", bgcolor="white"]');
+		expect(dot).toContain('node [shape="circle", color="blue"]');
+		expect(dot).toContain('edge [color="red", style="dashed"]');
+	});
 
-    it("should include node declarations with labels", () => {
-        const dot = formatGraph(sampleGraph, "dot");
-        expect(dot).toContain('label="Paper A"');
-        expect(dot).toContain('label="Paper B"');
-        // ノード c にはタイトルがないので DOI がラベルになる
-        expect(dot).toContain('label="10.9999/c"');
-    });
+	it("should produce a valid DOT digraph", () => {
+		const dot = formatGraph(sampleGraph, "dot");
+		expect(dot).toContain("digraph citations {");
+		expect(dot).toContain('rankdir="LR";');
+		expect(dot).toContain("}");
+	});
 
-    it("should include edge declarations", () => {
-        const dot = formatGraph(sampleGraph, "dot");
-        expect(dot).toContain("->");
-        // creationDate 付きエッジにはラベルが付く
-        expect(dot).toContain('label="2024-01-01"');
-    });
+	it("should include node declarations with labels", () => {
+		const dot = formatGraph(sampleGraph, "dot");
+		expect(dot).toContain('label="Paper A"');
+		expect(dot).toContain('label="Paper B"');
+		// ノード c にはタイトルがないので DOI がラベルになる
+		expect(dot).toContain('label="10.9999/c"');
+	});
 
-    it("should escape special characters in labels", () => {
-        const graph: CitationGraph = {
-            nodes: [{ doi: "10.1/x", title: 'Title with "quotes"' }],
-            edges: [],
-        };
-        const dot = formatGraph(graph, "dot");
-        expect(dot).toContain('Title with \\"quotes\\"');
-    });
+	it("should include edge declarations", () => {
+		const dot = formatGraph(sampleGraph, "dot");
+		expect(dot).toContain("->");
+		// creationDate 付きエッジにはラベルが付く
+		expect(dot).toContain('label="2024-01-01"');
+	});
+
+	it("should escape special characters in labels", () => {
+		const graph: CitationGraph = {
+			nodes: [{ doi: "10.1/x", title: 'Title with "quotes"' }],
+			edges: [],
+		};
+		const dot = formatGraph(graph, "dot");
+		expect(dot).toContain('Title with \\"quotes\\"');
+	});
 });
 
 describe("formatGraph with mermaid format", () => {
-    it("should produce a Mermaid flowchart", () => {
-        const mermaid = formatGraph(sampleGraph, "mermaid");
-        expect(mermaid).toContain("graph LR");
-    });
+	it("should produce a Mermaid flowchart", () => {
+		const mermaid = formatGraph(sampleGraph, "mermaid");
+		expect(mermaid).toContain("graph LR");
+	});
 
-    it("should include node definitions with labels", () => {
-        const mermaid = formatGraph(sampleGraph, "mermaid");
-        expect(mermaid).toContain('["Paper A"]');
-        expect(mermaid).toContain('["Paper B"]');
-    });
+	it("should include node definitions with labels", () => {
+		const mermaid = formatGraph(sampleGraph, "mermaid");
+		expect(mermaid).toContain('["Paper A"]');
+		expect(mermaid).toContain('["Paper B"]');
+	});
 
-    it("should include edge definitions", () => {
-        const mermaid = formatGraph(sampleGraph, "mermaid");
-        expect(mermaid).toContain("-->");
-        // creationDate 付きエッジにはラベルが付く
-        expect(mermaid).toContain("|");
-    });
+	it("should include edge definitions", () => {
+		const mermaid = formatGraph(sampleGraph, "mermaid");
+		expect(mermaid).toContain("-->");
+		// creationDate 付きエッジにはラベルが付く
+		expect(mermaid).toContain("|");
+	});
 
-    it("should escape quotes in Mermaid labels", () => {
-        const graph: CitationGraph = {
-            nodes: [{ doi: "10.1/x", title: 'A "quoted" title' }],
-            edges: [],
-        };
-        const mermaid = formatGraph(graph, "mermaid");
-        expect(mermaid).toContain("&#34;");
-        expect(mermaid).not.toContain('"quoted"');
-    });
+	it("should escape quotes in Mermaid labels", () => {
+		const graph: CitationGraph = {
+			nodes: [{ doi: "10.1/x", title: 'A "quoted" title' }],
+			edges: [],
+		};
+		const mermaid = formatGraph(graph, "mermaid");
+		expect(mermaid).toContain("&#34;");
+		expect(mermaid).not.toContain('"quoted"');
+	});
 });
 
-
 describe("format constants", () => {
-    it("should expose supported formats in one place", () => {
-        expect(SUPPORTED_FORMATS).toEqual(["json", "dot", "mermaid"]);
-    });
+	it("should expose supported formats in one place", () => {
+		expect(SUPPORTED_FORMATS).toEqual(["json", "dot", "mermaid"]);
+	});
 
-    it("should throw a helpful message for unsupported formats", () => {
-        expect(() => formatGraph(sampleGraph, "xml" as Format)).toThrow(
-            "Unknown format: xml. Supported formats are: json, dot, mermaid"
-        );
-    });
+	it("should throw a helpful message for unsupported formats", () => {
+		expect(() => formatGraph(sampleGraph, "xml" as Format)).toThrow(
+			"Unknown format: xml. Supported formats are: json, dot, mermaid",
+		);
+	});
 });


### PR DESCRIPTION
🎯 **What:** Resolved a code health TODO by refactoring `toDot` and `formatGraph` in `packages/visualizer/src/format.ts` to accept an optional `dotStyling` parameter of type `DotStyling`, enabling custom `graph`, `node`, and `edge` attributes.
💡 **Why:** This improves the maintainability of the codebase by moving hardcoded DOT attributes into an overridable configuration object, making the module flexible for different visualization needs without duplicating layout logic.
✅ **Verification:** Verified the fix by successfully running the full `pnpm test` suite in `packages/visualizer`, formatting the code using `@biomejs/biome check --write`, passing a mock review ensuring syntactical validity of comma-joined multiple graph attributes in DOT via `graph [...]`, and confirming TypeScript typings match via workspace build.
✨ **Result:** The `formatGraph` function now seamlessly supports DOT attribute customization while preserving default behavior when not provided.

---
*PR created automatically by Jules for task [10619572574171252089](https://jules.google.com/task/10619572574171252089) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

formatGraph に任意の DOT グラフ・ノード・エッジ属性を渡せる DotStyling 設定を追加しています。
- DOT 属性を共通整形する formatAttrs を導入
- 未指定時の既定 DOT スタイルを維持
- グラフ、ノード、エッジのカスタム属性を検証するテストを追加
- 属性値の改行処理と公開型の再エクスポートに修正点あり
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

属性値に改行が含まれると無効な DOT が生成されるため、その処理を修正してからマージする必要があります。

新しい DotStyling は任意の string 値を受け付けますが、シリアライザーが実改行を処理しないため Graphviz が解析できない出力を生成し、加えて設定型がパッケージの公開エントリーポイントから再エクスポートされていません。

**Files Needing Attention:** packages/visualizer/src/format.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/visualizer/src/format.ts | DOT スタイル設定を追加したが、属性値の実改行が不正な DOT を生成し、DotStyling も公開エントリーポイントから参照できない。 |
| packages/visualizer/tests/format.test.ts | 通常のカスタム属性を検証しているが、改行を含む属性値とパッケージ公開面の型エクスポートは未検証。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/visualizer/src/format.ts:69
**改行で DOT 属性値が破損**

`dotStyling` の属性値に実改行が含まれると、`escapeLabel` はそれを処理せず二重引用符内へ出力するため、DOT の文字列が分断されて Graphviz が生成結果を構文エラーとして拒否します。

### Issue 2
packages/visualizer/src/format.ts:6-10
**公開設定型の再エクスポート漏れ**

新しい `DotStyling` がパッケージのエントリーポイントから再エクスポートされていないため、利用者が `@paper-tools/visualizer` からこの公開設定型を import すると TS2305 になり、スタイリング設定を明示的に型付けできません。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: support graph attributes styli..."](https://github.com/hiroki-org/paper-tools/commit/8cad88e249af86871d5174f238fee0bf9c89a02b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49583174)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Visualizer](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/visualizer.md)

<!-- /greptile_comment -->