### PR TITLE
🧹 Refactor SearchPage to extract sub-components

### DIFF
--- a/packages/web/src/app/search/components/DrilldownSection.tsx
+++ b/packages/web/src/app/search/components/DrilldownSection.tsx
@@ -1,0 +1,274 @@
+import type { Paper } from "@paper-tools/core";
+import { useState, useCallback, useEffect } from "react";
+import type { DrilldownResult } from "@paper-tools/drilldown";
+import SearchPaperList from "./SearchPaperList";
+
+interface DrilldownSectionProps {
+  papers: Paper[];
+  isSaved: (paper: Paper) => boolean;
+  markSaved: (paper: Paper) => void;
+  getGraphHref: (paper: Paper) => string;
+  getRecommendHref: (paper: Paper) => string;
+  getPaperId: (paper: Paper & { paperId?: string }) => string | null;
+  preCacheFromPaper: (paper: Paper & { paperId?: string }, paperId: string) => void;
+  fieldClassName: string;
+}
+
+export default function DrilldownSection({
+  papers,
+  isSaved,
+  markSaved,
+  getGraphHref,
+  getRecommendHref,
+  getPaperId,
+  preCacheFromPaper,
+  fieldClassName,
+}: DrilldownSectionProps) {
+  const [drilldownResults, setDrilldownResults] = useState<DrilldownResult[]>([]);
+  const [drilldownLoading, setDrilldownLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [seedCount, setSeedCount] = useState(5);
+  const [drilldownDepth, setDrilldownDepth] = useState(1);
+  const [maxPerLevel, setMaxPerLevel] = useState(10);
+  const [enrich, setEnrich] = useState(false);
+
+  useEffect(() => {
+    setDrilldownResults([]);
+    setError(null);
+  }, [papers]);
+
+  const handleDrilldown = useCallback(async () => {
+    if (papers.length === 0) return;
+
+    setDrilldownLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/search/drilldown", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          seedPapers: papers.slice(0, seedCount),
+          depth: drilldownDepth,
+          maxPerLevel,
+          enrich,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error ?? "Drilldown failed");
+      }
+
+      setDrilldownResults(data.results ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setDrilldownLoading(false);
+    }
+  }, [papers, seedCount, drilldownDepth, maxPerLevel, enrich]);
+
+  const levelDescription = useCallback(
+    (level: number) => {
+      if (level === 0) {
+        return `シード論文（検索結果の上位 ${seedCount} 本）`;
+      }
+      if (level === 1) {
+        return "シード論文のキーワードから発見された関連論文";
+      }
+      return `Level ${level - 1} のキーワードからさらに深掘りした論文`;
+    },
+    [seedCount],
+  );
+
+  return (
+    <>
+      <section className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-5 shadow-sm backdrop-blur">
+        {error && (
+          <div className="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
+              Guided expansion
+            </p>
+            <h2 className="mt-2 text-xl font-semibold text-[var(--color-text)]">
+              Drilldown
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--color-text-muted)]">
+              検索結果の上位論文をシードとして、関連キーワードから周辺研究を広げます。
+              最初に広めに集めたいときは depth
+              を上げ、精度重視ならシード数と件数を抑えるのがおすすめです。
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            <div className="font-semibold text-slate-800">
+              Results loaded
+            </div>
+            <div className="mt-1">
+              {papers.length} papers ready for drilldown
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <label className="space-y-1.5">
+            <span className="block text-sm font-semibold text-[var(--color-text)]">
+              シード論文数
+            </span>
+            <input
+              type="number"
+              min={1}
+              max={10}
+              value={seedCount}
+              onChange={(e) =>
+                setSeedCount(
+                  Math.max(1, Math.min(10, Number(e.target.value) || 1)),
+                )
+              }
+              className={fieldClassName}
+            />
+            <span className="block text-xs text-[var(--color-text-muted)]">
+              検索結果の先頭から使う論文数
+            </span>
+          </label>
+
+          <label className="space-y-1.5">
+            <span className="block text-sm font-semibold text-[var(--color-text)]">
+              Depth
+            </span>
+            <select
+              value={drilldownDepth}
+              onChange={(e) => setDrilldownDepth(Number(e.target.value))}
+              className={fieldClassName}
+            >
+              <option value={1}>1</option>
+              <option value={2}>2</option>
+              <option value={3}>3</option>
+            </select>
+            <span className="block text-xs text-[var(--color-text-muted)]">
+              キーワード展開の段階数
+            </span>
+          </label>
+
+          <label className="space-y-1.5">
+            <span className="block text-sm font-semibold text-[var(--color-text)]">
+              Max per level
+            </span>
+            <input
+              type="number"
+              min={5}
+              max={30}
+              value={maxPerLevel}
+              onChange={(e) =>
+                setMaxPerLevel(
+                  Math.max(5, Math.min(30, Number(e.target.value) || 5)),
+                )
+              }
+              className={fieldClassName}
+            />
+            <span className="block text-xs text-[var(--color-text-muted)]">
+              各レベルで保持する最大件数
+            </span>
+          </label>
+
+          <div className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white p-4">
+            <div>
+              <p className="text-sm font-semibold text-[var(--color-text)]">
+                Metadata enrich
+              </p>
+              <p className="mt-1 text-xs leading-5 text-[var(--color-text-muted)]">
+                Crossref を使って DOI や書誌情報を補完します。
+              </p>
+            </div>
+
+            <label className="mt-4 inline-flex items-center gap-3 text-sm font-medium text-[var(--color-text)]">
+              <input
+                type="checkbox"
+                checked={enrich}
+                onChange={(e) => setEnrich(e.target.checked)}
+                className="h-4 w-4 rounded border-slate-300 text-[var(--color-primary)] focus:ring-[var(--color-primary)]"
+              />
+              Crossref で補完
+            </label>
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200/80 pt-4">
+          <p className="text-xs text-[var(--color-text-muted)]">
+            Seed {seedCount} 件 / Depth {drilldownDepth} / Max per level{" "}
+            {maxPerLevel}
+            {enrich ? " / Crossref enrich on" : ""}
+          </p>
+
+          <button
+            type="button"
+            onClick={handleDrilldown}
+            disabled={drilldownLoading}
+            className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {drilldownLoading ? "Drilldown running…" : "ドリルダウン開始"}
+          </button>
+        </div>
+      </section>
+
+      {drilldownResults.length > 0 && (
+        <section className="space-y-5">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
+                Expanded search
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-[var(--color-text)]">
+                Drilldown Results
+              </h2>
+            </div>
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {drilldownResults.reduce(
+                (sum, level) => sum + level.papers.length,
+                0,
+              )}{" "}
+              papers across {drilldownResults.length} levels
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            {drilldownResults.map((result, levelIndex) => (
+              <section
+                key={levelIndex}
+                className="rounded-2xl border border-[var(--color-border)] bg-white/85 p-5 shadow-sm backdrop-blur"
+              >
+                <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <h3 className="text-base font-semibold text-[var(--color-text)]">
+                      Level {result.level}
+                    </h3>
+                    <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+                      {levelDescription(result.level)}
+                    </p>
+                  </div>
+                  <span className="text-xs font-medium text-[var(--color-text-muted)]">
+                    {result.papers.length} papers
+                  </span>
+                </div>
+
+                <SearchPaperList
+                  papers={result.papers}
+                  isSaved={isSaved}
+                  markSaved={markSaved}
+                  getGraphHref={getGraphHref}
+                  getRecommendHref={getRecommendHref}
+                  getPaperId={getPaperId}
+                  preCacheFromPaper={preCacheFromPaper}
+                />
+              </section>
+            ))}
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/app/search/components/SearchHeader.tsx
+++ b/packages/web/src/app/search/components/SearchHeader.tsx
@@ -1,0 +1,29 @@
+import SearchForm from "@/components/SearchForm";
+
+interface SearchHeaderProps {
+  onSearch: (query: string, maxResults: number) => Promise<void>;
+  loading: boolean;
+}
+
+export default function SearchHeader({ onSearch, loading }: SearchHeaderProps) {
+  return (
+    <section className="rounded-3xl border border-[var(--color-border)] bg-white/85 p-6 shadow-sm backdrop-blur sm:p-8">
+      <div className="max-w-3xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
+          Literature search
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
+          Search Papers
+        </h1>
+        <p className="mt-3 text-sm leading-7 text-[var(--color-text-muted)]">
+          キーワードから論文を探し、検索結果を起点に引用探索や推薦にそのまま繋げられます。
+          必要に応じてドリルダウンを使い、関連トピックを段階的に広げていけます。
+        </p>
+      </div>
+
+      <div className="mt-6">
+        <SearchForm onSearch={onSearch} loading={loading} />
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/app/search/components/SearchResultsSection.tsx
+++ b/packages/web/src/app/search/components/SearchResultsSection.tsx
@@ -1,0 +1,50 @@
+import type { Paper } from "@paper-tools/core";
+import SearchPaperList from "./SearchPaperList";
+
+interface SearchResultsSectionProps {
+  papers: Paper[];
+  isSaved: (paper: Paper) => boolean;
+  markSaved: (paper: Paper) => void;
+  getGraphHref: (paper: Paper) => string;
+  getRecommendHref: (paper: Paper) => string;
+  getPaperId: (paper: Paper & { paperId?: string }) => string | null;
+  preCacheFromPaper: (paper: Paper & { paperId?: string }, paperId: string) => void;
+}
+
+export default function SearchResultsSection({
+  papers,
+  isSaved,
+  markSaved,
+  getGraphHref,
+  getRecommendHref,
+  getPaperId,
+  preCacheFromPaper,
+}: SearchResultsSectionProps) {
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
+            Search results
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-[var(--color-text)]">
+            Results ({papers.length})
+          </h2>
+        </div>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          検索結果からそのまま詳細閲覧、グラフ化、推薦に進めます。
+        </p>
+      </div>
+
+      <SearchPaperList
+        papers={papers}
+        isSaved={isSaved}
+        markSaved={markSaved}
+        getGraphHref={getGraphHref}
+        getRecommendHref={getRecommendHref}
+        getPaperId={getPaperId}
+        preCacheFromPaper={preCacheFromPaper}
+      />
+    </section>
+  );
+}

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -1,40 +1,30 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import type { Paper } from "@paper-tools/core";
-import type { DrilldownResult } from "@paper-tools/drilldown";
-import SearchForm from "@/components/SearchForm";
 import { preCachePaper } from "@/components/paper/usePaperDetail";
 import { useSavedPapers } from "./hooks/useSavedPapers";
-import SearchPaperList from "./components/SearchPaperList";
+import SearchHeader from "./components/SearchHeader";
+import DrilldownSection from "./components/DrilldownSection";
+import SearchResultsSection from "./components/SearchResultsSection";
 
+export const fieldClassName =
+  "w-full rounded-xl border border-[var(--color-border)] bg-white px-3.5 py-2.5 text-sm text-[var(--color-text)] shadow-sm outline-none focus:border-[var(--color-primary)] focus:ring-4 focus:ring-[var(--color-primary)]/10";
 
 type SearchPaper = Paper & {
   paperId?: string;
 };
 
-const fieldClassName =
-  "w-full rounded-xl border border-[var(--color-border)] bg-white px-3.5 py-2.5 text-sm text-[var(--color-text)] shadow-sm outline-none focus:border-[var(--color-primary)] focus:ring-4 focus:ring-[var(--color-primary)]/10";
-
 export default function SearchPage() {
   const { isSaved, markSaved } = useSavedPapers();
   const [papers, setPapers] = useState<Paper[]>([]);
-  const [drilldownResults, setDrilldownResults] = useState<DrilldownResult[]>(
-    [],
-  );
   const [loading, setLoading] = useState(false);
-  const [drilldownLoading, setDrilldownLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [seedCount, setSeedCount] = useState(5);
-  const [drilldownDepth, setDrilldownDepth] = useState(1);
-  const [maxPerLevel, setMaxPerLevel] = useState(10);
-  const [enrich, setEnrich] = useState(false);
 
   const handleSearch = useCallback(
     async (query: string, maxResults: number) => {
       setLoading(true);
       setError(null);
-      setDrilldownResults([]);
 
       try {
         const res = await fetch(
@@ -68,37 +58,6 @@ export default function SearchPage() {
     },
     [],
   );
-
-  const handleDrilldown = useCallback(async () => {
-    if (papers.length === 0) return;
-
-    setDrilldownLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/search/drilldown", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          seedPapers: papers.slice(0, seedCount),
-          depth: drilldownDepth,
-          maxPerLevel,
-          enrich,
-        }),
-      });
-
-      const data = await res.json();
-      if (!res.ok) {
-        throw new Error(data.error ?? "Drilldown failed");
-      }
-
-      setDrilldownResults(data.results ?? []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      setDrilldownLoading(false);
-    }
-  }, [papers, seedCount, drilldownDepth, maxPerLevel, enrich]);
 
   const getGraphHref = useCallback((paper: Paper) => {
     if (paper.doi) {
@@ -182,39 +141,9 @@ export default function SearchPage() {
     [],
   );
 
-  const levelDescription = useCallback(
-    (level: number) => {
-      if (level === 0) {
-        return `シード論文（検索結果の上位 ${seedCount} 本）`;
-      }
-      if (level === 1) {
-        return "シード論文のキーワードから発見された関連論文";
-      }
-      return `Level ${level - 1} のキーワードからさらに深掘りした論文`;
-    },
-    [seedCount],
-  );
-
   return (
     <div className="space-y-8">
-      <section className="rounded-3xl border border-[var(--color-border)] bg-white/85 p-6 shadow-sm backdrop-blur sm:p-8">
-        <div className="max-w-3xl">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
-            Literature search
-          </p>
-          <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
-            Search Papers
-          </h1>
-          <p className="mt-3 text-sm leading-7 text-[var(--color-text-muted)]">
-            キーワードから論文を探し、検索結果を起点に引用探索や推薦にそのまま繋げられます。
-            必要に応じてドリルダウンを使い、関連トピックを段階的に広げていけます。
-          </p>
-        </div>
-
-        <div className="mt-6">
-          <SearchForm onSearch={handleSearch} loading={loading} />
-        </div>
-      </section>
+      <SearchHeader onSearch={handleSearch} loading={loading} />
 
       {error && (
         <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -224,213 +153,26 @@ export default function SearchPage() {
 
       {papers.length > 0 && (
         <>
-          <section className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-5 shadow-sm backdrop-blur">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-              <div className="max-w-2xl">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
-                  Guided expansion
-                </p>
-                <h2 className="mt-2 text-xl font-semibold text-[var(--color-text)]">
-                  Drilldown
-                </h2>
-                <p className="mt-2 text-sm leading-6 text-[var(--color-text-muted)]">
-                  検索結果の上位論文をシードとして、関連キーワードから周辺研究を広げます。
-                  最初に広めに集めたいときは depth
-                  を上げ、精度重視ならシード数と件数を抑えるのがおすすめです。
-                </p>
-              </div>
+          <DrilldownSection
+            papers={papers}
+            isSaved={isSaved}
+            markSaved={markSaved}
+            getGraphHref={getGraphHref}
+            getRecommendHref={getRecommendHref}
+            getPaperId={getPaperId}
+            preCacheFromPaper={preCacheFromPaper}
+            fieldClassName={fieldClassName}
+          />
 
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-                <div className="font-semibold text-slate-800">
-                  Results loaded
-                </div>
-                <div className="mt-1">
-                  {papers.length} papers ready for drilldown
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-              <label className="space-y-1.5">
-                <span className="block text-sm font-semibold text-[var(--color-text)]">
-                  シード論文数
-                </span>
-                <input
-                  type="number"
-                  min={1}
-                  max={10}
-                  value={seedCount}
-                  onChange={(e) =>
-                    setSeedCount(
-                      Math.max(1, Math.min(10, Number(e.target.value) || 1)),
-                    )
-                  }
-                  className={fieldClassName}
-                />
-                <span className="block text-xs text-[var(--color-text-muted)]">
-                  検索結果の先頭から使う論文数
-                </span>
-              </label>
-
-              <label className="space-y-1.5">
-                <span className="block text-sm font-semibold text-[var(--color-text)]">
-                  Depth
-                </span>
-                <select
-                  value={drilldownDepth}
-                  onChange={(e) => setDrilldownDepth(Number(e.target.value))}
-                  className={fieldClassName}
-                >
-                  <option value={1}>1</option>
-                  <option value={2}>2</option>
-                  <option value={3}>3</option>
-                </select>
-                <span className="block text-xs text-[var(--color-text-muted)]">
-                  キーワード展開の段階数
-                </span>
-              </label>
-
-              <label className="space-y-1.5">
-                <span className="block text-sm font-semibold text-[var(--color-text)]">
-                  Max per level
-                </span>
-                <input
-                  type="number"
-                  min={5}
-                  max={30}
-                  value={maxPerLevel}
-                  onChange={(e) =>
-                    setMaxPerLevel(
-                      Math.max(5, Math.min(30, Number(e.target.value) || 5)),
-                    )
-                  }
-                  className={fieldClassName}
-                />
-                <span className="block text-xs text-[var(--color-text-muted)]">
-                  各レベルで保持する最大件数
-                </span>
-              </label>
-
-              <div className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white p-4">
-                <div>
-                  <p className="text-sm font-semibold text-[var(--color-text)]">
-                    Metadata enrich
-                  </p>
-                  <p className="mt-1 text-xs leading-5 text-[var(--color-text-muted)]">
-                    Crossref を使って DOI や書誌情報を補完します。
-                  </p>
-                </div>
-
-                <label className="mt-4 inline-flex items-center gap-3 text-sm font-medium text-[var(--color-text)]">
-                  <input
-                    type="checkbox"
-                    checked={enrich}
-                    onChange={(e) => setEnrich(e.target.checked)}
-                    className="h-4 w-4 rounded border-slate-300 text-[var(--color-primary)] focus:ring-[var(--color-primary)]"
-                  />
-                  Crossref で補完
-                </label>
-              </div>
-            </div>
-
-            <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200/80 pt-4">
-              <p className="text-xs text-[var(--color-text-muted)]">
-                Seed {seedCount} 件 / Depth {drilldownDepth} / Max per level{" "}
-                {maxPerLevel}
-                {enrich ? " / Crossref enrich on" : ""}
-              </p>
-
-              <button
-                type="button"
-                onClick={handleDrilldown}
-                disabled={drilldownLoading}
-                className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
-              >
-                {drilldownLoading ? "Drilldown running…" : "ドリルダウン開始"}
-              </button>
-            </div>
-          </section>
-
-          {drilldownResults.length > 0 && (
-            <section className="space-y-5">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
-                    Expanded search
-                  </p>
-                  <h2 className="mt-2 text-xl font-semibold text-[var(--color-text)]">
-                    Drilldown Results
-                  </h2>
-                </div>
-                <p className="text-sm text-[var(--color-text-muted)]">
-                  {drilldownResults.reduce(
-                    (sum, level) => sum + level.papers.length,
-                    0,
-                  )}{" "}
-                  papers across {drilldownResults.length} levels
-                </p>
-              </div>
-
-              <div className="space-y-6">
-                {drilldownResults.map((result, levelIndex) => (
-                  <section
-                    key={levelIndex}
-                    className="rounded-2xl border border-[var(--color-border)] bg-white/85 p-5 shadow-sm backdrop-blur"
-                  >
-                    <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                      <div>
-                        <h3 className="text-base font-semibold text-[var(--color-text)]">
-                          Level {result.level}
-                        </h3>
-                        <p className="mt-1 text-sm text-[var(--color-text-muted)]">
-                          {levelDescription(result.level)}
-                        </p>
-                      </div>
-                      <span className="text-xs font-medium text-[var(--color-text-muted)]">
-                        {result.papers.length} papers
-                      </span>
-                    </div>
-
-                    <SearchPaperList
-                      papers={result.papers}
-                      isSaved={isSaved}
-                      markSaved={markSaved}
-                      getGraphHref={getGraphHref}
-                      getRecommendHref={getRecommendHref}
-                      getPaperId={getPaperId}
-                      preCacheFromPaper={preCacheFromPaper}
-                    />
-                  </section>
-                ))}
-              </div>
-            </section>
-          )}
-
-          <section className="space-y-4">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-text-muted)]">
-                  Search results
-                </p>
-                <h2 className="mt-2 text-xl font-semibold text-[var(--color-text)]">
-                  Results ({papers.length})
-                </h2>
-              </div>
-              <p className="text-sm text-[var(--color-text-muted)]">
-                検索結果からそのまま詳細閲覧、グラフ化、推薦に進めます。
-              </p>
-            </div>
-
-            <SearchPaperList
-              papers={papers}
-              isSaved={isSaved}
-              markSaved={markSaved}
-              getGraphHref={getGraphHref}
-              getRecommendHref={getRecommendHref}
-              getPaperId={getPaperId}
-              preCacheFromPaper={preCacheFromPaper}
-            />
-          </section>
+          <SearchResultsSection
+            papers={papers}
+            isSaved={isSaved}
+            markSaved={markSaved}
+            getGraphHref={getGraphHref}
+            getRecommendHref={getRecommendHref}
+            getPaperId={getPaperId}
+            preCacheFromPaper={preCacheFromPaper}
+          />
         </>
       )}
     </div>


### PR DESCRIPTION
🎯 **What:** Extracted `DrilldownSection`, `SearchHeader`, and `SearchResultsSection` from the 420-line `SearchPage` component.
💡 **Why:** Significantly improves code maintainability and readability by separating concerns into focused components.
✅ **Verification:** Verified that the code compiles successfully (`pnpm build`) and passes all tests (`pnpm vitest`).
✨ **Result:** A cleaner, more modular SearchPage component that is easier to maintain and extend.

---
*PR created automatically by Jules for task [18410284477432864506](https://jules.google.com/task/18410284477432864506) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

SearchPage の表示とドリルダウン処理を、責務別の3コンポーネントへ分割するリファクタリングです。ただし、状態の移動により検索切り替え時のドリルダウン表示と設定保持に回帰があります。

- 検索フォームを `SearchHeader` に抽出
- 通常の検索結果を `SearchResultsSection` に抽出
- ドリルダウンの設定、通信、結果表示を `DrilldownSection` に抽出
- SearchPage は検索処理と共通の論文リンク・キャッシュ処理を担当
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

新しい検索中に古いドリルダウン結果が残る問題と、空結果・エラー後に設定が失われる問題を修正してからマージすべきです。

ドリルダウン state の子コンポーネントへの移動により、検索開始時の即時クリアが失われ、条件付きアンマウント時にはユーザー設定も既定値へ戻ります。

**Files Needing Attention:** packages/web/src/app/search/components/DrilldownSection.tsx, packages/web/src/app/search/page.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web/src/app/search/page.tsx | ページを構成コンポーネントへ分割した一方、検索開始時のドリルダウン結果消去が失われ、子コンポーネントの条件付きマウントによる設定消失を招いています。 |
| packages/web/src/app/search/components/DrilldownSection.tsx | ドリルダウンのUIと処理を集約していますが、結果消去のタイミングとローカル設定 state のライフサイクルに回帰があります。 |
| packages/web/src/app/search/components/SearchHeader.tsx | 既存のヘッダーと SearchForm を挙動を変えずに抽出しています。 |
| packages/web/src/app/search/components/SearchResultsSection.tsx | 既存の検索結果見出しと SearchPaperList への props 転送をそのまま抽出しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/web/src/app/search/components/DrilldownSection.tsx:35-38
**検索開始時の結果消去が遅延**

ドリルダウン結果を表示した状態で新しい検索を送信すると、`papers` は応答が返るまで変化しないため、この effect は検索開始時に実行されません。その結果、以前のクエリに属するドリルダウン結果が新しい検索の完了まで表示され続けます。

### Issue 2
packages/web/src/app/search/components/DrilldownSection.tsx:30-33
**条件付きアンマウントで設定消失**

ユーザーがドリルダウン設定を変更した後に検索が空結果またはエラーになると、`DrilldownSection` がアンマウントされてローカル state が破棄されます。次に検索結果が得られた際、シード数、depth、最大件数、enrich が通知なく既定値へ戻り、ユーザーの指定と異なる条件になります。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor SearchPage"](https://github.com/hiroki-org/paper-tools/commit/fb311f0ba5058688492b91f5864e716a7980f734) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49583692)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Web app (`packages/web`)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/web.md)

<!-- /greptile_comment -->