### PR TITLE
🧪 Test getValidationWarnings in bibtex-formatter

### DIFF
--- a/packages/bibtex/tests/bibtex-formatter.test.ts
+++ b/packages/bibtex/tests/bibtex-formatter.test.ts
@@ -1,7 +1,116 @@
 import { describe, expect, it } from "vitest";
-import { deriveBibtexKey, formatBibtex, parseBibtexEntry, splitBibtexEntries } from "../src/bibtex-formatter.js";
+import { deriveBibtexKey, formatBibtex, parseBibtexEntry, splitBibtexEntries, getValidationWarnings } from "../src/bibtex-formatter.js";
 
 describe("bibtex-formatter", () => {
+    describe("getValidationWarnings", () => {
+        it("returns empty array when all required fields are present", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {
+                    author: "Smith",
+                    title: "Title",
+                    year: "2024",
+                    journal: "Journal"
+                }
+            };
+            expect(getValidationWarnings(parsed)).toEqual([]);
+        });
+
+        it("returns warning for missing author", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {
+                    title: "Title",
+                    year: "2024",
+                    journal: "Journal"
+                }
+            };
+            expect(getValidationWarnings(parsed)).toEqual(["Missing required field: author"]);
+        });
+
+        it("returns warning for missing title", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {
+                    author: "Smith",
+                    year: "2024",
+                    journal: "Journal"
+                }
+            };
+            expect(getValidationWarnings(parsed)).toEqual(["Missing required field: title"]);
+        });
+
+        it("returns warning for missing year", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {
+                    author: "Smith",
+                    title: "Title",
+                    journal: "Journal"
+                }
+            };
+            expect(getValidationWarnings(parsed)).toEqual(["Missing required field: year"]);
+        });
+
+        it("returns warning for missing booktitle or journal", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {
+                    author: "Smith",
+                    title: "Title",
+                    year: "2024"
+                }
+            };
+            expect(getValidationWarnings(parsed)).toEqual(["Missing required field: booktitle or journal"]);
+        });
+
+        it("returns empty array when booktitle is present but journal is missing", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {
+                    author: "Smith",
+                    title: "Title",
+                    year: "2024",
+                    booktitle: "Book"
+                }
+            };
+            expect(getValidationWarnings(parsed)).toEqual([]);
+        });
+
+        it("returns empty array when journal is present but booktitle is missing", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {
+                    author: "Smith",
+                    title: "Title",
+                    year: "2024",
+                    journal: "Journal"
+                }
+            };
+            expect(getValidationWarnings(parsed)).toEqual([]);
+        });
+
+        it("returns multiple warnings if multiple fields are missing", () => {
+            const parsed = {
+                entryType: "article",
+                key: "test",
+                fields: {}
+            };
+            expect(getValidationWarnings(parsed)).toEqual([
+                "Missing required field: author",
+                "Missing required field: title",
+                "Missing required field: year",
+                "Missing required field: booktitle or journal"
+            ]);
+        });
+    });
     describe("deriveBibtexKey", () => {
         it("returns undefined if keyFormat is 'default'", () => {
             const result = deriveBibtexKey(`@article{tmp, title={Paper}, author={Alice Smith}, year={2024}, journal={J}}`, "default");
@@ -47,7 +156,9 @@ describe("bibtex-formatter", () => {
     });
 
     it("splits multiple entries", () => {
-        const entries = splitBibtexEntries(`@article{a,title={A}}\n\n@article{b,title={B}}`);
+        const entries = splitBibtexEntries(`@article{a,title={A}}
+
+@article{b,title={B}}`);
         expect(entries).toHaveLength(2);
     });
 

--- a/test-debug.ts
+++ b/test-debug.ts
@@ -1,0 +1,14 @@
+import { getValidationWarnings } from "./packages/bibtex/src/bibtex-formatter.js";
+
+const parsed = {
+    entryType: "article",
+    key: "test",
+    fields: {
+        author: "Smith",
+        title: "Title",
+        year: "2024",
+        booktitle: "Book"
+    }
+};
+
+console.log(getValidationWarnings(parsed));


### PR DESCRIPTION
🎯 **What:** Added tests for `getValidationWarnings` in `bibtex-formatter`.
📊 **Coverage:** Covered happy paths, edge cases, and missing required fields (author, title, year, booktitle/journal).
✨ **Result:** Increased test coverage and confidence in `bibtex-formatter.ts`.

---
*PR created automatically by Jules for task [4841258060414737193](https://jules.google.com/task/4841258060414737193) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`getValidationWarnings` の正常系、必須フィールド欠落、複数警告を検証する単体テストを追加しています。
- `booktitle` と `journal` の代替条件を含む警告生成を検証
- 複数エントリ分割テストの入力表記を複数行化
- 自動化された処理から参照されないデバッグ用スクリプトを追加
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる問題はありませんが、自動化されていない一時デバッグスクリプトは削除するのが望ましいです。

追加された単体テストは既存の警告生成仕様と一致しており、唯一の指摘は実行経路を持たずテスト内容と重複するデバッグファイルの整理です。

**Files Needing Attention:** test-debug.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/bibtex/tests/bibtex-formatter.test.ts | `getValidationWarnings` の既存仕様に沿った正常系・欠落フィールド・複数警告のテストを追加しており、期待値に明確な問題はありません。 |
| test-debug.ts | 単体テストと重複する手動確認スクリプトで、既存のビルド・テスト・型チェックから参照されない不要なデッドコードです。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test-debug.ts:1-14
**未統合のデバッグスクリプト**

このスクリプトは同じ正常系を単体テストと重複して確認していますが、ワークスペース、ビルド、テスト、型チェックのいずれからも参照されないため、自動検証されないデッドコードとして保守対象に残ります。

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for getValidationWarning..."](https://github.com/hiroki-org/paper-tools/commit/afe4bb67a9227f1b481ef19bab487af3a8e85b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49584417)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [BibTeX package](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/paper-tools/-/docs/bibtex.md)

<!-- /greptile_comment -->