### PR TITLE
🧹 Refactor Graph Export format tests to use parameterized testing

### DIFF
--- a/packages/web/src/app/api/graph/export/route.test.ts
+++ b/packages/web/src/app/api/graph/export/route.test.ts
@@ -58,46 +58,21 @@ describe("/api/graph/export POST", () => {
     expect(data.error).toContain("Unsupported format");
   });
 
-  it("formatがjsonのとき、toJsonの結果を返す", async () => {
-    const mockOutput = '{"mocked": "json"}';
+  it.each([
+    { format: "json", fnName: "toJson", mockOutput: '{"mocked": "json"}' },
+    { format: "dot", fnName: "toDot", mockOutput: "digraph { mock }" },
+    { format: "mermaid", fnName: "toMermaid", mockOutput: "graph TD; mock;" },
+  ])("formatが$formatのとき、$fnNameの結果を返す", async ({ format, mockOutput }) => {
     vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
 
-    const req = createRequest({ graph: mockGraph, format: "json" });
+    const req = createRequest({ graph: mockGraph, format });
     const res = await POST(req);
     const data = await res.json();
 
     expect(res.status).toBe(200);
     expect(data.output).toBe(mockOutput);
-    expect(data.format).toBe("json");
-    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "json");
-  });
-
-  it("formatがdotのとき、toDotの結果を返す", async () => {
-    const mockOutput = "digraph { mock }";
-    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
-
-    const req = createRequest({ graph: mockGraph, format: "dot" });
-    const res = await POST(req);
-    const data = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(data.output).toBe(mockOutput);
-    expect(data.format).toBe("dot");
-    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "dot");
-  });
-
-  it("formatがmermaidのとき、toMermaidの結果を返す", async () => {
-    const mockOutput = "graph TD; mock;";
-    vi.mocked(visualizer.formatGraph).mockReturnValueOnce(mockOutput);
-
-    const req = createRequest({ graph: mockGraph, format: "mermaid" });
-    const res = await POST(req);
-    const data = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(data.output).toBe(mockOutput);
-    expect(data.format).toBe("mermaid");
-    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, "mermaid");
+    expect(data.format).toBe(format);
+    expect(visualizer.formatGraph).toHaveBeenCalledWith(mockGraph, format);
   });
 
   it("予期せぬエラー発生時に500を返す", async () => {


### PR DESCRIPTION
🎯 **What:** Refactored the `graph/export` API route tests by replacing duplicated tests for the `json`, `dot`, and `mermaid` formats with a single parameterized test using `it.each`.

💡 **Why:** This improves the maintainability and readability of the codebase by eliminating duplicated code and making it much easier to test future additions to the `SUPPORTED_FORMATS`.

✅ **Verification:** Verified the fix by successfully running the full test suite in `packages/web` (`cd packages/web && pnpm test`) and verifying that the entire workspace builds successfully (`NODE_OPTIONS="--max-old-space-size=4096" pnpm -r build`).

✨ **Result:** Reduced code duplication in the test file and simplified the test logic while maintaining 100% test coverage for the graph format cases.

---
*PR created automatically by Jules for task [3997085024753323311](https://jules.google.com/task/3997085024753323311) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

JSON・DOT・Mermaid のグラフエクスポート API テストを `it.each` による単一のパラメータ化テストへ整理しています。
- 重複していた3形式の成功ケースをテーブル駆動テストへ統合
- 各形式のステータス、出力、レスポンス形式、`formatGraph` 呼び出し引数の検証を維持
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

本番コードは変更されておらず、各フォーマットに対する既存の入力、レスポンス、モック呼び出しの検証も維持されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/api/graph/export/route.test.ts | 既存の3つの成功ケースを、検証内容を維持したまま同等のパラメータ化テストへ安全に統合しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Refactor Graph Export format tests to..."](https://github.com/hiroki-org/paper-tools/commit/73caa9a59459245de8587cd0d0bd8c26ab21318d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49583490)</sub>

<!-- /greptile_comment -->